### PR TITLE
feat(dashboard): 新增仪表盘时间模式切换功能

### DIFF
--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -110,6 +110,7 @@ type DashboardStatsResponse struct {
 	RPM          StatCard `json:"rpm"`
 	RequestCount StatCard `json:"request_count"`
 	ErrorRate    StatCard `json:"error_rate"`
+	TimeMode     string   `json:"time_mode"` // 时间模式: "rolling" 或 "daily"
 }
 
 // ChartDataset 用于图表的数据集
@@ -123,6 +124,7 @@ type ChartDataset struct {
 type ChartData struct {
 	Labels   []string       `json:"labels"`
 	Datasets []ChartDataset `json:"datasets"`
+	TimeMode string         `json:"time_mode"` // 时间模式: "rolling" 或 "daily"
 }
 
 // GroupHourlyStat 对应 group_hourly_stats 表，用于存储每个分组每小时的请求统计

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -38,6 +38,9 @@ type SystemSettings struct {
 	KeyValidationConcurrency     int `json:"key_validation_concurrency" default:"10" name:"密钥验证并发数" category:"密钥配置" desc:"后台定时验证无效 Key 时的并发数。" validate:"min=1"`
 	KeyValidationTimeoutSeconds  int `json:"key_validation_timeout_seconds" default:"20" name:"密钥验证超时（秒）" category:"密钥配置" desc:"后台定时验证单个 Key 时的 API 请求超时时间（秒）。" validate:"min=5"`
 
+	// 界面设置
+	DashboardTimeMode string `json:"dashboard_time_mode" default:"rolling" name:"仪表盘时间模式" category:"界面设置" desc:"仪表盘统计的时间范围计算方式：rolling(滚动24小时)、daily(自然日)"`
+
 	// For cache
 	ProxyKeysMap map[string]struct{} `json:"-"`
 }

--- a/web/src/components/BaseInfoCard.vue
+++ b/web/src/components/BaseInfoCard.vue
@@ -9,6 +9,14 @@ const stats = ref<DashboardStatsResponse | null>(null);
 const loading = ref(true);
 const animatedValues = ref<Record<string, number>>({});
 
+// 根据时间模式获取显示文案
+const getTimeLabel = (baseLabel: string) => {
+  if (!stats.value) {
+    return baseLabel;
+  }
+  return stats.value.time_mode === "daily" ? baseLabel.replace("24小时", "今日") : baseLabel;
+};
+
 // 格式化数值显示
 const formatValue = (value: number, type: "count" | "rate" = "count"): string => {
   if (type === "rate") {
@@ -145,7 +153,7 @@ onMounted(() => {
               <div class="stat-value">
                 {{ stats ? formatValue(stats.request_count.value) : "--" }}
               </div>
-              <div class="stat-title">24小时请求</div>
+              <div class="stat-title">{{ getTimeLabel("24小时请求") }}</div>
             </div>
 
             <div class="stat-bar">
@@ -178,7 +186,7 @@ onMounted(() => {
               <div class="stat-value">
                 {{ stats ? formatValue(stats.error_rate.value ?? 0, "rate") : "--" }}
               </div>
-              <div class="stat-title">24小时错误率</div>
+              <div class="stat-title">{{ getTimeLabel("24小时错误率") }}</div>
             </div>
 
             <div class="stat-bar">

--- a/web/src/components/LineChart.vue
+++ b/web/src/components/LineChart.vue
@@ -9,6 +9,14 @@ import { computed, onMounted, ref, watch } from "vue";
 const chartData = ref<ChartData | null>(null);
 const selectedGroup = ref<number | null>(null);
 const loading = ref(true);
+
+// 根据时间模式获取显示文案
+const getTimeLabel = (baseLabel: string) => {
+  if (!chartData.value) {
+    return baseLabel;
+  }
+  return chartData.value.time_mode === "daily" ? baseLabel.replace("24小时", "今日") : baseLabel;
+};
 const animationProgress = ref(0);
 const hoveredPoint = ref<{
   datasetIndex: number;
@@ -370,7 +378,7 @@ onMounted(() => {
   <div class="chart-container">
     <div class="chart-header">
       <div class="chart-title-section">
-        <h3 class="chart-title">24小时请求趋势</h3>
+        <h3 class="chart-title">{{ getTimeLabel("24小时请求趋势") }}</h3>
       </div>
       <n-select
         v-model:value="selectedGroup"

--- a/web/src/types/models.ts
+++ b/web/src/types/models.ts
@@ -174,6 +174,7 @@ export interface DashboardStatsResponse {
   rpm: StatCard;
   request_count: StatCard;
   error_rate: StatCard;
+  time_mode: string; // 时间模式: "rolling" 或 "daily"
 }
 
 // 图表数据集
@@ -187,4 +188,5 @@ export interface ChartDataset {
 export interface ChartData {
   labels: string[];
   datasets: ChartDataset[];
+  time_mode: string; // 时间模式: "rolling" 或 "daily"
 }

--- a/web/src/views/Settings.vue
+++ b/web/src/views/Settings.vue
@@ -12,6 +12,8 @@ import {
   NIcon,
   NInput,
   NInputNumber,
+  NRadio,
+  NRadioGroup,
   NSpace,
   NTooltip,
   useMessage,
@@ -110,6 +112,16 @@ async function handleSubmit() {
                   style="width: 100%"
                   size="small"
                 />
+                <n-radio-group
+                  v-else-if="item.key === 'dashboard_time_mode'"
+                  v-model:value="form[item.key] as string"
+                  size="small"
+                >
+                  <n-space>
+                    <n-radio value="rolling">滚动24小时</n-radio>
+                    <n-radio value="daily">自然日</n-radio>
+                  </n-space>
+                </n-radio-group>
                 <proxy-keys-input
                   v-else-if="item.key === 'proxy_keys'"
                   v-model="form[item.key] as string"


### PR DESCRIPTION
### 变更内容 / Change Content
添加支持在滚动24小时和自然日两种时间模式间切换的功能，包括后端时间范围计算逻辑、前端展示文案适配以及设置界面选项。
<img width="1920" height="870" alt="image" src="https://github.com/user-attachments/assets/82bbde40-ce2f-4b55-98aa-e10764d442d6" />


