### PR TITLE
Add the Anthropic Console channel for the Claude code mirror sites

### DIFF
--- a/internal/channel/anthropic_console_channel.go
+++ b/internal/channel/anthropic_console_channel.go
@@ -1,0 +1,59 @@
+package channel
+
+import (
+	"context"
+	"gpt-load/internal/models"
+	"net/http"
+)
+
+func init() {
+	Register("anthropic_console", newAnthropicConsoleChannel)
+}
+
+type AnthropicConsoleChannel struct {
+	*AnthropicChannel
+}
+
+func newAnthropicConsoleChannel(f *Factory, group *models.Group) (ChannelProxy, error) {
+	anthropicChannel, err := newAnthropicChannel(f, group)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AnthropicConsoleChannel{
+		AnthropicChannel: anthropicChannel.(*AnthropicChannel),
+	}, nil
+}
+
+func (ch *AnthropicConsoleChannel) ModifyRequest(req *http.Request, apiKey *models.APIKey, group *models.Group) {
+	req.Header.Set("Authorization", "Bearer "+apiKey.KeyValue)
+	req.Header.Set("anthropic-version", "2023-06-01")
+}
+
+func (ch *AnthropicConsoleChannel) ValidateKey(ctx context.Context, key string) (bool, error) {
+	// Wrap HTTP client to intercept and modify auth headers
+	originalTransport := ch.HTTPClient.Transport
+    ch.HTTPClient.Transport = &headerRewriteTransport{
+        base: originalTransport,
+        keyRewriter: func(req *http.Request) {
+            if apiKey := req.Header.Get("x-api-key"); apiKey != "" {
+                req.Header.Del("x-api-key")
+                req.Header.Set("Authorization", "Bearer "+apiKey)
+            }
+        },
+    }
+    defer func() {
+        ch.HTTPClient.Transport = originalTransport
+    }()
+    return ch.AnthropicChannel.ValidateKey(ctx, key)
+}
+
+type headerRewriteTransport struct {
+    base        http.RoundTripper
+    keyRewriter func(*http.Request)
+}
+
+func (t *headerRewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+    t.keyRewriter(req)
+    return t.base.RoundTrip(req)
+}

--- a/web/src/components/keys/GroupFormModal.vue
+++ b/web/src/components/keys/GroupFormModal.vue
@@ -53,7 +53,7 @@ interface GroupFormData {
   display_name: string;
   description: string;
   upstreams: UpstreamInfo[];
-  channel_type: "anthropic" | "gemini" | "openai";
+  channel_type: "anthropic" | "anthropic_console" | "gemini" | "openai";
   sort: number;
   test_model: string;
   validation_endpoint: string;
@@ -104,6 +104,8 @@ const testModelPlaceholder = computed(() => {
       return "gemini-2.0-flash-lite";
     case "anthropic":
       return "claude-3-haiku-20240307";
+    case "anthropic_console":
+      return "claude-3-5-haiku-20241022";
     default:
       return "请输入模型名称";
   }
@@ -117,6 +119,8 @@ const upstreamPlaceholder = computed(() => {
       return "https://generativelanguage.googleapis.com";
     case "anthropic":
       return "https://api.anthropic.com";
+    case "anthropic_console":
+      return "https://api.anthropic.com";
     default:
       return "请输入上游地址";
   }
@@ -127,6 +131,8 @@ const validationEndpointPlaceholder = computed(() => {
     case "openai":
       return "/v1/chat/completions";
     case "anthropic":
+      return "/v1/messages";
+    case "anthropic_console":
       return "/v1/messages";
     case "gemini":
       return ""; // Gemini 不显示此字段
@@ -229,6 +235,8 @@ function getOldDefaultTestModel(channelType: string): string {
       return "gemini-2.0-flash-lite";
     case "anthropic":
       return "claude-3-haiku-20240307";
+    case "anthropic_console":
+      return "claude-3-5-haiku-20241022";
     default:
       return "";
   }
@@ -241,6 +249,8 @@ function getOldDefaultUpstream(channelType: string): string {
     case "gemini":
       return "https://generativelanguage.googleapis.com";
     case "anthropic":
+      return "https://api.anthropic.com";
+    case "anthropic_console":
       return "https://api.anthropic.com";
     default:
       return "";

--- a/web/src/components/keys/GroupList.vue
+++ b/web/src/components/keys/GroupList.vue
@@ -101,6 +101,7 @@ function handleGroupCreated(group: Group) {
                 <span v-if="group.channel_type === 'openai'">🤖</span>
                 <span v-else-if="group.channel_type === 'gemini'">💎</span>
                 <span v-else-if="group.channel_type === 'anthropic'">🧠</span>
+                <span v-else-if="group.channel_type === 'anthropic_console'">🧠</span>
                 <span v-else>🔧</span>
               </div>
               <div class="group-content">

--- a/web/src/types/models.ts
+++ b/web/src/types/models.ts
@@ -36,7 +36,7 @@ export interface Group {
   description: string;
   sort: number;
   test_model: string;
-  channel_type: "openai" | "gemini" | "anthropic";
+  channel_type: "openai" | "gemini" | "anthropic" | "anthropic_console";
   upstreams: UpstreamInfo[];
   validation_endpoint: string;
   config: Record<string, unknown>;


### PR DESCRIPTION
### 关联 Issue / Related Issue
<!-- 请填写此 PR 关联的 issue 编号，例如：Closes #123 / Please link the issue number, e.g., Closes #123 -->
N/A

### 变更内容 / Change Content
<!-- 请简要描述本次变更的核心内容 / Please briefly describe the core changes of this PR -->
- [ ] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [x] 其他改动 / Other changes


<!-- 请在下方详细描述你的变更 / Please describe your changes in detail below -->
- The original Anthropic group type uses `x-api-key` authentication and cannot connect to Claude Code mirror sites that require **AUTH TOKEN** authentication.
- Added the Anthropic Console group type to support Claude Code mirror sites.
- The Anthropic Console group type only overrides the request header logic (ModifyRequest and ValidateKey) from Anthropic.

### 自查清单 / Checklist
- [x] 我已在本地测试过我的变更。 / I have tested my changes locally.
- [ ] 我已更新了必要的文档。 / I have updated the necessary documentation.
