### PR TITLE
fix(proxy): 排除404状态码避免无意义重试

### DIFF
--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -181,7 +181,8 @@ func (ps *ProxyServer) executeRequestWithRetry(
 	}
 
 	// Unified error handling for retries.
-	if err != nil || (resp != nil && resp.StatusCode >= 400) {
+	// Exclude 404 from being a retryable error.
+	if err != nil || (resp != nil && resp.StatusCode >= 400 && resp.StatusCode != http.StatusNotFound) {
 		if err != nil && app_errors.IsIgnorableError(err) {
 			logrus.Debugf("Client-side ignorable error for key %s, aborting retries: %v", utils.MaskAPIKey(apiKey.KeyValue), err)
 			ps.logRequest(c, group, apiKey, startTime, 499, retryCount+1, err, isStream, upstreamURL, channelHandler, bodyBytes)


### PR DESCRIPTION
当请求资源不存在时，不代表key无效，反而可能错误地将key判断为无效，而且此时重试没有意义

### 关联 Issue / Related Issue
<!-- 请填写此 PR 关联的 issue 编号，例如：Closes #123 / Please link the issue number, e.g., Closes #123 -->
Closes #

### 变更内容 / Change Content
<!-- 请简要描述本次变更的核心内容 / Please briefly describe the core changes of this PR -->
- [x] Bug 修复 / Bug fix

<!-- 请在下方详细描述你的变更 / Please describe your changes in detail below -->


### 自查清单 / Checklist
- [x] 我已在本地测试过我的变更。 / I have tested my changes locally.
