### PR TITLE
fix: 修复main.go中注释的拼写错误

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 		logrus.Fatalf("Failed to provide indexPage: %v", err)
 	}
 
-	// Initialzie global logger
+	// Initialize global logger
 	if err := container.Invoke(func(configManager types.ConfigManager) {
 		utils.SetupLogger(configManager)
 	}); err != nil {


### PR DESCRIPTION
将"Initialzie"更正为"Initialize"  - main.go:41