### PR TITLE
feat: 添加请求和响应体日志记录功能

### DIFF
--- a/internal/config/system_settings.go
+++ b/internal/config/system_settings.go
@@ -334,6 +334,15 @@ func (sm *SystemSettingsManager) ValidateGroupConfigOverrides(configMap map[stri
 			continue
 		}
 
+		// 跳过分组特有的配置项（不在系统设置中的配置）
+		if key == "disable_request_body_logging" {
+			// 验证布尔类型
+			if _, ok := value.(bool); !ok {
+				return fmt.Errorf("invalid type for %s: expected boolean, got %T", key, value)
+			}
+			continue
+		}
+
 		field, ok := jsonToField[key]
 		if !ok {
 			return fmt.Errorf("invalid setting key: %s", key)
@@ -376,6 +385,11 @@ func (sm *SystemSettingsManager) ValidateGroupConfigOverrides(configMap map[stri
 						return fmt.Errorf("value for %s is required", key)
 					}
 				}
+			}
+		case reflect.Bool:
+			_, ok := value.(bool)
+			if !ok {
+				return fmt.Errorf("invalid type for %s: expected boolean, got %T", key, value)
 			}
 		default:
 			// Do not validate other types for group overrides

--- a/internal/config/system_settings.go
+++ b/internal/config/system_settings.go
@@ -334,14 +334,6 @@ func (sm *SystemSettingsManager) ValidateGroupConfigOverrides(configMap map[stri
 			continue
 		}
 
-		// 跳过分组特有的配置项（不在系统设置中的配置）
-		if key == "disable_request_body_logging" {
-			// 验证布尔类型
-			if _, ok := value.(bool); !ok {
-				return fmt.Errorf("invalid type for %s: expected boolean, got %T", key, value)
-			}
-			continue
-		}
 
 		field, ok := jsonToField[key]
 		if !ok {

--- a/internal/handler/group_handler.go
+++ b/internal/handler/group_handler.go
@@ -683,6 +683,15 @@ func (s *Server) GetGroupConfigOptions(c *gin.Context) {
 				DefaultValue: defaultValue,
 			}
 			options = append(options, option)
+		} else if key == "disable_request_body_logging" {
+			// 手动添加分组级日志记录禁用选项（仅在分组配置中显示）
+			option := ConfigOption{
+				Key:          key,
+				Name:         "禁用请求和响应体日志记录",
+				Description:  "禁用此分组的请求体和响应体日志记录，优先级高于系统设置",
+				DefaultValue: false,
+			}
+			options = append(options, option)
 		}
 	}
 

--- a/internal/handler/group_handler.go
+++ b/internal/handler/group_handler.go
@@ -683,15 +683,6 @@ func (s *Server) GetGroupConfigOptions(c *gin.Context) {
 				DefaultValue: defaultValue,
 			}
 			options = append(options, option)
-		} else if key == "disable_request_body_logging" {
-			// 手动添加分组级日志记录禁用选项（仅在分组配置中显示）
-			option := ConfigOption{
-				Key:          key,
-				Name:         "禁用请求和响应体日志记录",
-				Description:  "禁用此分组的请求体和响应体日志记录，优先级高于系统设置",
-				DefaultValue: false,
-			}
-			options = append(options, option)
 		}
 	}
 

--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -104,6 +104,8 @@ type RequestLog struct {
 	Retries      int       `gorm:"not null" json:"retries"`
 	UpstreamAddr string    `gorm:"type:varchar(500)" json:"upstream_addr"`
 	IsStream     bool      `gorm:"not null" json:"is_stream"`
+	RequestBody  string    `gorm:"type:longtext" json:"request_body"`
+	ResponseBody string    `gorm:"type:longtext" json:"response_body"`
 }
 
 // StatCard 用于仪表盘的单个统计卡片数据

--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -37,7 +37,7 @@ type GroupConfig struct {
 	KeyValidationIntervalMinutes *int    `json:"key_validation_interval_minutes,omitempty"`
 	KeyValidationConcurrency     *int    `json:"key_validation_concurrency,omitempty"`
 	KeyValidationTimeoutSeconds  *int    `json:"key_validation_timeout_seconds,omitempty"`
-	DisableRequestBodyLogging    *bool   `json:"disable_request_body_logging,omitempty"`
+	EnableRequestBodyLogging     *bool   `json:"enable_request_body_logging,omitempty"`
 }
 
 // HeaderRule defines a single rule for header manipulation.
@@ -105,9 +105,9 @@ type RequestLog struct {
 	Retries      int       `gorm:"not null" json:"retries"`
 	UpstreamAddr string    `gorm:"type:varchar(500)" json:"upstream_addr"`
 	IsStream     bool      `gorm:"not null" json:"is_stream"`
-	RequestBody  string    `gorm:"type:longtext" json:"request_body"`
-	ResponseBody string    `gorm:"type:longtext" json:"response_body"`
-	BodyLogStatus string   `gorm:"type:varchar(50)" json:"body_log_status"` // "enabled", "system_disabled", "group_disabled"
+	RequestBody   string `gorm:"type:longtext" json:"request_body"`
+	ResponseBody  string `gorm:"type:longtext" json:"response_body"`
+	BodyLogStatus string `gorm:"type:varchar(50)" json:"body_log_status"` // "enabled", "system_disabled", "group_disabled"
 }
 
 // StatCard 用于仪表盘的单个统计卡片数据

--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -37,6 +37,7 @@ type GroupConfig struct {
 	KeyValidationIntervalMinutes *int    `json:"key_validation_interval_minutes,omitempty"`
 	KeyValidationConcurrency     *int    `json:"key_validation_concurrency,omitempty"`
 	KeyValidationTimeoutSeconds  *int    `json:"key_validation_timeout_seconds,omitempty"`
+	DisableRequestBodyLogging    *bool   `json:"disable_request_body_logging,omitempty"`
 }
 
 // HeaderRule defines a single rule for header manipulation.
@@ -106,6 +107,7 @@ type RequestLog struct {
 	IsStream     bool      `gorm:"not null" json:"is_stream"`
 	RequestBody  string    `gorm:"type:longtext" json:"request_body"`
 	ResponseBody string    `gorm:"type:longtext" json:"response_body"`
+	BodyLogStatus string   `gorm:"type:varchar(50)" json:"body_log_status"` // "enabled", "system_disabled", "group_disabled"
 }
 
 // StatCard 用于仪表盘的单个统计卡片数据

--- a/internal/proxy/response_handlers.go
+++ b/internal/proxy/response_handlers.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bytes"
 	"io"
 	"net/http"
 
@@ -8,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func (ps *ProxyServer) handleStreamingResponse(c *gin.Context, resp *http.Response) {
+func (ps *ProxyServer) handleStreamingResponse(c *gin.Context, resp *http.Response) string {
 	c.Header("Content-Type", "text/event-stream")
 	c.Header("Cache-Control", "no-cache")
 	c.Header("Connection", "keep-alive")
@@ -17,18 +18,21 @@ func (ps *ProxyServer) handleStreamingResponse(c *gin.Context, resp *http.Respon
 	flusher, ok := c.Writer.(http.Flusher)
 	if !ok {
 		logrus.Error("Streaming unsupported by the writer, falling back to normal response")
-		ps.handleNormalResponse(c, resp)
-		return
+		return ps.handleNormalResponse(c, resp)
 	}
 
+	var responseBuffer bytes.Buffer
 	buf := make([]byte, 4*1024)
 	for {
 		n, err := resp.Body.Read(buf)
 		if n > 0 {
+			// Write to client
 			if _, writeErr := c.Writer.Write(buf[:n]); writeErr != nil {
 				logUpstreamError("writing stream to client", writeErr)
-				return
+				return responseBuffer.String()
 			}
+			// Also capture for logging
+			responseBuffer.Write(buf[:n])
 			flusher.Flush()
 		}
 		if err == io.EOF {
@@ -36,13 +40,24 @@ func (ps *ProxyServer) handleStreamingResponse(c *gin.Context, resp *http.Respon
 		}
 		if err != nil {
 			logUpstreamError("reading from upstream", err)
-			return
+			return responseBuffer.String()
 		}
 	}
+	return responseBuffer.String()
 }
 
-func (ps *ProxyServer) handleNormalResponse(c *gin.Context, resp *http.Response) {
-	if _, err := io.Copy(c.Writer, resp.Body); err != nil {
+func (ps *ProxyServer) handleNormalResponse(c *gin.Context, resp *http.Response) string {
+	// Read the response body
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		logUpstreamError("reading response body", err)
+		return ""
+	}
+
+	// Write to client
+	if _, err := c.Writer.Write(responseBody); err != nil {
 		logUpstreamError("copying response body", err)
 	}
+
+	return string(responseBody)
 }

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -273,6 +273,13 @@ func (ps *ProxyServer) logRequest(
 
 	duration := time.Since(startTime).Milliseconds()
 
+	// 根据系统设置决定是否记录请求体和响应体
+	var requestBodyToLog, responseBodyToLog string
+	if ps.settingsManager.GetSettings().EnableRequestBodyLogging {
+		requestBodyToLog = string(bodyBytes)
+		responseBodyToLog = responseBody
+	}
+
 	logEntry := &models.RequestLog{
 		GroupID:      group.ID,
 		GroupName:    group.Name,
@@ -285,8 +292,8 @@ func (ps *ProxyServer) logRequest(
 		Retries:      retries,
 		IsStream:     isStream,
 		UpstreamAddr: utils.TruncateString(upstreamAddr, 500),
-		RequestBody:  string(bodyBytes),
-		ResponseBody: responseBody,
+		RequestBody:  requestBodyToLog,
+		ResponseBody: responseBodyToLog,
 	}
 
 	if channelHandler != nil && bodyBytes != nil {

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -273,26 +273,26 @@ func (ps *ProxyServer) logRequest(
 
 	duration := time.Since(startTime).Milliseconds()
 
-	// 日志记录逻辑：系统开启 AND NOT 分组禁用 = 记录
+	// 日志记录逻辑：系统开启 AND 分组开启 = 记录
 	var requestBodyToLog, responseBodyToLog string
 	var bodyLogStatus string
-	
+
 	systemEnabled := ps.settingsManager.GetSettings().EnableRequestBodyLogging
-	
-	// 检查分组配置中的禁用设置
-	groupDisabled := false
+	groupEnabled := true // 默认分组开启
+
+	// 检查分组配置中的设置
 	if group.Config != nil {
-		if disableValue, exists := group.Config["disable_request_body_logging"]; exists {
-			if disable, ok := disableValue.(bool); ok {
-				groupDisabled = disable
+		if enableValue, exists := group.Config["enable_request_body_logging"]; exists {
+			if enable, ok := enableValue.(bool); ok {
+				groupEnabled = enable
 			}
 		}
 	}
-	
-	// 设置日志状态
+
+	// 只有系统和分组都开启才记录
 	if !systemEnabled {
 		bodyLogStatus = "system_disabled"
-	} else if groupDisabled {
+	} else if !groupEnabled {
 		bodyLogStatus = "group_disabled"
 	} else {
 		bodyLogStatus = "enabled"

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -114,11 +114,11 @@ func (ps *ProxyServer) executeRequestWithRetry(
 			}
 			logrus.Debugf("Max retries exceeded for group %s after %d attempts. Parsed Error: %s", group.Name, retryCount, logMessage)
 
-			ps.logRequest(c, group, &models.APIKey{KeyValue: lastError.KeyValue}, startTime, lastError.StatusCode, retryCount, errors.New(logMessage), isStream, lastError.UpstreamAddr, channelHandler, bodyBytes)
+			ps.logRequest(c, group, &models.APIKey{KeyValue: lastError.KeyValue}, startTime, lastError.StatusCode, retryCount, errors.New(logMessage), isStream, lastError.UpstreamAddr, channelHandler, bodyBytes, "")
 		} else {
 			response.Error(c, app_errors.ErrMaxRetriesExceeded)
 			logrus.Debugf("Max retries exceeded for group %s after %d attempts.", group.Name, retryCount)
-			ps.logRequest(c, group, nil, startTime, http.StatusServiceUnavailable, retryCount, app_errors.ErrMaxRetriesExceeded, isStream, "", channelHandler, bodyBytes)
+			ps.logRequest(c, group, nil, startTime, http.StatusServiceUnavailable, retryCount, app_errors.ErrMaxRetriesExceeded, isStream, "", channelHandler, bodyBytes, "")
 		}
 		return
 	}
@@ -127,7 +127,7 @@ func (ps *ProxyServer) executeRequestWithRetry(
 	if err != nil {
 		logrus.Errorf("Failed to select a key for group %s on attempt %d: %v", group.Name, retryCount+1, err)
 		response.Error(c, app_errors.NewAPIError(app_errors.ErrNoKeysAvailable, err.Error()))
-		ps.logRequest(c, group, nil, startTime, http.StatusServiceUnavailable, retryCount, err, isStream, "", channelHandler, bodyBytes)
+		ps.logRequest(c, group, nil, startTime, http.StatusServiceUnavailable, retryCount, err, isStream, "", channelHandler, bodyBytes, "")
 		return
 	}
 
@@ -191,7 +191,7 @@ func (ps *ProxyServer) executeRequestWithRetry(
 	if err != nil || (resp != nil && resp.StatusCode >= 400 && resp.StatusCode != http.StatusNotFound) {
 		if err != nil && app_errors.IsIgnorableError(err) {
 			logrus.Debugf("Client-side ignorable error for key %s, aborting retries: %v", utils.MaskAPIKey(apiKey.KeyValue), err)
-			ps.logRequest(c, group, apiKey, startTime, 499, retryCount+1, err, isStream, upstreamURL, channelHandler, bodyBytes)
+			ps.logRequest(c, group, apiKey, startTime, 499, retryCount+1, err, isStream, upstreamURL, channelHandler, bodyBytes, "")
 			return
 		}
 
@@ -234,7 +234,6 @@ func (ps *ProxyServer) executeRequestWithRetry(
 
 	// ps.keyProvider.UpdateStatus(apiKey, group, true) // 请求成功不再重置成功次数，减少IO消耗
 	logrus.Debugf("Request for group %s succeeded on attempt %d with key %s", group.Name, retryCount+1, utils.MaskAPIKey(apiKey.KeyValue))
-	ps.logRequest(c, group, apiKey, startTime, resp.StatusCode, retryCount+1, nil, isStream, upstreamURL, channelHandler, bodyBytes)
 
 	for key, values := range resp.Header {
 		for _, value := range values {
@@ -243,11 +242,14 @@ func (ps *ProxyServer) executeRequestWithRetry(
 	}
 	c.Status(resp.StatusCode)
 
+	var responseBody string
 	if isStream {
-		ps.handleStreamingResponse(c, resp)
+		responseBody = ps.handleStreamingResponse(c, resp)
 	} else {
-		ps.handleNormalResponse(c, resp)
+		responseBody = ps.handleNormalResponse(c, resp)
 	}
+
+	ps.logRequest(c, group, apiKey, startTime, resp.StatusCode, retryCount+1, nil, isStream, upstreamURL, channelHandler, bodyBytes, responseBody)
 }
 
 // logRequest is a helper function to create and record a request log.
@@ -263,6 +265,7 @@ func (ps *ProxyServer) logRequest(
 	upstreamAddr string,
 	channelHandler channel.ChannelProxy,
 	bodyBytes []byte,
+	responseBody string,
 ) {
 	if ps.requestLogService == nil {
 		return
@@ -282,6 +285,8 @@ func (ps *ProxyServer) logRequest(
 		Retries:      retries,
 		IsStream:     isStream,
 		UpstreamAddr: utils.TruncateString(upstreamAddr, 500),
+		RequestBody:  string(bodyBytes),
+		ResponseBody: responseBody,
 	}
 
 	if channelHandler != nil && bodyBytes != nil {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -21,6 +21,7 @@ type SystemSettings struct {
 	AppUrl                         string `json:"app_url" default:"http://localhost:3001" name:"项目地址" category:"基础参数" desc:"项目的基础 URL，用于拼接分组终端节点地址。系统配置优先于环境变量 APP_URL。" validate:"required"`
 	RequestLogRetentionDays        int    `json:"request_log_retention_days" default:"7" name:"日志保留时长（天）" category:"基础参数" desc:"请求日志在数据库中的保留天数，0为不清理日志。" validate:"required,min=0"`
 	RequestLogWriteIntervalMinutes int    `json:"request_log_write_interval_minutes" default:"1" name:"日志延迟写入周期（分钟）" category:"基础参数" desc:"请求日志从缓存写入数据库的周期（分钟），0为实时写入数据。" validate:"required,min=0"`
+	EnableRequestBodyLogging       bool   `json:"enable_request_body_logging" default:"true" name:"记录请求和响应体" category:"基础参数" desc:"是否在请求日志中记录完整的请求体和响应体内容。关闭此选项可以减少存储空间占用。"`
 	ProxyKeys                      string `json:"proxy_keys" name:"全局代理密钥" category:"基础参数" desc:"全局代理密钥，用于访问所有分组的代理端点。多个密钥请用逗号分隔。" validate:"required"`
 
 	// 请求设置

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -21,10 +21,10 @@ type SystemSettings struct {
 	AppUrl                         string `json:"app_url" default:"http://localhost:3001" name:"项目地址" category:"基础参数" desc:"项目的基础 URL，用于拼接分组终端节点地址。系统配置优先于环境变量 APP_URL。" validate:"required"`
 	RequestLogRetentionDays        int    `json:"request_log_retention_days" default:"7" name:"日志保留时长（天）" category:"基础参数" desc:"请求日志在数据库中的保留天数，0为不清理日志。" validate:"required,min=0"`
 	RequestLogWriteIntervalMinutes int    `json:"request_log_write_interval_minutes" default:"1" name:"日志延迟写入周期（分钟）" category:"基础参数" desc:"请求日志从缓存写入数据库的周期（分钟），0为实时写入数据。" validate:"required,min=0"`
-	EnableRequestBodyLogging       bool   `json:"enable_request_body_logging" default:"false" name:"记录请求和响应体" category:"基础参数" desc:"是否在请求日志中记录完整的请求体和响应体内容。关闭此选项可以减少存储空间占用。"`
 	ProxyKeys                      string `json:"proxy_keys" name:"全局代理密钥" category:"基础参数" desc:"全局代理密钥，用于访问所有分组的代理端点。多个密钥请用逗号分隔。" validate:"required"`
 
 	// 请求设置
+	EnableRequestBodyLogging  bool   `json:"enable_request_body_logging" default:"false" name:"记录请求和响应体" category:"请求设置" desc:"是否在请求日志中记录完整的请求体和响应体内容。关闭此选项可以减少存储空间占用。"`
 	RequestTimeout        int    `json:"request_timeout" default:"600" name:"请求超时（秒）" category:"请求设置" desc:"转发请求的完整生命周期超时（秒）等。" validate:"required,min=1"`
 	ConnectTimeout        int    `json:"connect_timeout" default:"15" name:"连接超时（秒）" category:"请求设置" desc:"与上游服务建立新连接的超时时间（秒）。" validate:"required,min=1"`
 	IdleConnTimeout       int    `json:"idle_conn_timeout" default:"120" name:"空闲连接超时（秒）" category:"请求设置" desc:"HTTP 客户端中空闲连接的超时时间（秒）。" validate:"required,min=1"`

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -21,7 +21,7 @@ type SystemSettings struct {
 	AppUrl                         string `json:"app_url" default:"http://localhost:3001" name:"项目地址" category:"基础参数" desc:"项目的基础 URL，用于拼接分组终端节点地址。系统配置优先于环境变量 APP_URL。" validate:"required"`
 	RequestLogRetentionDays        int    `json:"request_log_retention_days" default:"7" name:"日志保留时长（天）" category:"基础参数" desc:"请求日志在数据库中的保留天数，0为不清理日志。" validate:"required,min=0"`
 	RequestLogWriteIntervalMinutes int    `json:"request_log_write_interval_minutes" default:"1" name:"日志延迟写入周期（分钟）" category:"基础参数" desc:"请求日志从缓存写入数据库的周期（分钟），0为实时写入数据。" validate:"required,min=0"`
-	EnableRequestBodyLogging       bool   `json:"enable_request_body_logging" default:"true" name:"记录请求和响应体" category:"基础参数" desc:"是否在请求日志中记录完整的请求体和响应体内容。关闭此选项可以减少存储空间占用。"`
+	EnableRequestBodyLogging       bool   `json:"enable_request_body_logging" default:"false" name:"记录请求和响应体" category:"基础参数" desc:"是否在请求日志中记录完整的请求体和响应体内容。关闭此选项可以减少存储空间占用。"`
 	ProxyKeys                      string `json:"proxy_keys" name:"全局代理密钥" category:"基础参数" desc:"全局代理密钥，用于访问所有分组的代理端点。多个密钥请用逗号分隔。" validate:"required"`
 
 	// 请求设置

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -3,8 +3,8 @@ import http from "@/utils/http";
 export interface Setting {
   key: string;
   name: string;
-  value: string | number;
-  type: "int" | "string";
+  value: string | number | boolean;
+  type: "int" | "string" | "bool";
   min_value?: number;
   description: string;
   required: boolean;
@@ -15,7 +15,7 @@ export interface SettingCategory {
   settings: Setting[];
 }
 
-export type SettingsUpdatePayload = Record<string, string | number>;
+export type SettingsUpdatePayload = Record<string, string | number | boolean>;
 
 export const settingsApi = {
   async getSettings(): Promise<SettingCategory[]> {

--- a/web/src/components/keys/GroupFormModal.vue
+++ b/web/src/components/keys/GroupFormModal.vue
@@ -14,6 +14,7 @@ import {
   NInputNumber,
   NModal,
   NSelect,
+  NSwitch,
   NTooltip,
   useMessage,
   type FormRules,
@@ -34,7 +35,7 @@ interface Emits {
 // 配置项类型
 interface ConfigItem {
   key: string;
-  value: number | string;
+  value: number | string | boolean;
 }
 
 // Header规则类型
@@ -65,7 +66,7 @@ interface GroupFormData {
   test_model: string;
   validation_endpoint: string;
   param_overrides: string;
-  config: Record<string, number | string>;
+  config: Record<string, number | string | boolean>;
   configItems: ConfigItem[];
   header_rules: HeaderRuleItem[];
   proxy_keys: string;
@@ -456,7 +457,7 @@ async function handleSubmit() {
     }
 
     // 将configItems转换为config对象
-    const config: Record<string, number | string> = {};
+    const config: Record<string, number | string | boolean> = {};
     formData.configItems.forEach((item: ConfigItem) => {
       if (item.key && item.key.trim()) {
         const option = configOptions.value.find(opt => opt.key === item.key);
@@ -860,6 +861,11 @@ async function handleSubmit() {
                               placeholder="参数值"
                               :precision="0"
                               style="width: 100%"
+                            />
+                            <n-switch
+                              v-else-if="typeof configItem.value === 'boolean'"
+                              v-model:value="configItem.value"
+                              size="small"
                             />
                             <n-input v-else v-model:value="configItem.value" placeholder="参数值" />
                           </template>

--- a/web/src/components/logs/LogTable.vue
+++ b/web/src/components/logs/LogTable.vue
@@ -484,7 +484,15 @@ function changePageSize(size: number) {
             <n-tabs type="line" animated>
               <n-tab-pane name="request" tab="请求内容">
                 <div v-if="!selectedLog.request_body" style="text-align: center; color: #999; padding: 20px;">
-                  未记录请求内容（可能已在系统设置中关闭请求体记录功能）
+                  <template v-if="selectedLog.body_log_status === 'system_disabled'">
+                    未记录请求内容（系统设置中已关闭请求体记录功能）
+                  </template>
+                  <template v-else-if="selectedLog.body_log_status === 'group_disabled'">
+                    未记录请求内容（此分组已禁用请求体记录功能）
+                  </template>
+                  <template v-else>
+                    未记录请求内容
+                  </template>
                 </div>
                 <n-code
                   v-else
@@ -496,7 +504,15 @@ function changePageSize(size: number) {
               </n-tab-pane>
               <n-tab-pane name="response" tab="响应内容">
                 <div v-if="!selectedLog.response_body" style="text-align: center; color: #999; padding: 20px;">
-                  未记录响应内容（可能已在系统设置中关闭响应体记录功能）
+                  <template v-if="selectedLog.body_log_status === 'system_disabled'">
+                    未记录响应内容（系统设置中已关闭响应体记录功能）
+                  </template>
+                  <template v-else-if="selectedLog.body_log_status === 'group_disabled'">
+                    未记录响应内容（此分组已禁用响应体记录功能）
+                  </template>
+                  <template v-else>
+                    未记录响应内容
+                  </template>
                 </div>
                 <n-code
                   v-else

--- a/web/src/components/logs/LogTable.vue
+++ b/web/src/components/logs/LogTable.vue
@@ -483,16 +483,24 @@ function changePageSize(size: number) {
           <n-card title="请求和响应内容" size="small">
             <n-tabs type="line" animated>
               <n-tab-pane name="request" tab="请求内容">
+                <div v-if="!selectedLog.request_body" style="text-align: center; color: #999; padding: 20px;">
+                  未记录请求内容（可能已在系统设置中关闭请求体记录功能）
+                </div>
                 <n-code
-                  :code="formatJsonString(selectedLog.request_body || '')"
+                  v-else
+                  :code="formatJsonString(selectedLog.request_body)"
                   language="json"
                   show-line-numbers
                   style="max-height: 400px; overflow-y: auto;"
                 />
               </n-tab-pane>
               <n-tab-pane name="response" tab="响应内容">
+                <div v-if="!selectedLog.response_body" style="text-align: center; color: #999; padding: 20px;">
+                  未记录响应内容（可能已在系统设置中关闭响应体记录功能）
+                </div>
                 <n-code
-                  :code="formatJsonString(selectedLog.response_body || '')"
+                  v-else
+                  :code="formatJsonString(selectedLog.response_body)"
                   language="json"
                   show-line-numbers
                   style="max-height: 400px; overflow-y: auto;"

--- a/web/src/components/logs/LogTable.vue
+++ b/web/src/components/logs/LogTable.vue
@@ -2,7 +2,7 @@
 import { logApi } from "@/api/logs";
 import type { LogFilter, RequestLog } from "@/types/models";
 import { maskKey } from "@/utils/display";
-import { DownloadOutline, EyeOffOutline, EyeOutline, Search } from "@vicons/ionicons5";
+import { DownloadOutline, EyeOffOutline, EyeOutline, Search, DocumentTextOutline } from "@vicons/ionicons5";
 import {
   NButton,
   NDataTable,
@@ -14,6 +14,11 @@ import {
   NSpace,
   NSpin,
   NTag,
+  NModal,
+  NCard,
+  NCode,
+  NTabs,
+  NTabPane,
 } from "naive-ui";
 import { computed, h, onMounted, reactive, ref, watch } from "vue";
 
@@ -28,6 +33,10 @@ const currentPage = ref(1);
 const pageSize = ref(15);
 const total = ref(0);
 const totalPages = computed(() => Math.ceil(total.value / pageSize.value));
+
+// Modal for viewing request/response details
+const showDetailModal = ref(false);
+const selectedLog = ref<LogRow | null>(null);
 
 // Filters
 const filters = reactive({
@@ -96,6 +105,25 @@ const formatDateTime = (timestamp: string) => {
 
 const toggleKeyVisibility = (row: LogRow) => {
   row.is_key_visible = !row.is_key_visible;
+};
+
+const viewLogDetails = (row: LogRow) => {
+  selectedLog.value = row;
+  showDetailModal.value = true;
+};
+
+const closeDetailModal = () => {
+  showDetailModal.value = false;
+  selectedLog.value = null;
+};
+
+const formatJsonString = (jsonStr: string) => {
+  if (!jsonStr) return "";
+  try {
+    return JSON.stringify(JSON.parse(jsonStr), null, 2);
+  } catch {
+    return jsonStr;
+  }
 };
 
 // Columns definition
@@ -182,6 +210,26 @@ const createColumns = () => [
     width: 220,
     render: (row: LogRow) =>
       h(NEllipsis, { style: "max-width: 200px" }, { default: () => row.user_agent }),
+  },
+  {
+    title: "操作",
+    key: "actions",
+    width: 100,
+    fixed: "right" as const,
+    render: (row: LogRow) =>
+      h(
+        NButton,
+        {
+          size: "small",
+          type: "primary",
+          ghost: true,
+          onClick: () => viewLogDetails(row)
+        },
+        {
+          icon: () => h(NIcon, null, { default: () => h(DocumentTextOutline) }),
+          default: () => "详情"
+        }
+      ),
   },
 ];
 
@@ -342,7 +390,7 @@ function changePageSize(size: number) {
               :bordered="false"
               remote
               size="small"
-              :scroll-x="1840"
+              :scroll-x="1920"
             />
           </n-spin>
         </div>
@@ -384,6 +432,91 @@ function changePageSize(size: number) {
         </div>
       </div>
     </n-space>
+
+    <!-- 详情模态框 -->
+    <n-modal v-model:show="showDetailModal" preset="card" style="width: 90%; max-width: 1200px;" title="请求详情">
+      <div v-if="selectedLog">
+        <n-space vertical size="large">
+          <!-- 基本信息 -->
+          <n-card title="基本信息" size="small">
+            <div class="detail-grid">
+              <div class="detail-item">
+                <span class="detail-label">时间:</span>
+                <span>{{ formatDateTime(selectedLog.timestamp) }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="detail-label">状态:</span>
+                <n-tag :type="selectedLog.is_success ? 'success' : 'error'" size="small">
+                  {{ selectedLog.is_success ? '成功' : '失败' }}
+                </n-tag>
+              </div>
+              <div class="detail-item">
+                <span class="detail-label">状态码:</span>
+                <span>{{ selectedLog.status_code }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="detail-label">耗时:</span>
+                <span>{{ selectedLog.duration_ms }}ms</span>
+              </div>
+              <div class="detail-item">
+                <span class="detail-label">分组:</span>
+                <span>{{ selectedLog.group_name }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="detail-label">模型:</span>
+                <span>{{ selectedLog.model }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="detail-label">重试次数:</span>
+                <span>{{ selectedLog.retries }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="detail-label">类型:</span>
+                <n-tag :type="selectedLog.is_stream ? 'info' : 'default'" size="small">
+                  {{ selectedLog.is_stream ? '流式' : '非流式' }}
+                </n-tag>
+              </div>
+            </div>
+          </n-card>
+
+          <!-- 请求和响应内容 -->
+          <n-card title="请求和响应内容" size="small">
+            <n-tabs type="line" animated>
+              <n-tab-pane name="request" tab="请求内容">
+                <n-code
+                  :code="formatJsonString(selectedLog.request_body || '')"
+                  language="json"
+                  show-line-numbers
+                  style="max-height: 400px; overflow-y: auto;"
+                />
+              </n-tab-pane>
+              <n-tab-pane name="response" tab="响应内容">
+                <n-code
+                  :code="formatJsonString(selectedLog.response_body || '')"
+                  language="json"
+                  show-line-numbers
+                  style="max-height: 400px; overflow-y: auto;"
+                />
+              </n-tab-pane>
+            </n-tabs>
+          </n-card>
+
+          <!-- 错误信息 -->
+          <n-card v-if="selectedLog.error_message" title="错误信息" size="small">
+            <n-code
+              :code="selectedLog.error_message"
+              language="text"
+              style="max-height: 200px; overflow-y: auto;"
+            />
+          </n-card>
+        </n-space>
+      </div>
+      <template #footer>
+        <n-space justify="end">
+          <n-button @click="closeDetailModal">关闭</n-button>
+        </n-space>
+      </template>
+    </n-modal>
   </div>
 </template>
 
@@ -492,5 +625,23 @@ function changePageSize(size: number) {
 .page-info {
   font-size: 13px;
   color: #666;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 12px;
+}
+
+.detail-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.detail-label {
+  font-weight: 500;
+  color: #666;
+  min-width: 60px;
 }
 </style>

--- a/web/src/types/models.ts
+++ b/web/src/types/models.ts
@@ -130,6 +130,7 @@ export interface RequestLog {
   is_stream: boolean;
   request_body?: string;
   response_body?: string;
+  body_log_status?: "enabled" | "system_disabled" | "group_disabled";
 }
 
 export interface Pagination {

--- a/web/src/types/models.ts
+++ b/web/src/types/models.ts
@@ -128,6 +128,8 @@ export interface RequestLog {
   model: string;
   upstream_addr: string;
   is_stream: boolean;
+  request_body?: string;
+  response_body?: string;
 }
 
 export interface Pagination {

--- a/web/src/views/Settings.vue
+++ b/web/src/views/Settings.vue
@@ -13,6 +13,7 @@ import {
   NInput,
   NInputNumber,
   NSpace,
+  NSwitch,
   NTooltip,
   useMessage,
   type FormItemRule,
@@ -21,7 +22,7 @@ import { ref } from "vue";
 
 const settingList = ref<SettingCategory[]>([]);
 const formRef = ref();
-const form = ref<Record<string, string | number>>({});
+const form = ref<Record<string, string | number | boolean>>({});
 const isSaving = ref(false);
 const message = useMessage();
 
@@ -38,7 +39,7 @@ async function fetchSettings() {
 }
 
 function initForm() {
-  form.value = settingList.value.reduce((acc: Record<string, string | number>, category) => {
+  form.value = settingList.value.reduce((acc: Record<string, string | number | boolean>, category) => {
     category.settings?.forEach(setting => {
       acc[setting.key] = setting.value;
     });
@@ -136,6 +137,11 @@ function generateValidationRules(item: Setting): FormItemRule[] {
                   placeholder="请输入数值"
                   clearable
                   style="width: 100%"
+                  size="small"
+                />
+                <n-switch
+                  v-else-if="item.type === 'bool'"
+                  v-model:value="form[item.key] as boolean"
                   size="small"
                 />
                 <proxy-keys-input


### PR DESCRIPTION
- 系统设置内添加是否记录响应和请求体按钮
- 分组内高级配置-分组配置添加分组级禁用请求和响应体记录
- 在 RequestLog 模型中添加 request_body 和 response_body 字段用于存储完整的请求和响应内容
- 修改响应处理器以捕获和返回响应体内容，支持流式和非流式响应
- 更新代理服务器逻辑，在请求日志中记录请求体和响应体
- 在前端日志表格中添加详情查看功能，支持查看完整的请求和响应内容

### 关联 Issue / Related Issue
<!-- 请填写此 PR 关联的 issue 编号，例如：Closes #123 / Please link the issue number, e.g., Closes #123 -->
Closes #179 

### 变更内容 / Change Content
<!-- 请简要描述本次变更的核心内容 / Please briefly describe the core changes of this PR -->
- [ ] Bug 修复 / Bug fix
- [x] 新功能 / New feature
- [ ] 其他改动 / Other changes

<!-- 请在下方详细描述你的变更 / Please describe your changes in detail below -->


### 自查清单 / Checklist
- [x] 我已在本地测试过我的变更。 / I have tested my changes locally.
- [x] 我已更新了必要的文档。 / I have updated the necessary documentation.
### 系统级记录按钮开关
<img width="1204" height="392" alt="image" src="https://github.com/user-attachments/assets/3540c56a-ec81-4693-89ca-a9dff07e676f" />

### 分组级别关闭配置
<img width="823" height="490" alt="CleanShot 2025-08-16 at 19 05 34@2x" src="https://github.com/user-attachments/assets/16771016-56b3-49be-b7f1-6502634db45d" />


### 系统级记录按钮打开，不开启分组禁用
![](https://lsky.useforall.com/Blog/2025/08/16/68a028a418501.png)
![](https://lsky.useforall.com/Blog/2025/08/16/68a028d43831a.png)
#### 非流响应体
<img width="1212" height="827" alt="CleanShot 2025-08-16 at 14 44 48@2x" src="https://github.com/user-attachments/assets/cde8e1e1-6997-4f1e-9937-87b80eeec1c6" />

#### 流式响应体
<img width="1205" height="825" alt="CleanShot 2025-08-16 at 14 47 37@2x" src="https://github.com/user-attachments/assets/c4898ad4-a210-4aa9-95ac-b88fd092a98e" />

### 系统级记录按钮打开，开启分组禁用
<img width="1215" height="492" alt="CleanShot 2025-08-16 at 19 07 15@2x" src="https://github.com/user-attachments/assets/101ea838-65c5-4d57-a00e-63047a7ed2a3" />
<img width="1208" height="487" alt="CleanShot 2025-08-16 at 19 07 25@2x" src="https://github.com/user-attachments/assets/288d4d11-3008-4b1d-8b69-0b847ade9056" />

### 系统级记录按钮关闭
<img width="1214" height="493" alt="CleanShot 2025-08-16 at 19 07 46@2x" src="https://github.com/user-attachments/assets/f400dcb0-e95e-46cb-9d74-f82420b03557" />
<img width="1218" height="490" alt="CleanShot 2025-08-16 at 19 07 55@2x" src="https://github.com/user-attachments/assets/cbab8200-a5ff-4176-9b4b-9303606a5fef" />



