### PR TITLE
feat: Add key sorting threshold

### DIFF
--- a/internal/i18n/locales/en-US.go
+++ b/internal/i18n/locales/en-US.go
@@ -159,6 +159,8 @@ var MessagesEnUS = map[string]string{
 	"config.max_retries_desc":                "Maximum number of retries for a single request using different keys, 0 for no retries.",
 	"config.blacklist_threshold":             "Blacklist Threshold",
 	"config.blacklist_threshold_desc":        "Number of consecutive failures before a key is blacklisted, 0 to disable blacklisting.",
+	"config.keys_sort_max_count":             "Key Sorting Threshold",
+	"config.keys_sort_max_count_desc":        "Maximum number of keys to enable sorting and display by last used time. If group total keys exceeds this value, sorting falls back to ID order for performance.",
 	"config.key_validation_interval":         "Key Validation Interval (minutes)",
 	"config.key_validation_interval_desc":    "Default interval (minutes) for background key validation.",
 	"config.key_validation_concurrency":      "Key Validation Concurrency",

--- a/internal/i18n/locales/ja-JP.go
+++ b/internal/i18n/locales/ja-JP.go
@@ -159,6 +159,8 @@ var MessagesJaJP = map[string]string{
 	"config.max_retries_desc":                "異なるキーを使用した単一リクエストの最大リトライ数、0でリトライなし。",
 	"config.blacklist_threshold":             "ブラックリストしきい値",
 	"config.blacklist_threshold_desc":        "キーがブラックリストに入るまでの連続失敗回数、0でブラックリスト無効。",
+	"config.keys_sort_max_count":             "キーソートしきい値",
+	"config.keys_sort_max_count_desc":        "最終使用時刻でのソート/表示を有効にする最大キー数。グループ内のキー総数がこの値を超えると、パフォーマンスのためID順にフォールバックします。",
 	"config.key_validation_interval":         "キー検証間隔（分）",
 	"config.key_validation_interval_desc":    "バックグラウンドキー検証のデフォルト間隔（分）。",
 	"config.key_validation_concurrency":      "キー検証並行数",

--- a/internal/i18n/locales/zh-CN.go
+++ b/internal/i18n/locales/zh-CN.go
@@ -159,6 +159,8 @@ var MessagesZhCN = map[string]string{
 	"config.max_retries_desc":                "单个请求使用不同 Key 的最大重试次数，0为不重试。",
 	"config.blacklist_threshold":             "黑名单阈值",
 	"config.blacklist_threshold_desc":        "一个 Key 连续失败多少次后进入黑名单，0为不拉黑。",
+	"config.keys_sort_max_count":             "密钥排序阈值",
+	"config.keys_sort_max_count_desc":        "启用按最近使用时间排序和展示的最大密钥数量。若分组密钥总数超过该值，为性能起见将回退为按 ID 排序。",
 	"config.key_validation_interval":         "密钥验证间隔（分钟）",
 	"config.key_validation_interval_desc":    "后台验证密钥的默认间隔（分钟）。",
 	"config.key_validation_concurrency":      "密钥验证并发数",

--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -34,6 +34,7 @@ type GroupConfig struct {
 	ProxyURL                     *string `json:"proxy_url,omitempty"`
 	MaxRetries                   *int    `json:"max_retries,omitempty"`
 	BlacklistThreshold           *int    `json:"blacklist_threshold,omitempty"`
+	KeysSortMaxCount             *int    `json:"keys_sort_max_count,omitempty"`
 	KeyValidationIntervalMinutes *int    `json:"key_validation_interval_minutes,omitempty"`
 	KeyValidationConcurrency     *int    `json:"key_validation_concurrency,omitempty"`
 	KeyValidationTimeoutSeconds  *int    `json:"key_validation_timeout_seconds,omitempty"`
@@ -119,6 +120,7 @@ type APIKey struct {
 	Notes        string     `gorm:"type:varchar(255);default:''" json:"notes"`
 	RequestCount int64      `gorm:"not null;default:0" json:"request_count"`
 	FailureCount int64      `gorm:"not null;default:0" json:"failure_count"`
+	LastUsedAt   *time.Time `gorm:"index" json:"last_used_at"`
 	CreatedAt    time.Time  `json:"created_at"`
 	UpdatedAt    time.Time  `json:"updated_at"`
 }

--- a/internal/response/pagination.go
+++ b/internal/response/pagination.go
@@ -25,6 +25,7 @@ type Pagination struct {
 type PaginatedResponse struct {
 	Items      any        `json:"items"`
 	Pagination Pagination `json:"pagination"`
+	Meta       any        `json:"meta,omitempty"`
 }
 
 // Paginate performs pagination on a GORM query and returns a standardized response.

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -37,6 +37,7 @@ type SystemSettings struct {
 	// 密钥配置
 	MaxRetries                   int `json:"max_retries" default:"3" name:"config.max_retries" category:"config.category.key" desc:"config.max_retries_desc" validate:"required,min=0"`
 	BlacklistThreshold           int `json:"blacklist_threshold" default:"3" name:"config.blacklist_threshold" category:"config.category.key" desc:"config.blacklist_threshold_desc" validate:"required,min=0"`
+	KeysSortMaxCount             int `json:"keys_sort_max_count" default:"10000" name:"config.keys_sort_max_count" category:"config.category.key" desc:"config.keys_sort_max_count_desc" validate:"required,min=0"`
 	KeyValidationIntervalMinutes int `json:"key_validation_interval_minutes" default:"60" name:"config.key_validation_interval" category:"config.category.key" desc:"config.key_validation_interval_desc" validate:"required,min=1"`
 	KeyValidationConcurrency     int `json:"key_validation_concurrency" default:"10" name:"config.key_validation_concurrency" category:"config.category.key" desc:"config.key_validation_concurrency_desc" validate:"required,min=1"`
 	KeyValidationTimeoutSeconds  int `json:"key_validation_timeout_seconds" default:"20" name:"config.key_validation_timeout" category:"config.category.key" desc:"config.key_validation_timeout_desc" validate:"required,min=1"`

--- a/web/src/api/keys.ts
+++ b/web/src/api/keys.ts
@@ -5,6 +5,7 @@ import type {
   GroupConfigOption,
   GroupStatsResponse,
   KeyStatus,
+  Pagination,
   ParentAggregateGroup,
   TaskInfo,
 } from "@/types/models";
@@ -76,9 +77,9 @@ export const keysApi = {
     status?: KeyStatus;
   }): Promise<{
     items: APIKey[];
-    pagination: {
-      total_items: number;
-      total_pages: number;
+    pagination: Pagination;
+    meta?: {
+      last_used_enabled?: boolean;
     };
   }> {
     const res = await http.get("/keys", { params });

--- a/web/src/components/keys/KeyTable.vue
+++ b/web/src/components/keys/KeyTable.vue
@@ -53,6 +53,7 @@ const currentPage = ref(1);
 const pageSize = ref(12);
 const total = ref(0);
 const totalPages = ref(0);
+const lastUsedEnabled = ref(true);
 const dialog = useDialog();
 const confirmInput = ref("");
 
@@ -207,6 +208,7 @@ async function loadKeys() {
     keys.value = result.items as KeyRow[];
     total.value = result.pagination.total_items;
     totalPages.value = result.pagination.total_pages;
+    lastUsedEnabled.value = result.meta?.last_used_enabled ?? true;
   } finally {
     loading.value = false;
   }
@@ -751,7 +753,7 @@ function resetPage() {
                   {{ t("keys.failuresShort") }}
                   <strong>{{ key.failure_count }}</strong>
                 </span>
-                <span class="stat-item">
+                <span v-if="lastUsedEnabled" class="stat-item">
                   {{ key.last_used_at ? formatRelativeTime(key.last_used_at) : t("keys.unused") }}
                 </span>
               </div>

--- a/web/src/locales/en-US.ts
+++ b/web/src/locales/en-US.ts
@@ -528,6 +528,7 @@ export default {
     connectTimeout: "Connect Timeout",
     maxRetries: "Max Retries",
     blacklistThreshold: "Blacklist Threshold",
+    keysSortMaxCount: "Key Sorting Threshold",
     keyValidationInterval: "Key Validation Interval",
     logRetentionDays: "Log Retention Days",
     enableRequestLogging: "Enable Request Logging",

--- a/web/src/locales/ja-JP.ts
+++ b/web/src/locales/ja-JP.ts
@@ -529,6 +529,7 @@ export default {
     connectTimeout: "接続タイムアウト",
     maxRetries: "最大リトライ回数",
     blacklistThreshold: "ブラックリスト閾値",
+    keysSortMaxCount: "キーソートしきい値",
     keyValidationInterval: "キー検証間隔",
     logRetentionDays: "ログ保存日数",
     enableRequestLogging: "リクエストログ有効化",

--- a/web/src/locales/zh-CN.ts
+++ b/web/src/locales/zh-CN.ts
@@ -512,6 +512,7 @@ export default {
     connectTimeout: "连接超时",
     maxRetries: "最大重试次数",
     blacklistThreshold: "黑名单阈值",
+    keysSortMaxCount: "密钥排序阈值",
     keyValidationInterval: "密钥验证间隔",
     logRetentionDays: "日志保留天数",
     enableRequestLogging: "启用请求日志",


### PR DESCRIPTION
* feat: Add keys_sort_max_count setting + group override
* feat: Track api_keys.last_used_at from request logs
* feat: Conditional keys sorting + UI toggle via last_used_enabled

### 关联 Issue / Related Issue
<!-- 请填写此 PR 关联的 issue 编号，例如：Closes #123 / Please link the issue number, e.g., Closes #123 -->
无

### 变更内容 / Change Content
<!-- 请简要描述本次变更的核心内容 / Please briefly describe the core changes of this PR -->
- [ ] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [x] 其他改动 / Other changes

<!-- 请在下方详细描述你的变更 / Please describe your changes in detail below -->

恢复少于1万的key（密钥排序阈值）进行排序和显示last_used时间的功能， `密钥排序阈值`可配置，默认为1万。不影响原有的高数量key相关的功能。

### 自查清单 / Checklist
- [x] 我已在本地测试过我的变更。 / I have tested my changes locally.
- [x] 我已更新了必要的文档。 / I have updated the necessary documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API keys now track and display "last used" timestamps in key listings.
  * Added a configurable threshold for key sorting; automatic fallback to ID-based sorting when key count exceeds the threshold for optimal performance.
  * API responses include metadata indicating whether last-used sorting is enabled.
  * Multi-language support for new configuration settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->