### PR TITLE
fix(proxy): normalize lenient JSON request bodies before forwarding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/glebarez/sqlite v1.11.0
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/google/uuid v1.6.0
+	github.com/hjson/hjson-go/v4 v4.6.0
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/klauspost/compress v1.18.1
@@ -21,6 +22,7 @@ require (
 	go.uber.org/dig v1.19.0
 	golang.org/x/crypto v0.37.0
 	golang.org/x/text v0.28.0
+	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/datatypes v1.2.1
 	gorm.io/driver/mysql v1.6.0
 	gorm.io/driver/postgres v1.6.0
@@ -63,7 +65,6 @@ require (
 	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.22.5 // indirect
 	modernc.org/mathutil v1.5.0 // indirect
 	modernc.org/memory v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/google/pprof v0.0.0-20221118152302-e6195bd50e26 h1:Xim43kblpZXfIBQsbu
 github.com/google/pprof v0.0.0-20221118152302-e6195bd50e26/go.mod h1:dDKJzRmX4S37WGHujM7tX//fmj1uioxKzKxz3lo4HJo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/hjson/hjson-go/v4 v4.6.0 h1:16e6ViyVfAANKsXo/46h8szUADez7FJs67xl/l+KHS4=
+github.com/hjson/hjson-go/v4 v4.6.0/go.mod h1:4zx6c7Y0vWcm8IRyVoQJUHAPJLXLvbG6X8nk1RLigSo=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -102,6 +102,13 @@ func (ps *ProxyServer) HandleProxy(c *gin.Context) {
 	}
 	c.Request.Body.Close()
 
+	if normalizedBody, normalized := utils.NormalizeJSONRequestBody(bodyBytes, c.GetHeader("Content-Type")); normalized {
+		logrus.WithFields(logrus.Fields{
+			"group": group.Name,
+		}).Debug("request body normalized from lenient JSON")
+		bodyBytes = normalizedBody
+	}
+
 	finalBodyBytes, err := ps.applyParamOverrides(bodyBytes, group)
 	if err != nil {
 		response.Error(c, app_errors.NewAPIError(app_errors.ErrInternalServer, fmt.Sprintf("Failed to apply parameter overrides: %v", err)))

--- a/internal/utils/json_normalizer.go
+++ b/internal/utils/json_normalizer.go
@@ -1,0 +1,188 @@
+package utils
+
+import (
+	"bytes"
+	"encoding/json"
+	"regexp"
+	"strings"
+
+	hjson "github.com/hjson/hjson-go/v4"
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	jsonKeyPattern           = regexp.MustCompile(`([{,]\s*)([A-Za-z_][A-Za-z0-9_-]*)(\s*:)`)
+	barewordValuePattern     = regexp.MustCompile(`(:\s*)([A-Za-z_./:@?&=%+~\-][A-Za-z0-9_./:@?&=%+~\-]*)(\s*[,}\]])`)
+	barewordArrayItemPattern = regexp.MustCompile(`([\[,]\s*)([A-Za-z_./:@?&=%+~\-][A-Za-z0-9_./:@?&=%+~\-]*)(\s*[\],])`)
+	strictJSONNumberPattern  = regexp.MustCompile(`^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$`)
+)
+
+// NormalizeJSONRequestBody attempts to normalize non-standard JSON-like bodies
+// (for example unquoted object keys) into strict JSON bytes.
+// Returns (normalizedBytes, true) when normalization succeeds.
+func NormalizeJSONRequestBody(body []byte, contentType string) ([]byte, bool) {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return body, false
+	}
+
+	if !shouldAttemptJSONNormalization(trimmed, contentType) {
+		return body, false
+	}
+
+	if json.Valid(trimmed) {
+		return body, false
+	}
+
+	if normalized, ok := normalizeByLooseTokenRepair(trimmed); ok {
+		return normalized, true
+	}
+
+	var parsed any
+	if err := hjson.Unmarshal(trimmed, &parsed); err != nil {
+		// YAML is kept as a secondary fallback for simple JSON-like payloads
+		// that are not accepted by hjson parser.
+		if err := yaml.Unmarshal(trimmed, &parsed); err != nil {
+			return body, false
+		}
+	}
+
+	normalized, ok := toJSONCompatible(parsed)
+	if !ok {
+		return body, false
+	}
+
+	switch normalized.(type) {
+	case map[string]any, []any:
+		// supported
+	default:
+		return body, false
+	}
+
+	normalizedBytes, err := json.Marshal(normalized)
+	if err != nil {
+		return body, false
+	}
+
+	return normalizedBytes, true
+}
+
+func normalizeByLooseTokenRepair(trimmed []byte) ([]byte, bool) {
+	repaired := jsonKeyPattern.ReplaceAll(trimmed, []byte(`${1}"${2}"${3}`))
+	repaired = quoteBarewordTokens(repaired, barewordValuePattern)
+	repaired = quoteBarewordTokens(repaired, barewordArrayItemPattern)
+	if !json.Valid(repaired) {
+		return nil, false
+	}
+	return repaired, true
+}
+
+func quoteBarewordTokens(input []byte, pattern *regexp.Regexp) []byte {
+	indices := pattern.FindAllSubmatchIndex(input, -1)
+	if len(indices) == 0 {
+		return input
+	}
+
+	var out bytes.Buffer
+	last := 0
+	for _, idx := range indices {
+		fullStart, fullEnd := idx[0], idx[1]
+		prefixStart, prefixEnd := idx[2], idx[3]
+		tokenStart, tokenEnd := idx[4], idx[5]
+		suffixStart, suffixEnd := idx[6], idx[7]
+
+		token := string(input[tokenStart:tokenEnd])
+		out.Write(input[last:fullStart])
+		out.Write(input[prefixStart:prefixEnd])
+		if shouldQuoteBarewordToken(token) {
+			out.WriteByte('"')
+			out.Write(input[tokenStart:tokenEnd])
+			out.WriteByte('"')
+		} else {
+			out.Write(input[tokenStart:tokenEnd])
+		}
+		out.Write(input[suffixStart:suffixEnd])
+		last = fullEnd
+	}
+	out.Write(input[last:])
+	return out.Bytes()
+}
+
+func shouldQuoteBarewordToken(token string) bool {
+	switch token {
+	case "true", "false", "null":
+		return false
+	}
+	return !strictJSONNumberPattern.MatchString(token)
+}
+
+func shouldAttemptJSONNormalization(trimmed []byte, contentType string) bool {
+	if len(trimmed) == 0 {
+		return false
+	}
+
+	first := trimmed[0]
+	if first != '{' && first != '[' {
+		return false
+	}
+
+	ct := strings.ToLower(strings.TrimSpace(contentType))
+	if ct == "" {
+		return true
+	}
+	return strings.Contains(ct, "application/json") || strings.Contains(ct, "+json")
+}
+
+func toJSONCompatible(v any) (any, bool) {
+	switch value := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(value))
+		for k, raw := range value {
+			converted, ok := toJSONCompatible(raw)
+			if !ok {
+				return nil, false
+			}
+			out[k] = converted
+		}
+		return out, true
+	case map[any]any:
+		out := make(map[string]any, len(value))
+		for k, raw := range value {
+			key, ok := k.(string)
+			if !ok {
+				return nil, false
+			}
+			converted, ok := toJSONCompatible(raw)
+			if !ok {
+				return nil, false
+			}
+			out[key] = converted
+		}
+		return out, true
+	case []any:
+		out := make([]any, len(value))
+		for i := range value {
+			converted, ok := toJSONCompatible(value[i])
+			if !ok {
+				return nil, false
+			}
+			out[i] = converted
+		}
+		return out, true
+	case nil, bool, string,
+		int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64, json.Number:
+		return value, true
+	default:
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return nil, false
+		}
+		var out any
+		if err := json.Unmarshal(encoded, &out); err != nil {
+			return nil, false
+		}
+		return out, true
+	}
+}

--- a/internal/utils/json_normalizer_test.go
+++ b/internal/utils/json_normalizer_test.go
@@ -1,0 +1,72 @@
+package utils
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestNormalizeJSONRequestBodyValidJSONNoChange(t *testing.T) {
+	original := []byte(`{"model":"mistral-large-latest","max_tokens":16}`)
+	got, normalized := NormalizeJSONRequestBody(original, "application/json")
+
+	if normalized {
+		t.Fatalf("expected normalized=false, got true")
+	}
+	if string(got) != string(original) {
+		t.Fatalf("expected body unchanged, got %s", string(got))
+	}
+}
+
+func TestNormalizeJSONRequestBodyLenientObject(t *testing.T) {
+	original := []byte(`{messages:[{content:ping,role:user}],model:mistral-large-latest,max_tokens:16}`)
+	got, normalized := NormalizeJSONRequestBody(original, "application/json")
+
+	if !normalized {
+		t.Fatalf("expected normalized=true, got false")
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(got, &parsed); err != nil {
+		t.Fatalf("normalized output is not valid JSON: %v", err)
+	}
+
+	expected := map[string]any{
+		"model":      "mistral-large-latest",
+		"max_tokens": float64(16),
+		"messages": []any{
+			map[string]any{
+				"content": "ping",
+				"role":    "user",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(parsed, expected) {
+		t.Fatalf("unexpected parsed JSON.\nexpected: %#v\ngot: %#v", expected, parsed)
+	}
+}
+
+func TestNormalizeJSONRequestBodySkipsNonJSONContentType(t *testing.T) {
+	original := []byte(`{messages:[{content:ping,role:user}],model:mistral-large-latest,max_tokens:16}`)
+	got, normalized := NormalizeJSONRequestBody(original, "text/plain")
+
+	if normalized {
+		t.Fatalf("expected normalized=false for text/plain")
+	}
+	if string(got) != string(original) {
+		t.Fatalf("expected body unchanged, got %s", string(got))
+	}
+}
+
+func TestNormalizeJSONRequestBodyInvalidGarbage(t *testing.T) {
+	original := []byte(`{this is not parseable:::`)
+	got, normalized := NormalizeJSONRequestBody(original, "application/json")
+
+	if normalized {
+		t.Fatalf("expected normalized=false for invalid garbage")
+	}
+	if string(got) != string(original) {
+		t.Fatalf("expected body unchanged, got %s", string(got))
+	}
+}


### PR DESCRIPTION
## Summary
- Add lenient JSON body normalization before proxy forwarding.
- Keep existing strict behavior unchanged for already-valid JSON and non-JSON payloads.
- Support common malformed payloads like unquoted object keys / bareword string values (for example `{messages:[{content:ping,role:user}],model:mistral-large-latest}`) by normalizing them into strict JSON.

## Changes
- Add `utils.NormalizeJSONRequestBody` (`internal/utils/json_normalizer.go`).
  - Attempt normalization only for JSON-ish bodies (`{`/`[` and `application/json` or `+json`).
  - Fast path for already-valid JSON.
  - Fallback strategies:
    - loose token repair (quote unquoted keys and bareword tokens)
    - hjson parse
    - yaml parse
  - Marshal normalized value back to strict JSON.
- Invoke normalization in proxy entrypoint before param overrides and upstream forwarding (`internal/proxy/server.go`).
- Add unit tests for normalization behavior (`internal/utils/json_normalizer_test.go`).
- Add dependency `github.com/hjson/hjson-go/v4`.

## Why
Some clients/shell invocations can accidentally send non-standard JSON. Previously, these payloads were forwarded as-is and upstream returned 422 JSON decode errors. With this patch, gpt-load can repair common malformed JSON request bodies and continue normal processing.

## Validation
- Unit tests:
  - `go test ./internal/utils -run NormalizeJSONRequestBody -v`
- Internal packages:
  - `go test ./internal/...`
- Manual E2E validation:
  - Patched local gpt-load accepted malformed body and returned `200` from Mistral upstream.
  - Same malformed body sent directly to Mistral returned `422 json_invalid`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Request bodies now support automatic normalization to handle non-standard JSON-like input formats.

* **Dependencies**
  * Added HJSON and YAML libraries to support flexible JSON parsing and conversion.

* **Tests**
  * Comprehensive test coverage added for JSON normalization functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->