### PR TITLE
feat: 支持分组级故障转移状态码

### DIFF
--- a/internal/config/system_settings.go
+++ b/internal/config/system_settings.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"gpt-load/internal/db"
+	"gpt-load/internal/failover"
 	"gpt-load/internal/models"
 	"gpt-load/internal/store"
 	"gpt-load/internal/syncer"
@@ -307,6 +308,11 @@ func (sm *SystemSettingsManager) ValidateSettings(settingsMap map[string]any) er
 					}
 				}
 			}
+			if key == "failover_status_codes" {
+				if _, err := failover.ParseStatusCodeMatcher(strVal); err != nil {
+					return err
+				}
+			}
 		default:
 			return fmt.Errorf("unsupported type for setting key validation: %s", key)
 		}
@@ -377,6 +383,11 @@ func (sm *SystemSettingsManager) ValidateGroupConfigOverrides(configMap map[stri
 					}
 				}
 			}
+			if key == "failover_status_codes" {
+				if _, err := failover.ParseStatusCodeMatcher(strVal); err != nil {
+					return err
+				}
+			}
 		case reflect.Bool:
 			_, ok := value.(bool)
 			if !ok {
@@ -410,6 +421,7 @@ func (sm *SystemSettingsManager) DisplaySystemConfig(settings types.SystemSettin
 	logrus.Info("  --- Key & Group Behavior ---")
 	logrus.Infof("    Max Retries: %d", settings.MaxRetries)
 	logrus.Infof("    Blacklist Threshold: %d", settings.BlacklistThreshold)
+	logrus.Infof("    Extra Failover Status Codes: %s", settings.FailoverStatusCodes)
 	logrus.Infof("    Key Validation Interval: %d minutes", settings.KeyValidationIntervalMinutes)
 	logrus.Info("====================================")
 	logrus.Info("")

--- a/internal/config/system_settings.go
+++ b/internal/config/system_settings.go
@@ -22,6 +22,7 @@ import (
 )
 
 const SettingsUpdateChannel = "system_settings:updated"
+const GroupScopedSettingKeyFailoverStatusCodes = "failover_status_codes"
 
 // SystemSettingsManager 管理系统配置
 type SystemSettingsManager struct {
@@ -31,6 +32,24 @@ type SystemSettingsManager struct {
 // NewSystemSettingsManager creates a new, uninitialized SystemSettingsManager.
 func NewSystemSettingsManager() *SystemSettingsManager {
 	return &SystemSettingsManager{}
+}
+
+func sanitizeRuntimeSystemSettings(settings types.SystemSettings) types.SystemSettings {
+	settings.FailoverStatusCodes = ""
+	return settings
+}
+
+func IsSystemSettingVisible(key string) bool {
+	return key != GroupScopedSettingKeyFailoverStatusCodes
+}
+
+func ValidateSystemSettingsPayload(settingsMap map[string]any) error {
+	for key := range settingsMap {
+		if !IsSystemSettingVisible(key) {
+			return fmt.Errorf("setting key %s is only supported in group settings", key)
+		}
+	}
+	return nil
 }
 
 type groupManager interface {
@@ -75,6 +94,7 @@ func (sm *SystemSettingsManager) Initialize(store store.Store, gm groupManager, 
 		}
 
 		settings.ProxyKeysMap = utils.StringToSet(settings.ProxyKeys, ",")
+		settings = sanitizeRuntimeSystemSettings(settings)
 
 		sm.DisplaySystemConfig(settings)
 
@@ -116,6 +136,10 @@ func (sm *SystemSettingsManager) EnsureSettingsInitialized(authConfig types.Auth
 	metadata := utils.GenerateSettingsMetadata(&defaultSettings)
 
 	for _, meta := range metadata {
+		if !IsSystemSettingVisible(meta.Key) {
+			continue
+		}
+
 		var existing models.SystemSetting
 		err := db.DB.Where("setting_key = ?", meta.Key).First(&existing).Error
 		if err != nil {
@@ -156,9 +180,9 @@ func (sm *SystemSettingsManager) EnsureSettingsInitialized(authConfig types.Auth
 func (sm *SystemSettingsManager) GetSettings() types.SystemSettings {
 	if sm.syncer == nil {
 		logrus.Warn("SystemSettingsManager is not initialized, returning default settings.")
-		return utils.DefaultSystemSettings()
+		return sanitizeRuntimeSystemSettings(utils.DefaultSystemSettings())
 	}
-	return sm.syncer.Get()
+	return sanitizeRuntimeSystemSettings(sm.syncer.Get())
 }
 
 // GetAppUrl returns the effective App URL.
@@ -181,6 +205,10 @@ func (sm *SystemSettingsManager) GetAppUrl() string {
 
 // UpdateSettings 更新系统配置
 func (sm *SystemSettingsManager) UpdateSettings(settingsMap map[string]any) error {
+	if err := ValidateSystemSettingsPayload(settingsMap); err != nil {
+		return err
+	}
+
 	// 验证配置项
 	if err := sm.ValidateSettings(settingsMap); err != nil {
 		return err
@@ -310,7 +338,7 @@ func (sm *SystemSettingsManager) ValidateSettings(settingsMap map[string]any) er
 			}
 			if key == "failover_status_codes" {
 				if _, err := failover.ParseStatusCodeMatcher(strVal); err != nil {
-					return err
+					return fmt.Errorf("invalid value for %s (%q): %w", key, strVal, err)
 				}
 			}
 		default:
@@ -385,7 +413,7 @@ func (sm *SystemSettingsManager) ValidateGroupConfigOverrides(configMap map[stri
 			}
 			if key == "failover_status_codes" {
 				if _, err := failover.ParseStatusCodeMatcher(strVal); err != nil {
-					return err
+					return fmt.Errorf("invalid value for %s (%q): %w", key, strVal, err)
 				}
 			}
 		case reflect.Bool:
@@ -421,7 +449,6 @@ func (sm *SystemSettingsManager) DisplaySystemConfig(settings types.SystemSettin
 	logrus.Info("  --- Key & Group Behavior ---")
 	logrus.Infof("    Max Retries: %d", settings.MaxRetries)
 	logrus.Infof("    Blacklist Threshold: %d", settings.BlacklistThreshold)
-	logrus.Infof("    Extra Failover Status Codes: %s", settings.FailoverStatusCodes)
 	logrus.Infof("    Key Validation Interval: %d minutes", settings.KeyValidationIntervalMinutes)
 	logrus.Info("====================================")
 	logrus.Info("")

--- a/internal/config/system_settings_test.go
+++ b/internal/config/system_settings_test.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"gpt-load/internal/types"
+)
+
+func TestSanitizeRuntimeSystemSettings_ClearsSystemFailoverStatusCodes(t *testing.T) {
+	settings := types.SystemSettings{
+		ProxyKeys:           "test-key",
+		FailoverStatusCodes: "404,250-260",
+	}
+
+	sanitized := sanitizeRuntimeSystemSettings(settings)
+
+	if sanitized.FailoverStatusCodes != "" {
+		t.Fatalf("expected system failover status codes to be cleared, got %q", sanitized.FailoverStatusCodes)
+	}
+	if sanitized.ProxyKeys != settings.ProxyKeys {
+		t.Fatalf("expected unrelated fields to remain unchanged")
+	}
+}
+
+func TestValidateSystemSettingsPayload_RejectsGroupScopedSetting(t *testing.T) {
+	err := ValidateSystemSettingsPayload(map[string]any{
+		GroupScopedSettingKeyFailoverStatusCodes: "404",
+	})
+	if err == nil {
+		t.Fatalf("expected validation error")
+	}
+	if !strings.Contains(err.Error(), GroupScopedSettingKeyFailoverStatusCodes) {
+		t.Fatalf("expected error to mention rejected key, got %v", err)
+	}
+}
+
+func TestValidateGroupConfigOverrides_FailoverStatusCodesErrorIncludesContext(t *testing.T) {
+	sm := NewSystemSettingsManager()
+
+	err := sm.ValidateGroupConfigOverrides(map[string]any{
+		GroupScopedSettingKeyFailoverStatusCodes: "404,abc",
+	})
+	if err == nil {
+		t.Fatalf("expected validation error")
+	}
+
+	errText := err.Error()
+	if !strings.Contains(errText, GroupScopedSettingKeyFailoverStatusCodes) {
+		t.Fatalf("expected error to include setting key, got %q", errText)
+	}
+	if !strings.Contains(errText, "404,abc") {
+		t.Fatalf("expected error to include original value, got %q", errText)
+	}
+}

--- a/internal/failover/status_code_matcher.go
+++ b/internal/failover/status_code_matcher.go
@@ -1,0 +1,142 @@
+package failover
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// StatusCodeRange represents an inclusive HTTP status code interval [Start, End].
+type StatusCodeRange struct {
+	Start int
+	End   int
+}
+
+// StatusCodeMatcher matches status codes against a compact, merged set of ranges.
+// The zero value matches nothing.
+type StatusCodeMatcher struct {
+	ranges []StatusCodeRange
+}
+
+// Match returns true if code is within any configured range.
+func (m StatusCodeMatcher) Match(code int) bool {
+	if len(m.ranges) == 0 {
+		return false
+	}
+
+	// Find first range whose Start is greater than code, then check previous one.
+	i := sort.Search(len(m.ranges), func(i int) bool {
+		return m.ranges[i].Start > code
+	})
+	if i == 0 {
+		return false
+	}
+	r := m.ranges[i-1]
+	return code >= r.Start && code <= r.End
+}
+
+// IsEmpty reports whether the matcher has no ranges configured.
+func (m StatusCodeMatcher) IsEmpty() bool {
+	return len(m.ranges) == 0
+}
+
+// ParseStatusCodeMatcher parses a comma-separated status code specification into a matcher.
+//
+// Spec grammar:
+//   - Single code: "404"
+//   - Inclusive range: "250-260"
+//   - Multiple entries separated by commas: "404,429,500-599"
+//
+// Whitespace around tokens and around "-" is allowed.
+// Empty tokens are ignored.
+func ParseStatusCodeMatcher(spec string) (StatusCodeMatcher, error) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return StatusCodeMatcher{}, nil
+	}
+
+	// Allow users to paste multi-line values (treat newline as comma).
+	spec = strings.ReplaceAll(spec, "\n", ",")
+
+	tokens := strings.Split(spec, ",")
+	parsed := make([]StatusCodeRange, 0, len(tokens))
+
+	for _, raw := range tokens {
+		token := strings.TrimSpace(raw)
+		if token == "" {
+			continue
+		}
+
+		if strings.Contains(token, "-") {
+			parts := strings.Split(token, "-")
+			if len(parts) != 2 {
+				return StatusCodeMatcher{}, fmt.Errorf("invalid status code range: %q", token)
+			}
+			startStr := strings.TrimSpace(parts[0])
+			endStr := strings.TrimSpace(parts[1])
+			if startStr == "" || endStr == "" {
+				return StatusCodeMatcher{}, fmt.Errorf("invalid status code range: %q", token)
+			}
+
+			start, err := strconv.Atoi(startStr)
+			if err != nil {
+				return StatusCodeMatcher{}, fmt.Errorf("invalid status code in range %q: %v", token, err)
+			}
+			end, err := strconv.Atoi(endStr)
+			if err != nil {
+				return StatusCodeMatcher{}, fmt.Errorf("invalid status code in range %q: %v", token, err)
+			}
+			if start > end {
+				return StatusCodeMatcher{}, fmt.Errorf("invalid status code range (start > end): %q", token)
+			}
+			if !isValidStatusCode(start) || !isValidStatusCode(end) {
+				return StatusCodeMatcher{}, fmt.Errorf("status code out of allowed range (100-999): %q", token)
+			}
+
+			parsed = append(parsed, StatusCodeRange{Start: start, End: end})
+			continue
+		}
+
+		code, err := strconv.Atoi(token)
+		if err != nil {
+			return StatusCodeMatcher{}, fmt.Errorf("invalid status code: %q", token)
+		}
+		if !isValidStatusCode(code) {
+			return StatusCodeMatcher{}, fmt.Errorf("status code out of allowed range (100-999): %q", token)
+		}
+		parsed = append(parsed, StatusCodeRange{Start: code, End: code})
+	}
+
+	if len(parsed) == 0 {
+		return StatusCodeMatcher{}, nil
+	}
+
+	sort.Slice(parsed, func(i, j int) bool {
+		if parsed[i].Start != parsed[j].Start {
+			return parsed[i].Start < parsed[j].Start
+		}
+		return parsed[i].End < parsed[j].End
+	})
+
+	merged := make([]StatusCodeRange, 0, len(parsed))
+	current := parsed[0]
+	for _, r := range parsed[1:] {
+		// Merge overlapping or adjacent ranges.
+		if r.Start <= current.End+1 {
+			if r.End > current.End {
+				current.End = r.End
+			}
+			continue
+		}
+		merged = append(merged, current)
+		current = r
+	}
+	merged = append(merged, current)
+
+	return StatusCodeMatcher{ranges: merged}, nil
+}
+
+func isValidStatusCode(code int) bool {
+	return code >= 100 && code <= 999
+}

--- a/internal/failover/status_code_matcher_test.go
+++ b/internal/failover/status_code_matcher_test.go
@@ -1,0 +1,91 @@
+package failover
+
+import "testing"
+
+func TestParseStatusCodeMatcher_Empty(t *testing.T) {
+	m, err := ParseStatusCodeMatcher("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !m.IsEmpty() {
+		t.Fatalf("expected empty matcher")
+	}
+	if m.Match(404) {
+		t.Fatalf("empty matcher should not match")
+	}
+}
+
+func TestParseStatusCodeMatcher_SingleCode(t *testing.T) {
+	m, err := ParseStatusCodeMatcher("404")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !m.Match(404) {
+		t.Fatalf("expected to match 404")
+	}
+	if m.Match(403) {
+		t.Fatalf("did not expect to match 403")
+	}
+}
+
+func TestParseStatusCodeMatcher_Range(t *testing.T) {
+	m, err := ParseStatusCodeMatcher("250-260")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, code := range []int{250, 255, 260} {
+		if !m.Match(code) {
+			t.Fatalf("expected to match %d", code)
+		}
+	}
+	for _, code := range []int{249, 261} {
+		if m.Match(code) {
+			t.Fatalf("did not expect to match %d", code)
+		}
+	}
+}
+
+func TestParseStatusCodeMatcher_MergeAdjacent(t *testing.T) {
+	m, err := ParseStatusCodeMatcher("250-260,261")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, code := range []int{250, 260, 261} {
+		if !m.Match(code) {
+			t.Fatalf("expected to match %d", code)
+		}
+	}
+	if m.Match(262) {
+		t.Fatalf("did not expect to match 262")
+	}
+}
+
+func TestParseStatusCodeMatcher_MergeOverlappingAndWhitespace(t *testing.T) {
+	m, err := ParseStatusCodeMatcher(" 404 , 500-550 , 540-599 ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !m.Match(404) || !m.Match(500) || !m.Match(575) || !m.Match(599) {
+		t.Fatalf("expected matches for configured codes")
+	}
+	if m.Match(400) || m.Match(600) {
+		t.Fatalf("did not expect matches outside configured codes")
+	}
+}
+
+func TestParseStatusCodeMatcher_InvalidSpecs(t *testing.T) {
+	cases := []string{
+		"abc",
+		"99",
+		"1000",
+		"250-",
+		"-260",
+		"260-250",
+		"250-260-270",
+	}
+	for _, c := range cases {
+		if _, err := ParseStatusCodeMatcher(c); err == nil {
+			t.Fatalf("expected error for %q", c)
+		}
+	}
+}

--- a/internal/handler/settings_handler.go
+++ b/internal/handler/settings_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"gpt-load/internal/config"
 	app_errors "gpt-load/internal/errors"
 	"gpt-load/internal/i18n"
 	"gpt-load/internal/models"
@@ -17,6 +18,13 @@ import (
 func (s *Server) GetSettings(c *gin.Context) {
 	currentSettings := s.SettingsManager.GetSettings()
 	settingsInfo := utils.GenerateSettingsMetadata(&currentSettings)
+	visibleSettings := make([]models.SystemSettingInfo, 0, len(settingsInfo))
+	for _, setting := range settingsInfo {
+		if config.IsSystemSettingVisible(setting.Key) {
+			visibleSettings = append(visibleSettings, setting)
+		}
+	}
+	settingsInfo = visibleSettings
 
 	// Translate settings info
 	for i := range settingsInfo {
@@ -66,6 +74,11 @@ func (s *Server) UpdateSettings(c *gin.Context) {
 
 	if len(settingsMap) == 0 {
 		response.Success(c, nil)
+		return
+	}
+
+	if err := config.ValidateSystemSettingsPayload(settingsMap); err != nil {
+		response.Error(c, app_errors.NewAPIError(app_errors.ErrValidation, err.Error()))
 		return
 	}
 

--- a/internal/i18n/locales/en-US.go
+++ b/internal/i18n/locales/en-US.go
@@ -159,6 +159,8 @@ var MessagesEnUS = map[string]string{
 	"config.max_retries_desc":                "Maximum number of retries for a single request using different keys, 0 for no retries.",
 	"config.blacklist_threshold":             "Blacklist Threshold",
 	"config.blacklist_threshold_desc":        "Number of consecutive failures before a key is blacklisted, 0 to disable blacklisting.",
+	"config.failover_status_codes":           "Extra Failover Status Codes",
+	"config.failover_status_codes_desc":      "Additional upstream HTTP status codes that will trigger failover (retry). Supports comma-separated values and ranges, e.g.: 404,429,250-260. Empty means default policy only.",
 	"config.key_validation_interval":         "Key Validation Interval (minutes)",
 	"config.key_validation_interval_desc":    "Default interval (minutes) for background key validation.",
 	"config.key_validation_concurrency":      "Key Validation Concurrency",

--- a/internal/i18n/locales/ja-JP.go
+++ b/internal/i18n/locales/ja-JP.go
@@ -159,6 +159,8 @@ var MessagesJaJP = map[string]string{
 	"config.max_retries_desc":                "異なるキーを使用した単一リクエストの最大リトライ数、0でリトライなし。",
 	"config.blacklist_threshold":             "ブラックリストしきい値",
 	"config.blacklist_threshold_desc":        "キーがブラックリストに入るまでの連続失敗回数、0でブラックリスト無効。",
+	"config.failover_status_codes":           "追加フェイルオーバーステータスコード",
+	"config.failover_status_codes_desc":      "フェイルオーバー（リトライ）を追加でトリガーする上流 HTTP ステータスコード。カンマ区切りと範囲指定に対応（例：404,429,250-260）。空の場合はデフォルトポリシーのみ。",
 	"config.key_validation_interval":         "キー検証間隔（分）",
 	"config.key_validation_interval_desc":    "バックグラウンドキー検証のデフォルト間隔（分）。",
 	"config.key_validation_concurrency":      "キー検証並行数",

--- a/internal/i18n/locales/zh-CN.go
+++ b/internal/i18n/locales/zh-CN.go
@@ -159,6 +159,8 @@ var MessagesZhCN = map[string]string{
 	"config.max_retries_desc":                "单个请求使用不同 Key 的最大重试次数，0为不重试。",
 	"config.blacklist_threshold":             "黑名单阈值",
 	"config.blacklist_threshold_desc":        "一个 Key 连续失败多少次后进入黑名单，0为不拉黑。",
+	"config.failover_status_codes":           "故障转移状态码（增量）",
+	"config.failover_status_codes_desc":      "额外触发故障转移（重试）的上游 HTTP 状态码列表，支持逗号分隔和范围，例如：404,429,250-260。为空表示仅使用默认策略。",
 	"config.key_validation_interval":         "密钥验证间隔（分钟）",
 	"config.key_validation_interval_desc":    "后台验证密钥的默认间隔（分钟）。",
 	"config.key_validation_concurrency":      "密钥验证并发数",

--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"gpt-load/internal/failover"
 	"gpt-load/internal/types"
 	"time"
 
@@ -34,6 +35,7 @@ type GroupConfig struct {
 	ProxyURL                     *string `json:"proxy_url,omitempty"`
 	MaxRetries                   *int    `json:"max_retries,omitempty"`
 	BlacklistThreshold           *int    `json:"blacklist_threshold,omitempty"`
+	FailoverStatusCodes          *string `json:"failover_status_codes,omitempty"`
 	KeyValidationIntervalMinutes *int    `json:"key_validation_interval_minutes,omitempty"`
 	KeyValidationConcurrency     *int    `json:"key_validation_concurrency,omitempty"`
 	KeyValidationTimeoutSeconds  *int    `json:"key_validation_timeout_seconds,omitempty"`
@@ -104,9 +106,10 @@ type Group struct {
 	UpdatedAt           time.Time            `json:"updated_at"`
 
 	// For cache
-	ProxyKeysMap     map[string]struct{} `gorm:"-" json:"-"`
-	HeaderRuleList   []HeaderRule        `gorm:"-" json:"-"`
-	ModelRedirectMap map[string]string   `gorm:"-" json:"-"`
+	ProxyKeysMap              map[string]struct{}        `gorm:"-" json:"-"`
+	HeaderRuleList            []HeaderRule               `gorm:"-" json:"-"`
+	ModelRedirectMap          map[string]string          `gorm:"-" json:"-"`
+	FailoverStatusCodeMatcher failover.StatusCodeMatcher `gorm:"-" json:"-"`
 }
 
 // APIKey 对应 api_keys 表

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -200,8 +200,11 @@ func (ps *ProxyServer) executeRequestWithRetry(
 		defer resp.Body.Close()
 	}
 
-	// Unified error handling for retries. Exclude 404 from being a retryable error.
-	if err != nil || (resp != nil && resp.StatusCode >= 400 && resp.StatusCode != http.StatusNotFound) {
+	// Unified error handling for retries.
+	// Default policy: retry any status >= 400 except 404.
+	// Group policy (incremental): additional status codes also trigger retry/failover.
+	shouldRetryByStatus := resp != nil && shouldFailoverOnStatusCode(resp.StatusCode, group)
+	if err != nil || shouldRetryByStatus {
 		if err != nil && app_errors.IsIgnorableError(err) {
 			logrus.Debugf("Client-side ignorable error for key %s, aborting retries: %v", utils.MaskAPIKey(apiKey.KeyValue), err)
 			ps.logRequest(c, originalGroup, group, apiKey, startTime, 499, err, isStream, upstreamURL, channelHandler, bodyBytes, models.RequestTypeFinal)
@@ -218,7 +221,7 @@ func (ps *ProxyServer) executeRequestWithRetry(
 			parsedError = errorMessage
 			logrus.Debugf("Request failed (attempt %d/%d) for key %s: %v", retryCount+1, cfg.MaxRetries, utils.MaskAPIKey(apiKey.KeyValue), err)
 		} else {
-			// HTTP-level error (status >= 400)
+			// Retryable upstream response (HTTP status code matched failover policy)
 			statusCode = resp.StatusCode
 			errorBody, readErr := io.ReadAll(resp.Body)
 			if readErr != nil {
@@ -281,6 +284,18 @@ func (ps *ProxyServer) executeRequestWithRetry(
 	}
 
 	ps.logRequest(c, originalGroup, group, apiKey, startTime, resp.StatusCode, nil, isStream, upstreamURL, channelHandler, bodyBytes, models.RequestTypeFinal)
+}
+
+func shouldFailoverOnStatusCode(statusCode int, group *models.Group) bool {
+	// Default behavior: treat 404 as non-retryable to avoid wasting retries.
+	// Group-specific additional rules are additive (OR) and can re-include 404 if desired.
+	if statusCode >= 400 && statusCode != http.StatusNotFound {
+		return true
+	}
+	if group == nil {
+		return false
+	}
+	return group.FailoverStatusCodeMatcher.Match(statusCode)
 }
 
 // logRequest is a helper function to create and record a request log.

--- a/internal/services/group_manager.go
+++ b/internal/services/group_manager.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"gpt-load/internal/config"
+	"gpt-load/internal/failover"
 	"gpt-load/internal/models"
 	"gpt-load/internal/store"
 	"gpt-load/internal/syncer"
@@ -72,6 +73,17 @@ func (gm *GroupManager) Initialize() error {
 			g.EffectiveConfig = gm.settingsManager.GetEffectiveConfig(g.Config)
 			g.ProxyKeysMap = utils.StringToSet(g.ProxyKeys, ",")
 
+			matcher, err := failover.ParseStatusCodeMatcher(g.EffectiveConfig.FailoverStatusCodes)
+			if err != nil {
+				logrus.WithFields(logrus.Fields{
+					"group_name": g.Name,
+					"spec":       g.EffectiveConfig.FailoverStatusCodes,
+					"error":      err,
+				}).Warn("Invalid failover status codes spec, ignoring")
+			} else {
+				g.FailoverStatusCodeMatcher = matcher
+			}
+
 			// Parse header rules with error handling
 			if len(group.HeaderRules) > 0 {
 				if err := json.Unmarshal(group.HeaderRules, &g.HeaderRuleList); err != nil {
@@ -119,12 +131,12 @@ func (gm *GroupManager) Initialize() error {
 
 			groupMap[g.Name] = &g
 			logrus.WithFields(logrus.Fields{
-				"group_name":               g.Name,
-				"effective_config":         g.EffectiveConfig,
-				"header_rules_count":       len(g.HeaderRuleList),
+				"group_name":                 g.Name,
+				"effective_config":           g.EffectiveConfig,
+				"header_rules_count":         len(g.HeaderRuleList),
 				"model_redirect_rules_count": len(g.ModelRedirectMap),
-				"model_redirect_strict":    g.ModelRedirectStrict,
-				"sub_group_count":          len(g.SubGroups),
+				"model_redirect_strict":      g.ModelRedirectStrict,
+				"sub_group_count":            len(g.SubGroups),
 			}).Debug("Loaded group with effective config")
 		}
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -35,11 +35,12 @@ type SystemSettings struct {
 	ProxyURL              string `json:"proxy_url" name:"config.proxy_url" category:"config.category.request" desc:"config.proxy_url_desc"`
 
 	// 密钥配置
-	MaxRetries                   int `json:"max_retries" default:"3" name:"config.max_retries" category:"config.category.key" desc:"config.max_retries_desc" validate:"required,min=0"`
-	BlacklistThreshold           int `json:"blacklist_threshold" default:"3" name:"config.blacklist_threshold" category:"config.category.key" desc:"config.blacklist_threshold_desc" validate:"required,min=0"`
-	KeyValidationIntervalMinutes int `json:"key_validation_interval_minutes" default:"60" name:"config.key_validation_interval" category:"config.category.key" desc:"config.key_validation_interval_desc" validate:"required,min=1"`
-	KeyValidationConcurrency     int `json:"key_validation_concurrency" default:"10" name:"config.key_validation_concurrency" category:"config.category.key" desc:"config.key_validation_concurrency_desc" validate:"required,min=1"`
-	KeyValidationTimeoutSeconds  int `json:"key_validation_timeout_seconds" default:"20" name:"config.key_validation_timeout" category:"config.category.key" desc:"config.key_validation_timeout_desc" validate:"required,min=1"`
+	MaxRetries                   int    `json:"max_retries" default:"3" name:"config.max_retries" category:"config.category.key" desc:"config.max_retries_desc" validate:"required,min=0"`
+	BlacklistThreshold           int    `json:"blacklist_threshold" default:"3" name:"config.blacklist_threshold" category:"config.category.key" desc:"config.blacklist_threshold_desc" validate:"required,min=0"`
+	FailoverStatusCodes          string `json:"failover_status_codes" name:"config.failover_status_codes" category:"config.category.key" desc:"config.failover_status_codes_desc"`
+	KeyValidationIntervalMinutes int    `json:"key_validation_interval_minutes" default:"60" name:"config.key_validation_interval" category:"config.category.key" desc:"config.key_validation_interval_desc" validate:"required,min=1"`
+	KeyValidationConcurrency     int    `json:"key_validation_concurrency" default:"10" name:"config.key_validation_concurrency" category:"config.category.key" desc:"config.key_validation_concurrency_desc" validate:"required,min=1"`
+	KeyValidationTimeoutSeconds  int    `json:"key_validation_timeout_seconds" default:"20" name:"config.key_validation_timeout" category:"config.category.key" desc:"config.key_validation_timeout_desc" validate:"required,min=1"`
 
 	// For cache
 	ProxyKeysMap map[string]struct{} `json:"-"`


### PR DESCRIPTION
### 关联 Issue / Related Issue

Closes #394

### 变更内容 / Change Content

- [ ] Bug 修复 / Bug fix
- [x] 新功能 / New feature
- [ ] 其他改动 / Other changes

- 新增分组级配置 `failover_status_codes`，支持：
  - 多值：`404,429`
  - 范围：`250-260`
  - 混合：`404,429,250-260`
- 保留原有全局故障转移策略，并支持在分组维度追加状态码规则；任一规则命中时即可触发故障转移。
- 系统设置页不再暴露 `failover_status_codes`，后端也不允许通过系统设置接口更新该字段，避免与分组级配置产生歧义。
- 未配置分组 `failover_status_codes` 时，保持原有行为不变。
- 优化分组状态码配置校验：输入非法值时返回更明确的错误信息，便于定位问题。
- 补充相关单元测试与配置校验测试。

### 自查清单 / Checklist
- [x] 我已在本地测试过我的变更。 / I have tested my changes locally.
- [ ] 我已更新了必要的文档。 / I have updated the necessary documentation.

补充测试说明：
- `go test -count=1 ./internal/...` 通过。
- `npm ci && npm run build` 通过。
- `go test -count=1 ./...` 通过。
- 本地二进制部署连续运行超过 3 天，未发现异常。