### PR TITLE
feat: Add key rotation interval configuration

### DIFF
--- a/internal/i18n/locales/en-US.go
+++ b/internal/i18n/locales/en-US.go
@@ -171,6 +171,8 @@ var MessagesEnUS = map[string]string{
 	"config.key_validation_concurrency_desc": "Concurrency level for background invalid key validation. Keep below 20 for SQLite or low-performance environments to avoid data consistency issues.",
 	"config.key_validation_timeout":          "Key Validation Timeout (seconds)",
 	"config.key_validation_timeout_desc":     "API request timeout (seconds) when validating a single key in the background.",
+	"config.key_rotation_interval":           "Key Rotation Interval (minutes)",
+	"config.key_rotation_interval_desc":      "How many minutes to wait before rotating to the next key after a key is rotated. Set to 0 for per-request rotation (default behavior). This feature improves upstream cache hit rate and reduces costs.",
 
 	// Category labels
 	"config.category.basic":   "Basic",

--- a/internal/i18n/locales/ja-JP.go
+++ b/internal/i18n/locales/ja-JP.go
@@ -171,6 +171,8 @@ var MessagesJaJP = map[string]string{
 	"config.key_validation_concurrency_desc": "バックグラウンドで無効なキーを検証する際の並行数。SQLiteや低性能環境では20以下を維持し、データ不整合を回避してください。",
 	"config.key_validation_timeout":          "キー検証タイムアウト（秒）",
 	"config.key_validation_timeout_desc":     "バックグラウンドで単一キーを検証する際のAPIリクエストタイムアウト（秒）。",
+	"config.key_rotation_interval":           "キー切り替え間隔（分）",
+	"config.key_rotation_interval_desc":      "キーが切り替えられた後、次のキーに切り替えるまでに待機する時間（分）。0に設定するとリクエストごとに切り替え（デフォルト動作）。この機能は上流キャッシュのヒット率を向上させ、コストを削減します。",
 
 	// Category labels
 	"config.category.basic":   "基本設定",

--- a/internal/i18n/locales/zh-CN.go
+++ b/internal/i18n/locales/zh-CN.go
@@ -171,6 +171,8 @@ var MessagesZhCN = map[string]string{
 	"config.key_validation_concurrency_desc": "后台定时验证无效 Key 时的并发数，如果使用SQLite或者运行环境性能不佳，请尽量保证20以下，避免过高的并发导致数据不一致问题。",
 	"config.key_validation_timeout":          "密钥验证超时（秒）",
 	"config.key_validation_timeout_desc":     "后台定时验证单个 Key 时的 API 请求超时时间（秒）。",
+	"config.key_rotation_interval":           "Key轮循间隔（分钟）",
+	"config.key_rotation_interval_desc":      "同一个Key在被轮循切换后，需等待多少分钟才会轮循到下一个Key。设置为0表示每次请求都轮循（默认行为）。此功能可提高上游缓存命中率，降低成本。",
 
 	// Category labels
 	"config.category.basic":   "基础参数",

--- a/internal/keypool/provider.go
+++ b/internal/keypool/provider.go
@@ -34,11 +34,50 @@ func NewProvider(db *gorm.DB, store store.Store, settingsManager *config.SystemS
 	}
 }
 
-// SelectKey 为指定的分组原子性地选择并轮换一个可用的 APIKey。
-func (p *KeyProvider) SelectKey(groupID uint) (*models.APIKey, error) {
+// SelectKey 为指定的分组选择一个可用的 APIKey。
+// 根据配置的轮循间隔时间决定是否需要轮循到新key。
+// rotationIntervalMinutes: 轮循间隔时间（分钟），0表示每次请求都轮循
+// forceRotate: 是否强制轮循（如key失败后的重试场景）
+func (p *KeyProvider) SelectKey(groupID uint, rotationIntervalMinutes int, forceRotate bool) (*models.APIKey, error) {
 	activeKeysListKey := fmt.Sprintf("group:%d:active_keys", groupID)
+	rotationTimeKey := fmt.Sprintf("group:%d:active_keys:rotation_time", groupID)
 
-	// 1. Atomically rotate the key ID from the list
+	// 如果配置了轮循间隔且不是强制轮循，尝试获取当前key
+	if rotationIntervalMinutes > 0 && !forceRotate {
+		currentKeyID, err := p.store.LIndex(activeKeysListKey, -1)
+		if err == nil && currentKeyID != "" {
+			// 获取最后轮循时间
+			timeBytes, timeErr := p.store.Get(rotationTimeKey)
+			var lastRotationTime int64
+			if timeErr == nil {
+				lastRotationTime, _ = strconv.ParseInt(string(timeBytes), 10, 64)
+			}
+
+			// 检查是否在轮循间隔内
+			now := time.Now().Unix()
+			intervalSeconds := int64(rotationIntervalMinutes * 60)
+
+			if now-lastRotationTime < intervalSeconds {
+				// 在间隔时间内，返回当前key（不轮循）
+				keyID, parseErr := strconv.ParseUint(currentKeyID, 10, 64)
+				if parseErr == nil {
+					apiKey, getErr := p.getKeyDetails(keyID, groupID)
+					if getErr == nil && apiKey.Status == models.KeyStatusActive {
+						logrus.WithFields(logrus.Fields{
+							"groupID":          groupID,
+							"keyID":            keyID,
+							"remainingSeconds": intervalSeconds - (now - lastRotationTime),
+						}).Debug("Using current key within rotation interval")
+						return apiKey, nil
+					}
+					// 当前key已失效，需要轮循
+					logrus.WithField("keyID", keyID).Debug("Current key is invalid, forcing rotation")
+				}
+			}
+		}
+	}
+
+	// 需要轮循：执行原子轮循操作
 	keyIDStr, err := p.store.Rotate(activeKeysListKey)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
@@ -52,14 +91,29 @@ func (p *KeyProvider) SelectKey(groupID uint) (*models.APIKey, error) {
 		return nil, fmt.Errorf("failed to parse key ID '%s': %w", keyIDStr, err)
 	}
 
-	// 2. Get key details from HASH
+	// 更新轮循时间戳（仅在配置了轮循间隔时）
+	if rotationIntervalMinutes > 0 {
+		now := time.Now().Unix()
+		if err := p.store.Set(rotationTimeKey, []byte(strconv.FormatInt(now, 10)), 0); err != nil {
+			logrus.WithFields(logrus.Fields{
+				"groupID": groupID,
+				"keyID":   keyID,
+				"error":   err,
+			}).Warn("Failed to update rotation timestamp")
+		}
+	}
+
+	return p.getKeyDetails(keyID, groupID)
+}
+
+// getKeyDetails 从HASH获取key详情并构建APIKey对象
+func (p *KeyProvider) getKeyDetails(keyID uint64, groupID uint) (*models.APIKey, error) {
 	keyHashKey := fmt.Sprintf("key:%d", keyID)
 	keyDetails, err := p.store.HGetAll(keyHashKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get key details for key ID %d: %w", keyID, err)
 	}
 
-	// 3. Manually unmarshal the map into an APIKey struct
 	failureCount, _ := strconv.ParseInt(keyDetails["failure_count"], 10, 64)
 	createdAt, _ := strconv.ParseInt(keyDetails["created_at"], 10, 64)
 
@@ -67,7 +121,6 @@ func (p *KeyProvider) SelectKey(groupID uint) (*models.APIKey, error) {
 	encryptedKeyValue := keyDetails["key_string"]
 	decryptedKeyValue, err := p.encryptionSvc.Decrypt(encryptedKeyValue)
 	if err != nil {
-		// If decryption fails, try to use the value as-is (backward compatibility for unencrypted keys)
 		logrus.WithFields(logrus.Fields{
 			"keyID": keyID,
 			"error": err,
@@ -195,6 +248,16 @@ func (p *KeyProvider) handleFailure(apiKey *models.APIKey, group *models.Group, 
 		return nil
 	}
 
+	// 标记需要立即轮循（将时间戳置为0）
+	// 这样下次请求时会触发轮循到下一个key
+	rotationTimeKey := activeKeysListKey + ":rotation_time"
+	if err := p.store.Set(rotationTimeKey, []byte("0"), 0); err != nil {
+		logrus.WithFields(logrus.Fields{
+			"groupID": group.ID,
+			"error":   err,
+		}).Warn("Failed to mark key for immediate rotation")
+	}
+
 	failureCount, _ := strconv.ParseInt(keyDetails["failure_count"], 10, 64)
 
 	// 获取该分组的有效配置
@@ -290,6 +353,12 @@ func (p *KeyProvider) LoadKeysFromDB() error {
 			p.store.Delete(activeKeysListKey)
 			if err := p.store.LPush(activeKeysListKey, activeIDs...); err != nil {
 				logrus.WithFields(logrus.Fields{"groupID": groupID, "error": err}).Error("Failed to LPush active keys for group")
+			}
+
+			// 初始化轮循时间戳为0，表示首次请求需要轮循
+			rotationTimeKey := activeKeysListKey + ":rotation_time"
+			if err := p.store.Set(rotationTimeKey, []byte("0"), 0); err != nil {
+				logrus.WithFields(logrus.Fields{"groupID": groupID, "error": err}).Warn("Failed to initialize rotation timestamp")
 			}
 		}
 	}

--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -38,6 +38,7 @@ type GroupConfig struct {
 	KeyValidationConcurrency     *int    `json:"key_validation_concurrency,omitempty"`
 	KeyValidationTimeoutSeconds  *int    `json:"key_validation_timeout_seconds,omitempty"`
 	EnableRequestBodyLogging     *bool   `json:"enable_request_body_logging,omitempty"`
+	KeyRotationIntervalMinutes   *int    `json:"key_rotation_interval_minutes,omitempty"`
 }
 
 // HeaderRule defines a single rule for header manipulation.

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -126,7 +126,12 @@ func (ps *ProxyServer) executeRequestWithRetry(
 ) {
 	cfg := group.EffectiveConfig
 
-	apiKey, err := ps.keyProvider.SelectKey(group.ID)
+	// 获取轮循间隔配置
+	rotationInterval := cfg.KeyRotationIntervalMinutes
+	// 重试时强制轮循（因为上一个key失败了）
+	forceRotate := retryCount > 0
+
+	apiKey, err := ps.keyProvider.SelectKey(group.ID, rotationInterval, forceRotate)
 	if err != nil {
 		logrus.Errorf("Failed to select a key for group %s on attempt %d: %v", group.Name, retryCount+1, err)
 		response.Error(c, app_errors.NewAPIError(app_errors.ErrNoKeysAvailable, err.Error()))

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -320,6 +320,39 @@ func (s *MemoryStore) LLen(key string) (int64, error) {
 	return int64(len(list)), nil
 }
 
+// LIndex returns the element at index in the list.
+// Index -1 returns the last element (current key in rotation context).
+func (s *MemoryStore) LIndex(key string, index int64) (string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	rawList, exists := s.data[key]
+	if !exists {
+		return "", ErrNotFound
+	}
+
+	list, ok := rawList.([]string)
+	if !ok {
+		return "", fmt.Errorf("type mismatch: key '%s' holds a different data type", key)
+	}
+
+	length := int64(len(list))
+	if length == 0 {
+		return "", ErrNotFound
+	}
+
+	// Handle negative index (like Redis: -1 is last, -2 is second last, etc.)
+	if index < 0 {
+		index = length + index
+	}
+
+	if index < 0 || index >= length {
+		return "", ErrNotFound
+	}
+
+	return list[index], nil
+}
+
 // --- SET operations ---
 
 // SAdd adds members to a set.

--- a/internal/store/redis.go
+++ b/internal/store/redis.go
@@ -127,6 +127,19 @@ func (s *RedisStore) LLen(key string) (int64, error) {
 	return s.client.LLen(context.Background(), s.prefixKey(key)).Result()
 }
 
+// LIndex returns the element at index in the list.
+// Index -1 returns the last element (current key in rotation context).
+func (s *RedisStore) LIndex(key string, index int64) (string, error) {
+	val, err := s.client.LIndex(context.Background(), s.prefixKey(key), index).Result()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return "", ErrNotFound
+		}
+		return "", err
+	}
+	return val, nil
+}
+
 // --- SET operations ---
 
 func (s *RedisStore) SAdd(key string, members ...any) error {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	LRem(key string, count int64, value any) error
 	Rotate(key string) (string, error)
 	LLen(key string) (int64, error)
+	LIndex(key string, index int64) (string, error)
 
 	// SET operations
 	SAdd(key string, members ...any) error

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -40,6 +40,7 @@ type SystemSettings struct {
 	KeyValidationIntervalMinutes int `json:"key_validation_interval_minutes" default:"60" name:"config.key_validation_interval" category:"config.category.key" desc:"config.key_validation_interval_desc" validate:"required,min=1"`
 	KeyValidationConcurrency     int `json:"key_validation_concurrency" default:"10" name:"config.key_validation_concurrency" category:"config.category.key" desc:"config.key_validation_concurrency_desc" validate:"required,min=1"`
 	KeyValidationTimeoutSeconds  int `json:"key_validation_timeout_seconds" default:"20" name:"config.key_validation_timeout" category:"config.category.key" desc:"config.key_validation_timeout_desc" validate:"required,min=1"`
+	KeyRotationIntervalMinutes   int `json:"key_rotation_interval_minutes" default:"0" name:"config.key_rotation_interval" category:"config.category.key" desc:"config.key_rotation_interval_desc" validate:"required,min=0"`
 
 	// For cache
 	ProxyKeysMap map[string]struct{} `json:"-"`


### PR DESCRIPTION
## Summary

Reimplement configurable key rotation interval from a clean upstream base to improve upstream cache hit rate and reduce cost.

- Add `KeyRotationIntervalMinutes` as a system setting with group-level override support
- `0` keeps the existing per-request rotation behavior
- `>0` pins a single key for the configured window and rotates only when the window expires or the key fails
- Retry after key failure forces immediate rotation to the next key

## Implementation

- Rework key selection around an explicit per-group `rotation_state` instead of inferring the current key from list position
- Add atomic store helper `SelectRotatingKey(listKey, stateKey, intervalSeconds, nowUnix, forceRotate)`
- Implement strict single-instance semantics in `MemoryStore` with a single lock around state check + rotation
- Implement Redis multi-instance consistency with a Lua script that atomically reuses or rotates the key window
- Use `RPush` for add/restore/import paths so new active keys do not interrupt the currently pinned key
- Clear rotation state when the pinned key is removed or blacklisted so the next request establishes a fresh window
- Add debug logging for key-selection decisions and display `Key Rotation Interval` in system settings output

## Configuration

- New system setting: `key_rotation_interval_minutes`
- New group override: `key_rotation_interval_minutes`
- i18n strings added for en-US, zh-CN, and ja-JP

## Test Plan

Automated:
- [x] `interval=0` preserves per-request round-robin behavior
- [x] `interval>0` reuses the same key within the configured window
- [x] window expiry rotates exactly once to the next key
- [x] `forceRotate=true` bypasses the interval and switches immediately
- [x] add/restore paths do not interrupt the currently pinned key
- [x] removing or failing the pinned key clears rotation state and selects the next active key
- [x] concurrent MemoryStore requests at the rotation boundary converge on a single new window key
- [x] group override applies `key_rotation_interval_minutes` correctly
- [x] Redis integration test is available behind `REDIS_TEST_DSN`

Validation:
- [x] `go test ./internal/...`
- [ ] `go test ./...` (currently blocked by upstream `web/dist` embed assets missing in the clean base)
