### PR TITLE
fix(security): 修复前端依赖 Dependabot 安全告警

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,6 +12,7 @@
         "@vicons/ionicons5": "^0.13.0",
         "@vueuse/core": "^13.6.0",
         "axios": "^1.13.5",
+        "form-data": "^4.0.6",
         "naive-ui": "^2.41.0",
         "vue": "^3.5.13",
         "vue-i18n": "^9.14.5",
@@ -31,7 +32,7 @@
         "eslint-plugin-vue": "^9.0.0",
         "prettier": "^3.6.2",
         "typescript": "~5.8.3",
-        "vite": "^6.4.1",
+        "vite": "^6.4.3",
         "vue-tsc": "^2.2.8"
       }
     },
@@ -2788,16 +2789,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -2940,9 +2941,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3895,9 +3896,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -34,6 +34,7 @@
     "@vicons/ionicons5": "^0.13.0",
     "@vueuse/core": "^13.6.0",
     "axios": "^1.13.5",
+    "form-data": "^4.0.6",
     "naive-ui": "^2.41.0",
     "vue": "^3.5.13",
     "vue-i18n": "^9.14.5",
@@ -53,7 +54,7 @@
     "eslint-plugin-vue": "^9.0.0",
     "prettier": "^3.6.2",
     "typescript": "~5.8.3",
-    "vite": "^6.4.1",
+    "vite": "^6.4.3",
     "vue-tsc": "^2.2.8"
   }
 }


### PR DESCRIPTION
## Summary
- 升级 `form-data` 4.0.5 → 4.0.6，修复 multipart 字段名/文件名未转义导致的 CRLF 注入（GHSA-hmw2-7cc7-3qxx）
- 升级 `vite` 6.4.2 → 6.4.3，修复 Windows 下 `server.fs.deny` 绕过（GHSA-fx2h-pf6j-xcff）与 launch-editor NTLMv2 哈希泄露（GHSA-v6wh-96g9-6wx3）
- 三处均升级到官方标注的 first patched version，`npm ls` 确认依赖树内无重复的旧版本残留

## Test plan
- [x] `npm run build`（`vue-tsc -b && vite build`）通过
- [x] `npm run lint:check` 无报错
- [x] `npm run type-check` 无报错
- [x] `npm ls form-data vite hasown mime-types` 确认全树已去重到修复版本