### PR TITLE
fix(security): 脱敏传输层错误中泄露的上游密钥

### DIFF
--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -234,6 +234,11 @@ func (ps *ProxyServer) executeRequestWithRetry(
 			logrus.Debugf("Request failed with status %d (attempt %d/%d) for key %s. Parsed Error: %s", statusCode, retryCount+1, cfg.MaxRetries, utils.MaskAPIKey(apiKey.KeyValue), parsedError)
 		}
 
+		// 上游 key 可能出现在错误文本中（如 Gemini 通道将 key 放入 URL query，
+		// 传输层错误会把完整 URL 带入 err.Error()），返回客户端和落库前先脱敏
+		errorMessage = utils.RedactSecret(errorMessage, apiKey.KeyValue)
+		parsedError = utils.RedactSecret(parsedError, apiKey.KeyValue)
+
 		// 使用解析后的错误信息更新密钥状态
 		ps.keyProvider.UpdateStatus(apiKey, group, false, parsedError)
 

--- a/internal/utils/string_utils.go
+++ b/internal/utils/string_utils.go
@@ -14,6 +14,14 @@ func MaskAPIKey(key string) string {
 	return fmt.Sprintf("%s****%s", key[:4], key[length-4:])
 }
 
+// RedactSecret replaces every occurrence of secret in text with its masked form.
+func RedactSecret(text, secret string) string {
+	if secret == "" {
+		return text
+	}
+	return strings.ReplaceAll(text, secret, MaskAPIKey(secret))
+}
+
 // TruncateString shortens a string to a maximum length.
 func TruncateString(s string, maxLength int) string {
 	if len(s) > maxLength {

--- a/internal/utils/string_utils_test.go
+++ b/internal/utils/string_utils_test.go
@@ -1,0 +1,63 @@
+package utils
+
+import "testing"
+
+// TestRedactSecret asserts that every occurrence of a known secret inside an
+// arbitrary text is replaced with its masked form. Regression test for the
+// Gemini-channel upstream key leak via unmasked transport errors (CWE-200).
+func TestRedactSecret(t *testing.T) {
+	secret := "sk-secret-upstream-key-1234"
+	text := `Post "http://upstream/v1beta/models/gemini-pro:generateContent?key=sk-secret-upstream-key-1234": context deadline exceeded`
+
+	got := RedactSecret(text, secret)
+
+	if got == text {
+		t.Fatalf("RedactSecret did not modify the text: %q", got)
+	}
+	for i := 0; i+len(secret) <= len(got); i++ {
+		if got[i:i+len(secret)] == secret {
+			t.Fatalf("raw secret still present in redacted text: %q", got)
+		}
+	}
+	want := `Post "http://upstream/v1beta/models/gemini-pro:generateContent?key=sk-s****1234": context deadline exceeded`
+	if got != want {
+		t.Errorf("RedactSecret() = %q, want %q", got, want)
+	}
+}
+
+// TestRedactSecretMultipleOccurrences asserts all occurrences are redacted, not just the first.
+func TestRedactSecretMultipleOccurrences(t *testing.T) {
+	secret := "sk-secret-upstream-key-1234"
+	text := secret + " appears twice: " + secret
+
+	got := RedactSecret(text, secret)
+
+	masked := MaskAPIKey(secret)
+	want := masked + " appears twice: " + masked
+	if got != want {
+		t.Errorf("RedactSecret() = %q, want %q", got, want)
+	}
+}
+
+// TestRedactSecretEmptySecret asserts an empty secret leaves the text untouched
+// (guards against strings.ReplaceAll's pathological behavior on an empty old value).
+func TestRedactSecretEmptySecret(t *testing.T) {
+	text := "some upstream error with no secret"
+
+	got := RedactSecret(text, "")
+
+	if got != text {
+		t.Errorf("RedactSecret() with empty secret = %q, want unchanged %q", got, text)
+	}
+}
+
+// TestRedactSecretNotPresent asserts text without the secret is returned unchanged.
+func TestRedactSecretNotPresent(t *testing.T) {
+	text := "connection refused"
+
+	got := RedactSecret(text, "sk-secret-upstream-key-1234")
+
+	if got != text {
+		t.Errorf("RedactSecret() = %q, want unchanged %q", got, text)
+	}
+}


### PR DESCRIPTION
## Summary

修复 GHSA-v6w2-mrg5-vc9r：Gemini 通道把上游 API key 放在 URL query（`?key=xxx`），当上游请求发生传输层错误（超时/连接失败/DNS）时，Go 的 `*url.Error` 字符串包含完整 URL（含明文 key），此前被原样返回给客户端并写入请求日志，任何持有该分组 proxy key 的普通消费者都能拿到运营者的上游 provider key。

- 新增 `utils.RedactSecret(text, secret)`：把 text 中出现的 secret 子串替换为已有的 `MaskAPIKey` 脱敏形式
- 在 `internal/proxy/server.go` 的 `errorMessage`/`parsedError` 计算完成、被用于返回客户端/写日志/更新 key 状态之前，统一调用 `RedactSecret` 剔除 `apiKey.KeyValue`
- 对所有渠道统一生效（不只是 Gemini），成本相同但更稳妥；OpenAI/Anthropic 用 header 传 key 本就不受影响

## Test plan
- [x] TDD：新增 `internal/utils/string_utils_test.go`，覆盖多次出现替换、空 secret、secret 不存在三种场景，RED→GREEN 验证
- [x] `go build ./...` / `go vet ./...` / `go test ./...` 全部通过
- [x] 端到端真实验证：本地启动服务，创建 Gemini 分组 + 指向不可达上游触发真实传输层错误（`connection refused`），确认：
  - 返回给客户端的 `UPSTREAM_ERROR` 消息中 key 已脱敏为 `sk-t****7890`
  - 持久化到 `request_logs.error_message` 的内容同样已脱敏（注意日志记录里另有一个独立的 `key_value` 字段，那是管理员本就可见的"本次请求使用了哪个 key"审计字段，与本漏洞无关，不在修复范围内）