### PR TITLE
chore(deps): 同步 fasthttp 上游竞态修复 / Sync upstream fasthttp race fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gin-gonic/gin v1.12.0
 	github.com/glebarez/sqlite v1.11.0
 	github.com/joho/godotenv v1.5.1
-	github.com/klauspost/compress v1.19.1
+	github.com/klauspost/compress v1.19.2
 	github.com/maximhq/bifrost/core v1.7.11
 	github.com/nicksnyder/go-i18n/v2 v2.6.1
 	github.com/sirupsen/logrus v1.9.4
@@ -114,7 +114,7 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	github.com/valyala/fasthttp v1.71.0 // indirect
+	github.com/valyala/fasthttp v1.73.0 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.1 // indirect
@@ -132,6 +132,6 @@ require (
 )
 
 // Temporary stream lifecycle fix: https://github.com/valyala/fasthttp/pull/2353
-replace github.com/valyala/fasthttp => github.com/tbphp/fasthttp v1.71.1-0.20260811052014-9e2f0ae954f2
+replace github.com/valyala/fasthttp => github.com/tbphp/fasthttp v1.73.1-0.20260816013004-12d1764a6311
 
 replace github.com/router-for-me/CLIProxyAPI/v7/gptload-embedded => ./third_party/cpaembedded

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
-github.com/klauspost/compress v1.19.1 h1:VsB4HPswih7mmZ8WleSFQ75c/Ui1M4trX5oAsJnhSlk=
-github.com/klauspost/compress v1.19.1/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/klauspost/compress v1.19.2 h1:hMRETovs/pu/dVWN7zIT1PGG8t509MwT6bO7XSi26R8=
+github.com/klauspost/compress v1.19.2/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -232,8 +232,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/tbphp/fasthttp v1.71.1-0.20260811052014-9e2f0ae954f2 h1:8ZZjx71MK2GSIF1s3WGGNcaiv6sNlckYS7opxJ+PPwk=
-github.com/tbphp/fasthttp v1.71.1-0.20260811052014-9e2f0ae954f2/go.mod h1:z1sDUvOShhXq/C9mwH/fSm1Vb71tUJwmQdgkBrBNwnA=
+github.com/tbphp/fasthttp v1.73.1-0.20260816013004-12d1764a6311 h1:YRNMEXnt+DLD14UVRtuii6BaBkhD7jn8Q4/x768Bnp4=
+github.com/tbphp/fasthttp v1.73.1-0.20260816013004-12d1764a6311/go.mod h1:Av8ic1DRn/EaPql1f03OpyPnj/NR1GzcryOxVbWoQi0=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=


### PR DESCRIPTION
### 关联 Issue / Related Issue

Upstream PR: https://github.com/valyala/fasthttp/pull/2353

### 变更内容 / Change Content

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

将 GPT-Load 的 fasthttp 依赖基线从官方 `v1.71.0` 更新到 `v1.73.0`，并将临时 `replace` 同步到上游 PR 当前最新提交 `12d1764a6311`。这样 GPT-Load 与上游修复分支保持同一条实现线，不再继续维护单独的 v1.71 backport。

`go mod tidy` 同步将 `github.com/klauspost/compress` 从 `v1.19.1` 更新到 `v1.19.2`，这是新 fasthttp 模块图带来的依赖变化。

本次只调整 Go 模块依赖，不改变公共 API、配置或数据格式。该 Draft PR 用于运行包含 race 的远端 CI；上游修复合并并发布后，再将临时 `replace` 切回官方版本。

本地验证：

- `go test -count=1 ./internal/execution/bifrost ./internal/gateway`
- `make check`

### 自查清单 / Checklist

- [x] 我已在本地测试过我的变更。 / I have tested my changes locally.
- [x] 我已更新了必要的文档。 / I have updated the necessary documentation.（本次无需文档变更 / No documentation change required）