### PR TITLE
移除 TeamoRouter 广告 / Remove TeamoRouter sponsorship

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@ For detailed documentation, please visit [Official Documentation](https://www.gp
 <table>
 <tbody>
 <tr>
-<td width="180"><a href="https://teamorouter.com/?utm_source=gpt_load&utm_medium=referral&utm_campaign=ai_directory"><img src="./screenshot/teamorouter.png" alt="TeamoRouter" width="150"></a></td>
-<td>Thanks to TeamoRouter for sponsoring this project! TeamoRouter is an enterprise-grade Agentic LLM gateway that lets developers, AI teams, and businesses access Claude Code, Codex, Gemini CLI, and other AI agents through one unified API without separate subscriptions, with discounts of up to 90%. It connects to official providers and trusted partners like OpenAI, Anthropic, Vertex, Azure, and AWS Bedrock, offering verified Agent protocol compatibility, request traceability, near-official TTFT, 99.6% SLA, and up to 5,000 QPM. It also includes centralized billing, team management, BYOK, smart routing, analytics, provider optimization, and dedicated support. Teamo Desktop enables one-click setup with no API key management or manual configuration, and new users can register via <a href="https://teamorouter.com/?utm_source=gpt_load&utm_medium=referral&utm_campaign=ai_directory">this link</a> for 10% off their first top-up.</td>
-</tr>
-<tr>
 <td width="180"><a href="https://linux.do"><img src="./screenshot/l.png" alt="LINUX DO" width="150"></a></td>
 <td>Thank you very much for the support from the LINUX DO community!</td>
 </tr>

--- a/README_CN.md
+++ b/README_CN.md
@@ -18,10 +18,6 @@
 <table>
 <tbody>
 <tr>
-<td width="180"><a href="https://teamorouter.com/?utm_source=gpt_load&utm_medium=referral&utm_campaign=ai_directory"><img src="./screenshot/teamorouter.png" alt="TeamoRouter" width="150"></a></td>
-<td>感谢 TeamoRouter 赞助了本项目！TeamoRouter 是企业级 Agentic LLM gateway，让开发者、AI 团队和企业可以通过一个统一 API 访问 Claude Code、Codex、Gemini CLI 和其他 AI agents，无需分别订阅，并可享受最高 90% 的折扣。它连接官方提供商和 OpenAI、Anthropic、Vertex、Azure、AWS Bedrock 等可信合作伙伴，提供经过验证的 Agent protocol 兼容性、请求可追踪性、接近官方的 TTFT、99.6% SLA 以及最高 5,000 QPM。它还包含集中计费、团队管理、BYOK、smart routing、analytics、provider optimization 和专属支持。Teamo Desktop 支持一键设置，无需管理 API key 或手动配置，新用户可通过<a href="https://teamorouter.com/?utm_source=gpt_load&utm_medium=referral&utm_campaign=ai_directory">此链接</a>注册，首充可享 10% 折扣。</td>
-</tr>
-<tr>
 <td width="180"><a href="https://linux.do"><img src="./screenshot/l.png" alt="LINUX DO" width="150"></a></td>
 <td>非常感谢 LINUX DO 社区的支持！</td>
 </tr>

--- a/README_JP.md
+++ b/README_JP.md
@@ -18,10 +18,6 @@
 <table>
 <tbody>
 <tr>
-<td width="180"><a href="https://teamorouter.com/?utm_source=gpt_load&utm_medium=referral&utm_campaign=ai_directory"><img src="./screenshot/teamorouter.png" alt="TeamoRouter" width="150"></a></td>
-<td>TeamoRouterによる本プロジェクトへのスポンサー支援に感謝します！TeamoRouterはエンタープライズグレードのAgentic LLM gatewayで、開発者、AIチーム、企業がClaude Code、Codex、Gemini CLI、その他のAI agentsに単一の統合APIからアクセスでき、個別のサブスクリプションは不要で、最大90%の割引を利用できます。OpenAI、Anthropic、Vertex、Azure、AWS Bedrockなどの公式プロバイダーおよび信頼できるパートナーに接続し、検証済みのAgent protocol互換性、リクエストのトレーサビリティ、公式に近いTTFT、99.6% SLA、最大5,000 QPMを提供します。集中請求、チーム管理、BYOK、smart routing、analytics、provider optimization、専属サポートも備えています。Teamo Desktopにより、API key管理や手動設定なしでワンクリックセットアップが可能で、新規ユーザーは<a href="https://teamorouter.com/?utm_source=gpt_load&utm_medium=referral&utm_campaign=ai_directory">こちらのリンク</a>から登録すると初回チャージが10%オフになります。</td>
-</tr>
-<tr>
 <td width="180"><a href="https://linux.do"><img src="./screenshot/l.png" alt="LINUX DO" width="150"></a></td>
 <td>LINUX DOコミュニティからのサポートに心より感謝いたします！</td>
 </tr>


### PR DESCRIPTION
### 关联 Issue / Related Issue

无 / N/A

### 变更内容 / Change Content

- [ ] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [x] 其他改动 / Other changes

- 从中文、英文和日文 README 的赞助商表格中移除已到期的 TeamoRouter 广告。
- 保留其他赞助商内容与现有图片资产不变。
- Remove the expired TeamoRouter sponsorship entry from the Chinese, English, and Japanese README sponsor tables.
- Keep all other sponsor content and existing image assets unchanged.

### 自查清单 / Checklist

- [x] 我已在本地测试过我的变更。 / I have tested my changes locally.
- [x] 我已更新了必要的文档。 / I have updated the necessary documentation.

验证 / Validation:

- `git diff --check`
- 确认三份 README 中已无 `TeamoRouter` 或 `teamorouter.com`
- `make check` 无法运行：`main` 分支的 Makefile 未定义 `check` 目标。