### PR TITLE
fix(import): 增加上游版本路径提示 / Add upstream version-path warning

### DIFF
--- a/web/src/components/ui/FormField.vue
+++ b/web/src/components/ui/FormField.vue
@@ -6,6 +6,7 @@ const props = withDefaults(
     id: string
     label: string
     description?: string
+    descriptionWarning?: string
     error?: string
     required?: boolean
     requiredText?: string
@@ -17,6 +18,7 @@ const props = withDefaults(
   }>(),
   {
     description: undefined,
+    descriptionWarning: undefined,
     error: undefined,
     requiredText: undefined,
     disabledReason: undefined,
@@ -26,7 +28,9 @@ const props = withDefaults(
   },
 )
 
-const descriptionId = computed(() => (props.description ? `${props.id}-description` : undefined))
+const descriptionId = computed(() =>
+  props.description || props.descriptionWarning ? `${props.id}-description` : undefined,
+)
 const errorId = computed(() => (props.error ? `${props.id}-error` : undefined))
 const disabledReasonId = computed(() =>
   props.disabledReason ? `${props.id}-disabled-reason` : undefined,
@@ -56,8 +60,16 @@ const describedBy = computed(
       :invalid="Boolean(error)"
       :required="Boolean(required)"
     />
-    <p v-if="description" :id="descriptionId" class="form-field__description">
-      {{ description }}
+    <p v-if="description || descriptionWarning" :id="descriptionId" class="form-field__description">
+      <span v-if="description">{{ description }}</span>
+      <span
+        v-if="descriptionWarning"
+        class="form-field__description-warning"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        <span aria-hidden="true"> · </span>{{ descriptionWarning }}
+      </span>
     </p>
     <p
       v-if="disabledReason"
@@ -168,6 +180,10 @@ const describedBy = computed(
 
 .form-field__description {
   color: var(--color-text-faint);
+}
+
+.form-field__description-warning {
+  color: var(--color-warning);
 }
 
 .form-field__error {

--- a/web/src/features/import/ImportConnectionSection.vue
+++ b/web/src/features/import/ImportConnectionSection.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import type { ChannelDto } from '@/app/resources/channels'
 import AppSwitch from '@/components/ui/AppSwitch.vue'
 import FormField from '@/components/ui/FormField.vue'
+import { hasUpstreamBaseURLVersionMismatch, isValidUpstreamBaseURL } from '@/lib/upstream-base-url'
 
 const props = defineProps<{
   channel: ChannelDto | null
@@ -38,6 +39,15 @@ function baseURLDescription(): string {
     url: props.channel.default_base_url,
   })
 }
+
+function baseURLVersionWarning(key: string): string | undefined {
+  if (key !== 'base_url' || !props.channel?.default_base_url) return undefined
+  const value = props.params[key]?.trim() ?? ''
+  if (!value || !isValidUpstreamBaseURL(value)) return undefined
+  return hasUpstreamBaseURLVersionMismatch(props.channel.default_base_url, value)
+    ? t('import.connection.urlVersionWarning')
+    : undefined
+}
 </script>
 
 <template>
@@ -71,6 +81,7 @@ function baseURLDescription(): string {
             class="import-connection__param import-connection__param--optional-url"
             :label="t('import.connection.customUrl')"
             :description="baseURLDescription()"
+            :description-warning="baseURLVersionWarning(param.key)"
             :error="fieldError(param.key)"
             :required="baseUrlOverrideEnabled"
             :required-text="t('import.required')"
@@ -116,6 +127,9 @@ function baseURLDescription(): string {
             class="import-connection__param"
             :label="param.key === 'base_url' ? t('import.connection.url') : param.label"
             :description="param.key === 'base_url' ? baseURLDescription() : undefined"
+            :description-warning="
+              param.key === 'base_url' ? baseURLVersionWarning(param.key) : undefined
+            "
             :error="fieldError(param.key)"
             :required="param.required"
             :required-text="t('import.required')"

--- a/web/src/i18n/locales/en-US/import.ts
+++ b/web/src/i18n/locales/en-US/import.ts
@@ -101,6 +101,7 @@ export default {
       compatibleUrlDescription:
         'Enter the complete API prefix, for example https://api.example.com/v1',
       urlDescriptionWithDefault: 'Default URL: {url}',
+      urlVersionWarning: 'Version path may differ; please verify',
       customUrl: 'Custom upstream URL',
       urlError: 'Enter a valid HTTP or HTTPS upstream URL',
       paramRequired: 'Enter {name}',

--- a/web/src/i18n/locales/ja-JP/import.ts
+++ b/web/src/i18n/locales/ja-JP/import.ts
@@ -99,6 +99,7 @@ export default {
       compatibleUrlDescription:
         'https://api.example.com/v1 のように完全な API プレフィックスを入力してください',
       urlDescriptionWithDefault: '既定の URL：{url}',
+      urlVersionWarning: 'バージョンパスが異なる可能性があります。確認してください',
       customUrl: 'カスタム上流 URL',
       urlError: '有効な HTTP または HTTPS のアップストリーム URL を入力してください',
       paramRequired: '{name} を入力してください',

--- a/web/src/i18n/locales/zh-CN/import.ts
+++ b/web/src/i18n/locales/zh-CN/import.ts
@@ -95,6 +95,7 @@ export default {
       urlDescription: '请按上游服务要求填写 Base URL',
       compatibleUrlDescription: '填写完整 API 前缀，例如 https://api.example.com/v1',
       urlDescriptionWithDefault: '默认地址：{url}',
+      urlVersionWarning: '版本路径可能不一致，请确认',
       customUrl: '自定义上游地址',
       urlError: '请输入有效的 HTTP 或 HTTPS 上游地址',
       paramRequired: '请输入{name}',

--- a/web/src/lib/upstream-base-url.ts
+++ b/web/src/lib/upstream-base-url.ts
@@ -12,3 +12,30 @@ export function isValidUpstreamBaseURL(value: string): boolean {
     return false
   }
 }
+
+const versionPathSegmentPattern = /^v\d+[a-z]*$/i
+
+function versionPathSegment(value: string): string | null {
+  try {
+    const parsed = new URL(value.trim())
+    const segments = parsed.pathname.split('/').filter(Boolean)
+    for (let index = segments.length - 1; index >= 0; index -= 1) {
+      const segment = segments[index]
+      if (versionPathSegmentPattern.test(segment)) return segment.toLowerCase()
+    }
+  } catch {
+    return null
+  }
+  return null
+}
+
+/**
+ * Compares only the version-like path shape of two valid upstream URLs.
+ * A missing version and a different version are both advisory mismatches.
+ */
+export function hasUpstreamBaseURLVersionMismatch(reference: string, value: string): boolean {
+  if (!isValidUpstreamBaseURL(reference) || !isValidUpstreamBaseURL(value)) return false
+  const referenceVersion = versionPathSegment(reference)
+  const valueVersion = versionPathSegment(value)
+  return referenceVersion !== valueVersion && (referenceVersion !== null || valueVersion !== null)
+}


### PR DESCRIPTION
### 关联 Issue / Related Issue
Closes #

### 变更内容 / Change Content
- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

本 PR 为渠道导入表单增加上游地址版本路径的非阻塞提示：
- 保留现有提示文案不变，仅在默认地址说明后同行追加动态警告。
- 比较默认地址与用户输入地址中的版本路径片段，支持 v1、v2、v4、v1beta 等形式。
- URL 格式无效时继续使用现有错误提示；版本路径疑似不一致时不阻止提交。
- 未提供可比较默认地址时不显示版本路径警告。

### 自查清单 / Checklist
- [x] 我已运行 make check，或在说明中写明无法运行的原因和未验证范围。 / I ran make check, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [ ] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.

验证：
- make check 通过
- Commit: c9437fde