### PR TITLE
fix(release): 支持手动强制检查版本

### DIFF
--- a/internal/control/server.go
+++ b/internal/control/server.go
@@ -28,7 +28,7 @@ import (
 
 // ReleaseUpdateChecker is the control-plane on-demand view of the public release checker.
 type ReleaseUpdateChecker interface {
-	Check(context.Context) (*releasecheck.Update, error)
+	Check(context.Context, bool) (*releasecheck.Update, error)
 }
 
 type Server struct {

--- a/internal/control/system_update.go
+++ b/internal/control/system_update.go
@@ -2,6 +2,7 @@ package control
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 
@@ -20,7 +21,8 @@ type releaseUpdateResponse struct {
 }
 
 func (s *Server) handleSystemUpdate(c *gin.Context) {
-	if c.Request.URL.RawQuery != "" || c.Request.URL.ForceQuery {
+	force, err := systemUpdateForce(c)
+	if err != nil {
 		writeServiceError(c, "system_update", app_errors.ErrBadRequest)
 		return
 	}
@@ -28,7 +30,7 @@ func (s *Server) handleSystemUpdate(c *gin.Context) {
 		writeServiceError(c, "system_update", app_errors.ErrInternalServer)
 		return
 	}
-	available, err := s.releaseChecker.Check(c.Request.Context())
+	available, err := s.releaseChecker.Check(c.Request.Context(), force)
 	if err != nil {
 		writeServiceError(
 			c,
@@ -46,4 +48,23 @@ func (s *Server) handleSystemUpdate(c *gin.Context) {
 		}
 	}
 	response.SuccessI18n(c, "common.success", systemUpdateResponse{Update: update})
+}
+
+func systemUpdateForce(c *gin.Context) (bool, error) {
+	if c.Request.URL.ForceQuery {
+		return false, app_errors.ErrBadRequest
+	}
+	if c.Request.URL.RawQuery == "" {
+		return false, nil
+	}
+	query := c.Request.URL.Query()
+	values, ok := query["force"]
+	if !ok || len(values) != 1 || len(query) != 1 {
+		return false, app_errors.ErrBadRequest
+	}
+	force, err := strconv.ParseBool(values[0])
+	if err != nil {
+		return false, app_errors.ErrBadRequest
+	}
+	return force, nil
 }

--- a/internal/control/system_update_test.go
+++ b/internal/control/system_update_test.go
@@ -20,10 +20,12 @@ type recordingReleaseUpdateChecker struct {
 	update *releasecheck.Update
 	err    error
 	calls  int
+	forces []bool
 }
 
-func (checker *recordingReleaseUpdateChecker) Check(context.Context) (*releasecheck.Update, error) {
+func (checker *recordingReleaseUpdateChecker) Check(_ context.Context, force bool) (*releasecheck.Update, error) {
 	checker.calls++
+	checker.forces = append(checker.forces, force)
 	if checker.update == nil {
 		return nil, checker.err
 	}
@@ -76,13 +78,19 @@ func TestSystemUpdateHTTPChecksOnDemandWithoutAffectingHome(t *testing.T) {
 		ReleaseURL:    checker.update.ReleaseURL,
 		PublishedAtMS: checker.update.PublishedAtMS,
 	}
-	if envelope.Data.Update == nil || *envelope.Data.Update != want || checker.calls != 1 {
+	if envelope.Data.Update == nil || *envelope.Data.Update != want || checker.calls != 1 ||
+		len(checker.forces) != 1 || checker.forces[0] {
 		t.Fatalf("update/calls = %#v/%d, want %#v/1", envelope.Data.Update, checker.calls, want)
 	}
 	assertManagementWireObject(t, envelope.Data, []string{"update"})
 	assertManagementWireObject(t, *envelope.Data.Update, []string{
 		"version", "release_url", "published_at_ms",
 	})
+
+	forced := performHomeRequest(engine, "/api/system/update?force=true", "test-auth-key")
+	if forced.Code != http.StatusOK || checker.calls != 2 || len(checker.forces) != 2 || !checker.forces[1] {
+		t.Fatalf("forced update = %d, calls=%d, forces=%v", forced.Code, checker.calls, checker.forces)
+	}
 }
 
 func TestSystemUpdateHTTPReturnsNullForSuccessfulNoUpdate(t *testing.T) {
@@ -98,7 +106,7 @@ func TestSystemUpdateHTTPReturnsNullForSuccessfulNoUpdate(t *testing.T) {
 	server.RegisterRoutes(engine)
 
 	recorder := performHomeRequest(engine, "/api/system/update", "test-auth-key")
-	if recorder.Code != http.StatusOK || checker.calls != 1 {
+	if recorder.Code != http.StatusOK || checker.calls != 1 || len(checker.forces) != 1 || checker.forces[0] {
 		t.Fatalf("GET /api/system/update = %d %s, calls=%d", recorder.Code, recorder.Body.String(), checker.calls)
 	}
 	var envelope struct {
@@ -125,14 +133,14 @@ func TestSystemUpdateHTTPHidesUpstreamFailureBehindBadGateway(t *testing.T) {
 	server.RegisterRoutes(engine)
 
 	recorder := performHomeRequest(engine, "/api/system/update", "test-auth-key")
-	if recorder.Code != http.StatusBadGateway || checker.calls != 1 ||
+	if recorder.Code != http.StatusBadGateway || checker.calls != 1 || len(checker.forces) != 1 || checker.forces[0] ||
 		!strings.Contains(recorder.Body.String(), `"code":"`+app_errors.ErrBadGateway.Code+`"`) ||
 		strings.Contains(recorder.Body.String(), "private upstream detail") {
 		t.Fatalf("GET /api/system/update = %d %s, calls=%d", recorder.Code, recorder.Body.String(), checker.calls)
 	}
 }
 
-func TestSystemUpdateHTTPRejectsAccessKeyAndQueryBeforeCheck(t *testing.T) {
+func TestSystemUpdateHTTPRejectsAccessKeyAndInvalidQueryBeforeCheck(t *testing.T) {
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	accessKey, err := fixture.service.CreateAccessKey(t.Context(), AccessKeyCreateRequest{Name: "read only"})
@@ -150,8 +158,14 @@ func TestSystemUpdateHTTPRejectsAccessKeyAndQueryBeforeCheck(t *testing.T) {
 
 	accessKeyResponse := performHomeRequest(engine, "/api/system/update", accessKey.Key)
 	assertHomeHTTPError(t, accessKeyResponse, http.StatusForbidden, app_errors.ErrForbidden.Code)
-	queryResponse := performHomeRequest(engine, "/api/system/update?refresh=1", "test-auth-key")
-	assertHomeHTTPError(t, queryResponse, http.StatusBadRequest, app_errors.ErrBadRequest.Code)
+	for _, path := range []string{
+		"/api/system/update?refresh=1",
+		"/api/system/update?force=maybe",
+		"/api/system/update?force=true&force=false",
+	} {
+		queryResponse := performHomeRequest(engine, path, "test-auth-key")
+		assertHomeHTTPError(t, queryResponse, http.StatusBadRequest, app_errors.ErrBadRequest.Code)
+	}
 	if checker.calls != 0 {
 		t.Fatalf("rejected request check calls = %d, want 0", checker.calls)
 	}

--- a/internal/releasecheck/checker.go
+++ b/internal/releasecheck/checker.go
@@ -44,7 +44,8 @@ func newChecker(fetcher releaseFetcher, current string) *Checker {
 }
 
 // Check returns the cached result or synchronously refreshes it from GitHub.
-func (checker *Checker) Check(ctx context.Context) (*Update, error) {
+// When force is true, it ignores an unexpired cache and fetches GitHub again.
+func (checker *Checker) Check(ctx context.Context, force bool) (*Update, error) {
 	if checker == nil || checker.fetcher == nil {
 		return nil, errors.New("check GitHub releases: checker is unavailable")
 	}
@@ -58,7 +59,7 @@ func (checker *Checker) Check(ctx context.Context) (*Update, error) {
 	}
 
 	now := checker.currentTime()
-	if now.Before(checker.expiresAt) {
+	if !force && now.Before(checker.expiresAt) {
 		return cloneUpdate(checker.update), checker.cachedErr
 	}
 

--- a/internal/releasecheck/checker_test.go
+++ b/internal/releasecheck/checker_test.go
@@ -49,13 +49,13 @@ func TestCheckerCheckRunsOnlyOnDemandAndCachesSuccess(t *testing.T) {
 	if calls := fetcher.callCount(); calls != 0 {
 		t.Fatalf("constructor fetch calls = %d, want 0", calls)
 	}
-	first, err := checker.Check(t.Context())
+	first, err := checker.Check(t.Context(), false)
 	if err != nil || first == nil || first.Version != "v2.0.1" || fetcher.callCount() != 1 {
 		t.Fatalf("first Check() = %#v, %v, calls=%d", first, err, fetcher.callCount())
 	}
 	first.Version = "mutated"
 	now = base.Add(2 * time.Hour)
-	second, err := checker.Check(t.Context())
+	second, err := checker.Check(t.Context(), false)
 	if err != nil || second == nil || second.Version != "v2.0.1" || fetcher.callCount() != 1 {
 		t.Fatalf("cached Check() = %#v, %v, calls=%d", second, err, fetcher.callCount())
 	}
@@ -73,31 +73,31 @@ func TestCheckerCachesSuccessForSixHoursAndFailureForThirtyMinutes(t *testing.T)
 	checker := newChecker(fetcher, "v2.0.0")
 	checker.now = func() time.Time { return now }
 
-	update, err := checker.Check(t.Context())
+	update, err := checker.Check(t.Context(), false)
 	if err != nil || update == nil || update.Version != "v2.0.1" {
 		t.Fatalf("first Check() = %#v, %v", update, err)
 	}
 
 	now = base.Add(2 * time.Hour)
-	update, err = checker.Check(t.Context())
+	update, err = checker.Check(t.Context(), false)
 	if err != nil || update == nil || update.Version != "v2.0.1" || fetcher.callCount() != 1 {
 		t.Fatalf("cached Check() = %#v, %v, calls=%d", update, err, fetcher.callCount())
 	}
 
 	now = base.Add(6 * time.Hour)
-	update, err = checker.Check(t.Context())
+	update, err = checker.Check(t.Context(), false)
 	if update != nil || !errors.Is(err, offlineErr) || fetcher.callCount() != 2 {
 		t.Fatalf("failed Check() = %#v, %v, calls=%d", update, err, fetcher.callCount())
 	}
 
 	now = base.Add(6*time.Hour + 15*time.Minute)
-	update, err = checker.Check(t.Context())
+	update, err = checker.Check(t.Context(), false)
 	if update != nil || !errors.Is(err, offlineErr) || fetcher.callCount() != 2 {
 		t.Fatalf("cached failure Check() = %#v, %v, calls=%d", update, err, fetcher.callCount())
 	}
 
 	now = base.Add(6*time.Hour + 30*time.Minute)
-	update, err = checker.Check(t.Context())
+	update, err = checker.Check(t.Context(), false)
 	if err != nil || update == nil || update.Version != "v2.0.2" || fetcher.callCount() != 3 {
 		t.Fatalf("recovered Check() = %#v, %v, calls=%d", update, err, fetcher.callCount())
 	}
@@ -108,13 +108,65 @@ func TestCheckerCachesSuccessfulNoUpdateResult(t *testing.T) {
 		releases: []Release{testRelease("v2.0.0-beta.8", "2026-08-19T11:00:00Z")},
 	}}}
 	checker := newChecker(fetcher, "v2.0.0")
-	update, err := checker.Check(t.Context())
+	update, err := checker.Check(t.Context(), false)
 	if err != nil || update != nil || fetcher.callCount() != 1 {
 		t.Fatalf("Check() = %#v, %v, calls=%d", update, err, fetcher.callCount())
 	}
-	update, err = checker.Check(t.Context())
+	update, err = checker.Check(t.Context(), false)
 	if err != nil || update != nil || fetcher.callCount() != 1 {
 		t.Fatalf("cached Check() = %#v, %v, calls=%d", update, err, fetcher.callCount())
+	}
+}
+
+func TestCheckerForceCheckBypassesAndReplacesCachedResult(t *testing.T) {
+	base := time.Date(2026, time.August, 20, 8, 0, 0, 0, time.UTC)
+	now := base
+	fetcher := &sequenceFetcher{results: []fetchResult{
+		{releases: []Release{testRelease("v2.0.1", "2026-08-20T07:00:00Z")}},
+		{releases: []Release{testRelease("v2.0.2", "2026-08-20T08:01:00Z")}},
+	}}
+	checker := newChecker(fetcher, "v2.0.0")
+	checker.now = func() time.Time { return now }
+
+	first, err := checker.Check(t.Context(), false)
+	if err != nil || first == nil || first.Version != "v2.0.1" {
+		t.Fatalf("first Check() = %#v, %v", first, err)
+	}
+
+	forced, err := checker.Check(t.Context(), true)
+	if err != nil || forced == nil || forced.Version != "v2.0.2" || fetcher.callCount() != 2 {
+		t.Fatalf("forced Check() = %#v, %v, calls=%d", forced, err, fetcher.callCount())
+	}
+
+	cached, err := checker.Check(t.Context(), false)
+	if err != nil || cached == nil || cached.Version != "v2.0.2" || fetcher.callCount() != 2 {
+		t.Fatalf("cached forced result = %#v, %v, calls=%d", cached, err, fetcher.callCount())
+	}
+}
+
+func TestCheckerForceCheckCachesFailure(t *testing.T) {
+	offlineErr := errors.New("offline")
+	fetcher := &sequenceFetcher{results: []fetchResult{
+		{releases: []Release{testRelease("v2.0.1", "2026-08-20T07:00:00Z")}},
+		{err: offlineErr},
+		{releases: []Release{testRelease("v2.0.2", "2026-08-20T08:01:00Z")}},
+	}}
+	checker := newChecker(fetcher, "v2.0.0")
+
+	if _, err := checker.Check(t.Context(), false); err != nil {
+		t.Fatalf("initial Check() error = %v", err)
+	}
+	forced, err := checker.Check(t.Context(), true)
+	if forced != nil || !errors.Is(err, offlineErr) || fetcher.callCount() != 2 {
+		t.Fatalf("forced failure = %#v, %v, calls=%d", forced, err, fetcher.callCount())
+	}
+	cached, err := checker.Check(t.Context(), false)
+	if cached != nil || !errors.Is(err, offlineErr) || fetcher.callCount() != 2 {
+		t.Fatalf("cached forced failure = %#v, %v, calls=%d", cached, err, fetcher.callCount())
+	}
+	recovered, err := checker.Check(t.Context(), true)
+	if err != nil || recovered == nil || recovered.Version != "v2.0.2" || fetcher.callCount() != 3 {
+		t.Fatalf("forced recovery = %#v, %v, calls=%d", recovered, err, fetcher.callCount())
 	}
 }
 
@@ -140,12 +192,12 @@ func TestCheckerCoalescesConcurrentChecks(t *testing.T) {
 	checker := newChecker(fetcher, "v2.0.0")
 	done := make(chan error, 2)
 	go func() {
-		_, err := checker.Check(t.Context())
+		_, err := checker.Check(t.Context(), false)
 		done <- err
 	}()
 	<-fetcher.started
 	go func() {
-		_, err := checker.Check(t.Context())
+		_, err := checker.Check(t.Context(), false)
 		done <- err
 	}()
 	time.Sleep(25 * time.Millisecond)
@@ -178,7 +230,7 @@ func TestCheckerCheckCancelsActiveFetch(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		_, err := checker.Check(ctx)
+		_, err := checker.Check(ctx, false)
 		done <- err
 	}()
 	select {

--- a/web/src/app/resources/system-update.ts
+++ b/web/src/app/resources/system-update.ts
@@ -85,8 +85,10 @@ export function projectSystemUpdate(value: unknown): SystemUpdateDto {
 export async function getSystemUpdate(
   client: ApiClient,
   signal?: AbortSignal,
+  force = false,
 ): Promise<SystemUpdateDto> {
-  return projectSystemUpdate(await client.request('/api/system/update', { signal }))
+  const path = force ? '/api/system/update?force=true' : '/api/system/update'
+  return projectSystemUpdate(await client.request(path, { signal }))
 }
 
 export function systemUpdateQueryOptions(client: ApiClient, enabled?: MaybeRefOrGetter<boolean>) {

--- a/web/src/features/settings/SystemInfoSection.vue
+++ b/web/src/features/settings/SystemInfoSection.vue
@@ -1,15 +1,20 @@
 <script setup lang="ts">
-import { useQuery } from '@tanstack/vue-query'
-import { computed } from 'vue'
+import { RefreshCw } from '@lucide/vue'
+import { useQuery, useQueryClient } from '@tanstack/vue-query'
+import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { RequestCancelledError } from '@/api/errors'
 import { useApiClient } from '@/api/client-context'
 import { useStableLoading } from '@/app/loading-state'
+import { controlQueryKeys } from '@/app/query-keys'
 import {
   systemInfoQueryOptions,
   type DatabaseDriver,
   type SecretSource,
 } from '@/app/resources/system-info'
+import { getSystemUpdate, type ReleaseUpdateDto } from '@/app/resources/system-update'
+import AppButton from '@/components/ui/AppButton.vue'
 import CopyButton from '@/components/ui/CopyButton.vue'
 import AsyncRefreshIndicator from '@/components/ui/AsyncRefreshIndicator.vue'
 import QueryFeedback from '@/components/ui/QueryFeedback.vue'
@@ -18,6 +23,7 @@ import StatusBadge from '@/components/ui/StatusBadge.vue'
 import Surface from '@/components/ui/Surface.vue'
 
 const client = useApiClient()
+const queryClient = useQueryClient()
 const { t } = useI18n()
 const infoQuery = useQuery(systemInfoQueryOptions(client))
 const initialLoading = useStableLoading(
@@ -26,6 +32,26 @@ const initialLoading = useStableLoading(
 const infoRefreshing = computed(
   () => infoQuery.data.value !== undefined && infoQuery.isFetching.value,
 )
+type UpdateCheckState =
+  | { kind: 'checking' }
+  | { kind: 'latest' }
+  | { kind: 'available'; update: ReleaseUpdateDto }
+  | { kind: 'failed' }
+
+const updateCheck = ref<UpdateCheckState | null>(null)
+const updateCheckPending = ref(false)
+const updateCheckTone = computed<'info' | 'success' | 'warning' | 'danger'>(() => {
+  switch (updateCheck.value?.kind) {
+    case 'latest':
+      return 'success'
+    case 'available':
+      return 'warning'
+    case 'failed':
+      return 'danger'
+    default:
+      return 'info'
+  }
+})
 
 function sourceLabel(source: SecretSource): string {
   return t(`settings.system.sources.${source}`)
@@ -33,6 +59,29 @@ function sourceLabel(source: SecretSource): string {
 
 function databaseLabel(database: DatabaseDriver): string {
   return t(`settings.system.databases.${database}`)
+}
+
+async function checkForUpdate(): Promise<void> {
+  if (updateCheckPending.value) return
+  updateCheckPending.value = true
+  updateCheck.value = { kind: 'checking' }
+  try {
+    const result = await getSystemUpdate(client, undefined, true)
+    queryClient.setQueryData(controlQueryKeys.systemUpdate(), result)
+    updateCheck.value = result.update
+      ? { kind: 'available', update: result.update }
+      : { kind: 'latest' }
+  } catch (error) {
+    if (error instanceof RequestCancelledError) {
+      updateCheck.value = null
+      return
+    }
+    // 后端失败时会清空更新结果；同步前端查询缓存，避免继续显示旧提示。
+    queryClient.setQueryData(controlQueryKeys.systemUpdate(), { update: null })
+    updateCheck.value = { kind: 'failed' }
+  } finally {
+    updateCheckPending.value = false
+  }
 }
 </script>
 
@@ -71,7 +120,55 @@ function databaseLabel(database: DatabaseDriver): string {
         <dl class="settings-system__definition">
           <div class="settings-system__row">
             <dt>{{ t('settings.system.version') }}</dt>
-            <dd class="settings-system__mono">{{ infoQuery.data.value.version }}</dd>
+            <dd class="settings-system__version">
+              <span class="settings-system__mono">{{ infoQuery.data.value.version }}</span>
+              <div class="settings-system__update-controls">
+                <AppButton
+                  variant="secondary"
+                  size="compact"
+                  :busy="updateCheckPending"
+                  @click="checkForUpdate"
+                >
+                  <RefreshCw
+                    :size="14"
+                    aria-hidden="true"
+                    :class="{ 'settings-system__refresh-icon--spinning': updateCheckPending }"
+                  />
+                  {{ t('settings.system.checkUpdate') }}
+                </AppButton>
+                <span
+                  v-if="updateCheck"
+                  class="settings-system__update-result"
+                  :class="`settings-system__update-result--${updateCheckTone}`"
+                  :role="updateCheck.kind === 'failed' ? 'alert' : 'status'"
+                  :aria-live="updateCheck.kind === 'failed' ? 'assertive' : 'polite'"
+                  aria-atomic="true"
+                >
+                  <template v-if="updateCheck.kind === 'checking'">
+                    {{ t('settings.system.checkingUpdate') }}
+                  </template>
+                  <template v-else-if="updateCheck.kind === 'latest'">
+                    {{ t('settings.system.latestVersion') }}
+                  </template>
+                  <template v-else-if="updateCheck.kind === 'available'">
+                    {{
+                      t('settings.system.updateAvailable', { version: updateCheck.update.version })
+                    }}
+                    <a
+                      class="settings-system__update-link"
+                      :href="updateCheck.update.release_url"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {{ t('settings.system.viewRelease') }}
+                    </a>
+                  </template>
+                  <template v-else>
+                    {{ t('settings.system.checkUpdateFailed') }}
+                  </template>
+                </span>
+              </div>
+            </dd>
           </div>
 
           <div class="settings-system__row">
@@ -239,6 +336,67 @@ function databaseLabel(database: DatabaseDriver): string {
 
 .settings-system__mono {
   font-family: var(--font-mono);
+}
+
+.settings-system__version {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.settings-system__update-controls {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.settings-system__update-result {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+.settings-system__update-result--info {
+  color: var(--color-action);
+}
+
+.settings-system__update-result--success {
+  color: var(--color-success);
+}
+
+.settings-system__update-result--warning {
+  color: var(--color-warning);
+}
+
+.settings-system__update-result--danger {
+  color: var(--color-danger);
+}
+
+.settings-system__update-link {
+  color: currentColor;
+  font-weight: 650;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.settings-system__refresh-icon--spinning {
+  animation: settings-system-refresh-spin 900ms linear infinite;
+}
+
+@keyframes settings-system-refresh-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .settings-system__refresh-icon--spinning {
+    animation: none;
+  }
 }
 
 @media (max-width: 760px) {

--- a/web/src/i18n/locales/en-US/settings.ts
+++ b/web/src/i18n/locales/en-US/settings.ts
@@ -140,7 +140,7 @@ export default {
       checkUpdate: 'Check for updates',
       checkingUpdate: 'Checking for updates…',
       latestVersion: 'You are already on the latest version',
-      updateAvailable: 'Version {version} is available. ',
+      updateAvailable: 'Version {version} is available.',
       viewRelease: 'View release',
       checkUpdateFailed: 'Unable to check for updates. Please try again later.',
       deployment: 'Deployment',

--- a/web/src/i18n/locales/en-US/settings.ts
+++ b/web/src/i18n/locales/en-US/settings.ts
@@ -132,11 +132,17 @@ export default {
     },
     system: {
       title: 'System information',
-      description: 'Read-only deployment and secret-source metadata.',
+      description: 'Read-only deployment and secret-source metadata with manual update checks.',
       loading: 'Loading system information…',
       loadFailed: 'Unable to load system information.',
       stale: 'System information may be stale because the background refresh failed.',
       version: 'Version',
+      checkUpdate: 'Check for updates',
+      checkingUpdate: 'Checking for updates…',
+      latestVersion: 'You are already on the latest version',
+      updateAvailable: 'Version {version} is available. ',
+      viewRelease: 'View release',
+      checkUpdateFailed: 'Unable to check for updates. Please try again later.',
       deployment: 'Deployment',
       single: 'Single instance',
       databases: {

--- a/web/src/i18n/locales/ja-JP/settings.ts
+++ b/web/src/i18n/locales/ja-JP/settings.ts
@@ -131,11 +131,17 @@ export default {
     },
     system: {
       title: 'システム情報',
-      description: 'デプロイとシークレット取得元の読み取り専用メタデータです。',
+      description: 'デプロイとシークレット取得元を表示し、手動で更新を確認できます。',
       loading: 'システム情報を読み込み中…',
       loadFailed: 'システム情報を読み込めません。',
       stale: 'バックグラウンド更新に失敗したため、システム情報が古い可能性があります。',
       version: 'バージョン',
+      checkUpdate: '更新を確認',
+      checkingUpdate: '更新を確認中…',
+      latestVersion: '現在のバージョンは最新です',
+      updateAvailable: '新しいバージョン {version} があります。',
+      viewRelease: 'リリースを表示',
+      checkUpdateFailed: '更新を確認できません。後でもう一度お試しください。',
       deployment: 'デプロイ',
       single: '単一インスタンス',
       databases: {

--- a/web/src/i18n/locales/zh-CN/settings.ts
+++ b/web/src/i18n/locales/zh-CN/settings.ts
@@ -120,11 +120,17 @@ export default {
     },
     system: {
       title: '系统信息',
-      description: '只读展示部署与密钥来源元数据。',
+      description: '只读展示部署与密钥来源元数据，也可以手动检查版本更新。',
       loading: '正在加载系统信息…',
       loadFailed: '无法加载系统信息。',
       stale: '后台刷新失败，系统信息可能已过期。',
       version: '版本',
+      checkUpdate: '检查更新',
+      checkingUpdate: '正在检查更新…',
+      latestVersion: '当前已经是最新版本',
+      updateAvailable: '发现新版本 {version}，',
+      viewRelease: '查看 Release',
+      checkUpdateFailed: '检查更新失败，请稍后重试。',
       deployment: '部署形态',
       single: '单实例',
       databases: {


### PR DESCRIPTION
### 关联 Issue / Related Issue
<!-- 请填写此 PR 关联的 issue 编号，例如：Closes #123 / Please link the issue number, e.g., Closes #123 -->
无 / None

### 变更内容 / Change Content
<!-- 请简要描述本次变更的核心内容 / Please briefly describe the core changes of this PR -->
- [ ] Bug 修复 / Bug fix
- [x] 新功能 / New feature
- [ ] 其他改动 / Other changes

<!-- 请在下方详细描述你的变更 / Please describe your changes in detail below -->
- 在设置 → 系统信息的版本行增加手动“检查更新”按钮。
- 手动检查请求使用 `force=true`，绕过后端有效缓存并同步请求 GitHub。
- 检查中、已是最新、有新版本、检查失败均在按钮后显示对应颜色的文字；有更新时提供版本号和 Release 链接。
- 保留成功 6 小时、失败 30 分钟的后端缓存策略，并同步前端更新查询缓存。
- 首页继续使用紧凑更新提示，设置页不显示更新图标或 Tooltip。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.（本次无需新增文档）
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.（仅增加可选查询参数，无数据迁移）