### PR TITLE
fix(web): 修复首页访问密钥额度翻译

### DIFF
--- a/web/src/app/router.ts
+++ b/web/src/app/router.ts
@@ -25,7 +25,12 @@ function pageRoute(
 const routes: RouteRecordRaw[] = [
   pageRoute(pageRouteNames.home, {
     component: lazyView(() => import('@/features/home/HomeView.vue')),
-    meta: { titleKey: 'home.ledger.title', requiresAuth: true, primaryNav: 'home' },
+    meta: {
+      titleKey: 'home.ledger.title',
+      requiresAuth: true,
+      primaryNav: 'home',
+      messageNamespaces: ['access-keys'],
+    },
   }),
   pageRoute(pageRouteNames.login, {
     component: lazyView(() => import('@/features/auth/LoginView.vue')),


### PR DESCRIPTION
### 关联 Issue / Related Issue
无 / None

### 变更内容 / Change Content
- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

首页路由声明 `access-keys` 翻译命名空间，使访问密钥登录后的首页以及整页刷新都在渲染前加载额度卡片所需的翻译。修复状态徽章、百分比提示和周期 Tooltip 偶尔显示翻译键的问题。

本次仅修改前端路由元数据，不涉及后端 API、数据结构、迁移或兼容性变化。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.（本次无必要文档更新 / N/A）
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.（无影响 / N/A）