### PR TITLE
fix(groups): 统一无模型分组可用性

### DIFF
--- a/internal/control/group_collection.go
+++ b/internal/control/group_collection.go
@@ -10,9 +10,7 @@ import (
 	"gorm.io/gorm"
 
 	"gpt-load/internal/channel"
-	"gpt-load/internal/execution"
 	app_errors "gpt-load/internal/platform/errors"
-	"gpt-load/internal/protocol"
 	"gpt-load/internal/state"
 	stateloader "gpt-load/internal/state/loader"
 	"gpt-load/internal/storage/models"
@@ -272,7 +270,6 @@ func mapGroupCollectionRecords(
 	}
 	records := make([]groupCollectionRecord, 0, len(rows.groups))
 	for _, group := range rows.groups {
-		supportsModelOptionalRequests := false
 		channelID := channel.ID(group.ChannelID)
 		if registry == nil {
 			return nil, groupCollectionDataError("channel registry is nil")
@@ -282,14 +279,9 @@ func mapGroupCollectionRecords(
 			return nil, groupCollectionDataError("validate group %d params: %v", group.ID, err)
 		}
 		params := validated.CanonicalJSON()
-		resolvedTarget, err := registry.Resolve(channelID, params)
-		if err != nil {
+		if _, err := registry.Resolve(channelID, params); err != nil {
 			return nil, groupCollectionDataError("resolve group %d channel: %v", group.ID, err)
 		}
-		_, supportsModelOptionalRequests = resolvedTarget.Mode(
-			protocol.OpenAIResponses,
-			execution.OperationResponsesRetrieve,
-		)
 		var groupModels []GroupModel
 		if err := json.Unmarshal(group.Models, &groupModels); err != nil {
 			return nil, groupCollectionDataError(
@@ -323,7 +315,6 @@ func mapGroupCollectionRecords(
 		record.Status, record.UnavailableReason = groupCollectionStatusAndReason(
 			catalog,
 			record.CredentialCounts,
-			supportsModelOptionalRequests,
 			record.ModelCount,
 		)
 		records = append(records, record)
@@ -416,13 +407,11 @@ func addGroupCollectionCredentialCount(counts *GroupCollectionCredentialCounts, 
 func groupCollectionStatus(
 	group state.GroupCatalogView,
 	counts GroupCollectionCredentialCounts,
-	supportsModelOptionalRequests bool,
 	modelCount int64,
 ) GroupCollectionStatus {
 	status, _ := groupCollectionStatusAndReason(
 		group,
 		counts,
-		supportsModelOptionalRequests,
 		modelCount,
 	)
 	return status
@@ -431,7 +420,6 @@ func groupCollectionStatus(
 func groupCollectionStatusAndReason(
 	group state.GroupCatalogView,
 	counts GroupCollectionCredentialCounts,
-	supportsModelOptionalRequests bool,
 	modelCount int64,
 ) (GroupCollectionStatus, *GroupUnavailableReason) {
 	if !group.Enabled || (group.WeightManual != nil && *group.WeightManual == 0) {
@@ -442,9 +430,6 @@ func groupCollectionStatusAndReason(
 		return GroupCollectionStatusUnavailable, &reason
 	}
 	if modelCount > 0 {
-		return GroupCollectionStatusAvailable, nil
-	}
-	if supportsModelOptionalRequests {
 		return GroupCollectionStatusAvailable, nil
 	}
 	reason := GroupUnavailableReasonNoModels

--- a/internal/control/group_detail_test.go
+++ b/internal/control/group_detail_test.go
@@ -20,18 +20,22 @@ func TestGetGroupSummaryUsesCollectionServiceStatusAndOnlyReturnsHeaderCounts(t 
 	fixture := newServiceFixture(t)
 	available := createGroupCollectionGroup(t, fixture, "summary-available", true, nil)
 	unavailable := createGroupCollectionGroup(t, fixture, "summary-unavailable", true, nil)
+	openAIWithoutModels := createGroupCollectionGroup(t, fixture, "summary-openai-no-models", true, nil)
 	disabled := createGroupCollectionGroup(t, fixture, "summary-disabled", false, nil)
 	noCredentials := createGroupCollectionGroup(t, fixture, "summary-no-credentials", true, nil)
 	setGroupCollectionChannel(t, fixture, available, channel.OpenAI, models.JSON(`{}`))
 	setGroupCollectionChannel(t, fixture, unavailable, channel.Anthropic, models.JSON(`{}`))
-	setGroupCollectionRoute(t, fixture, available, `["openai-responses"]`, `[]`)
+	setGroupCollectionChannel(t, fixture, openAIWithoutModels, channel.OpenAI, models.JSON(`{}`))
+	setGroupCollectionRoute(t, fixture, available, `["openai-responses"]`, `[{"id":"gpt-test"}]`)
 	setGroupCollectionRoute(t, fixture, unavailable, `["openai-completions"]`, `[]`)
+	setGroupCollectionRoute(t, fixture, openAIWithoutModels, `["openai-responses"]`, `[]`)
 	setGroupCollectionRoute(t, fixture, disabled, `["openai-responses"]`, `[]`)
 	setGroupCollectionChannel(t, fixture, noCredentials, channel.Anthropic, models.JSON(`{}`))
 	setGroupCollectionRoute(t, fixture, noCredentials, `["openai-completions"]`, `[{"id":"model"}]`)
 	publishGroupCollectionRuntime(t, fixture, []state.CredentialEntry{
 		createGroupCollectionKey(t, fixture, available.ID, models.CredentialStatusActive, nil),
 		createGroupCollectionKey(t, fixture, unavailable.ID, models.CredentialStatusActive, nil),
+		createGroupCollectionKey(t, fixture, openAIWithoutModels.ID, models.CredentialStatusActive, nil),
 		createGroupCollectionKey(t, fixture, disabled.ID, models.CredentialStatusActive, nil),
 	})
 
@@ -44,6 +48,7 @@ func TestGetGroupSummaryUsesCollectionServiceStatusAndOnlyReturnsHeaderCounts(t 
 	}{
 		{name: "available", groupID: available.ID, wantStatus: GroupCollectionStatusAvailable, wantKeys: 1},
 		{name: "unavailable without models", groupID: unavailable.ID, wantStatus: GroupCollectionStatusUnavailable, wantReason: GroupUnavailableReasonNoModels, wantKeys: 1},
+		{name: "OpenAI unavailable without models", groupID: openAIWithoutModels.ID, wantStatus: GroupCollectionStatusUnavailable, wantReason: GroupUnavailableReasonNoModels, wantKeys: 1},
 		{name: "disabled", groupID: disabled.ID, wantStatus: GroupCollectionStatusDisabled, wantKeys: 1},
 		{name: "unavailable without credentials", groupID: noCredentials.ID, wantStatus: GroupCollectionStatusUnavailable, wantReason: GroupUnavailableReasonNoAvailableCredentials, wantKeys: 0},
 	} {

--- a/internal/gateway/request_log_test.go
+++ b/internal/gateway/request_log_test.go
@@ -264,7 +264,7 @@ func TestHandlerRecordsProtocolOnlyResponsesResourceWithoutFabricatingModels(t *
 	if _, err := manager.Publish(state.CompileInput{
 		ChannelRegistry: channel.NewRegistry(),
 		Groups: []state.GroupConfig{{ConnectionType: "api_key", ID: 1, Name: "responses", ChannelID: channel.OpenAI,
-			Params: json.RawMessage(`{}`), Enabled: true,
+			Params: json.RawMessage(`{}`), Models: []state.ModelConfig{{ID: "gpt-resource"}}, Enabled: true,
 		}},
 		Credentials: []state.CredentialConfig{testCredentialConfig(1, 1)},
 		AccessKeys: []state.AccessKeyConfig{{
@@ -300,6 +300,58 @@ func TestHandlerRecordsProtocolOnlyResponsesResourceWithoutFabricatingModels(t *
 			CostState: "not_applicable", PricingCompleteness: "not_applicable",
 		}) {
 		t.Fatalf("event = %#v", event)
+	}
+}
+
+func TestHandlerRejectsResponsesResourceWhenGroupHasNoModels(t *testing.T) {
+	forwarder := &scriptedForwarder{}
+	sink := &recordingRequestLogSink{}
+	engine, handler, manager, _ := newRequestLogHandlerTestRuntime(
+		t,
+		forwarder,
+		&recordingAccessKeyRPMLimiter{},
+		sink,
+		"sk-first",
+	)
+	if _, err := manager.Publish(state.CompileInput{
+		ChannelRegistry: channel.NewRegistry(),
+		Groups: []state.GroupConfig{{ConnectionType: "api_key", ID: 1, Name: "responses", ChannelID: channel.OpenAI,
+			Params: json.RawMessage(`{}`), Enabled: true,
+		}},
+		Credentials: []state.CredentialConfig{testCredentialConfig(1, 1)},
+		AccessKeys: []state.AccessKeyConfig{{
+			ID:      1,
+			Name:    "client",
+			KeyHash: handler.encryption.Hash("gl-client"),
+			Status:  state.AccessKeyStatusActive,
+		}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	handler.dialects = dialect.NewSet(dialect.NewOpenAIResponses())
+
+	request := httptest.NewRequest(http.MethodGet, "/v1/responses/resp_123", nil)
+	request.Header.Set("Authorization", "Bearer gl-client")
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, request)
+
+	var body struct {
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	events := sink.snapshot()
+	if response.Code != http.StatusServiceUnavailable || body.Code != reasonNoCandidate.Code ||
+		len(forwarder.inputs) != 0 || len(events) != 1 || len(events[0].Attempts) != 0 {
+		t.Fatalf(
+			"response/code/attempts/events = %d/%q/%d/%#v, want 503/%q/0/one event without attempts",
+			response.Code,
+			body.Code,
+			len(forwarder.inputs),
+			events,
+			reasonNoCandidate.Code,
+		)
 	}
 }
 

--- a/internal/scheduler/channel_scheduler_test.go
+++ b/internal/scheduler/channel_scheduler_test.go
@@ -111,7 +111,7 @@ func TestIteratorSkipGroupAndAllowedCredentialIDsApplyAcrossRouteTiers(t *testin
 	}
 }
 
-func TestIteratorRoutesModelLessResponsesResourceOperation(t *testing.T) {
+func TestIteratorRejectsResponsesResourceOperationWithoutConfiguredModels(t *testing.T) {
 	t.Parallel()
 
 	snapshot, err := state.Compile(state.CompileInput{
@@ -123,17 +123,16 @@ func TestIteratorRoutesModelLessResponsesResourceOperation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Compile() error = %v", err)
 	}
-	selection, err := New(snapshot, fakeCredentialSource{keys: []state.CredentialMeta{{ID: 71, GroupID: 7}}}, Query{
+	iterator := New(snapshot, fakeCredentialSource{keys: []state.CredentialMeta{{ID: 71, GroupID: 7}}}, Query{
 		ClientProtocol: protocol.OpenAIResponses,
 		Operation:      execution.OperationResponsesRetrieve,
 		ExternalModel:  nil,
-	}, rand.New(zeroRandSource{})).Next()
-	if err != nil {
-		t.Fatalf("Next() error = %v", err)
+	}, rand.New(zeroRandSource{}))
+	if iterator.StaticReason() != ReasonNoRouteTarget {
+		t.Fatalf("StaticReason() = %q, want %q", iterator.StaticReason(), ReasonNoRouteTarget)
 	}
-	if selection.CredentialID != 71 || selection.GroupID != 7 || selection.UpstreamModelID != nil ||
-		selection.RouteMode != channel.RouteNative {
-		t.Fatalf("Selection = %#v", selection)
+	if _, err := iterator.Next(); !errors.Is(err, ErrExhausted) {
+		t.Fatalf("Next() error = %v, want ErrExhausted", err)
 	}
 }
 
@@ -169,7 +168,7 @@ func TestCandidateGroupIDsForQueryUsesExecutionRoutesAndAccessKeyFilters(t *test
 	}
 }
 
-func TestCandidateGroupIDsForQuerySupportsModelLessResourceOperation(t *testing.T) {
+func TestCandidateGroupIDsForQueryRejectsResourceOperationWithoutConfiguredModels(t *testing.T) {
 	t.Parallel()
 
 	snapshot, err := state.Compile(state.CompileInput{
@@ -193,8 +192,8 @@ func TestCandidateGroupIDsForQuerySupportsModelLessResourceOperation(t *testing.
 		ExternalModel:    nil,
 		AccessKey:        state.AccessKeyView{Status: state.AccessKeyStatusActive},
 	})
-	if !slices.Equal(got, []uint{7}) {
-		t.Fatalf("CandidateGroupIDsForQuery() = %#v, want native Responses group [7]", got)
+	if len(got) != 0 {
+		t.Fatalf("CandidateGroupIDsForQuery() = %#v, want none", got)
 	}
 }
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -100,7 +100,7 @@ func TestFilterTargetsSkipsCandidateWithoutGroupView(t *testing.T) {
 	}
 }
 
-func TestIteratorSelectsProtocolOnlyGroupWithoutModel(t *testing.T) {
+func TestIteratorRejectsProtocolOnlyGroupWithoutConfiguredModels(t *testing.T) {
 	t.Parallel()
 
 	snapshot, err := state.Compile(state.CompileInput{
@@ -116,7 +116,7 @@ func TestIteratorSelectsProtocolOnlyGroupWithoutModel(t *testing.T) {
 		ID: 71, GroupID: 7, WeightAuto: state.DefaultWeight,
 	}}}
 
-	selection, err := New(
+	iterator := New(
 		snapshot,
 		source,
 		Query{
@@ -128,13 +128,12 @@ func TestIteratorSelectsProtocolOnlyGroupWithoutModel(t *testing.T) {
 			},
 		},
 		rand.New(zeroRandSource{}),
-	).Next()
-	if err != nil {
-		t.Fatalf("Next() error = %v", err)
+	)
+	if iterator.StaticReason() != ReasonNoRouteTarget {
+		t.Fatalf("StaticReason() = %q, want %q", iterator.StaticReason(), ReasonNoRouteTarget)
 	}
-	if selection.GroupID != 7 || selection.CredentialID != 71 ||
-		selection.UpstreamModelID != nil {
-		t.Fatalf("Selection = %#v, want protocol-only group/key and nil model", selection)
+	if _, err := iterator.Next(); !errors.Is(err, ErrExhausted) {
+		t.Fatalf("Next() error = %v, want ErrExhausted", err)
 	}
 }
 

--- a/internal/state/channel_snapshot_test.go
+++ b/internal/state/channel_snapshot_test.go
@@ -94,7 +94,7 @@ func TestCompileSelectsNativeVertexGeminiModePerModel(t *testing.T) {
 	}
 }
 
-func TestCompileIndexesNativeResponsesResourceOperationsWithoutModels(t *testing.T) {
+func TestCompileDoesNotIndexResponsesResourceOperationsWithoutModels(t *testing.T) {
 	t.Parallel()
 
 	snapshot, err := Compile(CompileInput{
@@ -113,14 +113,16 @@ func TestCompileIndexesNativeResponsesResourceOperationsWithoutModels(t *testing
 		execution.OperationResponsesDelete,
 		execution.OperationResponsesCancel,
 		execution.OperationResponsesInputItems,
+		execution.OperationResponsesPassthrough,
 	} {
-		got := snapshot.ExecutionCandidates[protocol.OpenAIResponses][operation][NoModelRouteKey]
-		if len(got) != 1 || got[0].GroupID != 1 || got[0].Mode != channel.RouteNative {
-			t.Errorf("resource candidates for %q = %#v, want native OpenAI only", operation, got)
+		for name, index := range map[string]ExecutionCandidateIndex{
+			"execution candidates": snapshot.ExecutionCandidates,
+			"route catalog":        snapshot.ExecutionRouteCatalog,
+		} {
+			if got := index[protocol.OpenAIResponses][operation][NoModelRouteKey]; len(got) != 0 {
+				t.Errorf("%s for %q = %#v, want none", name, operation, got)
+			}
 		}
-	}
-	if got := snapshot.ExecutionCandidates[protocol.OpenAIResponses][execution.OperationResponsesCreate]; len(got) != 0 {
-		t.Fatalf("model-less Responses create candidates = %#v, want none", got)
 	}
 }
 
@@ -139,6 +141,19 @@ func TestCompileIndexesAllNativeResponsesExtensions(t *testing.T) {
 	}
 
 	for _, operation := range []execution.Operation{
+		execution.OperationResponsesRetrieve,
+		execution.OperationResponsesDelete,
+		execution.OperationResponsesCancel,
+		execution.OperationResponsesInputItems,
+		execution.OperationResponsesPassthrough,
+	} {
+		got := snapshot.ExecutionCandidates[protocol.OpenAIResponses][operation][NoModelRouteKey]
+		if len(got) != 1 || got[0].GroupID != 1 || got[0].Mode != channel.RouteNative {
+			t.Errorf("resource candidates for %q = %#v, want native OpenAI only", operation, got)
+		}
+	}
+
+	for _, operation := range []execution.Operation{
 		execution.OperationResponsesCompact,
 		execution.OperationResponsesInputTokens,
 	} {
@@ -148,10 +163,6 @@ func TestCompileIndexesAllNativeResponsesExtensions(t *testing.T) {
 		}
 	}
 
-	noModel := snapshot.ExecutionCandidates[protocol.OpenAIResponses][execution.OperationResponsesPassthrough][NoModelRouteKey]
-	if len(noModel) != 1 || noModel[0].GroupID != 1 {
-		t.Fatalf("model-less passthrough candidates = %#v", noModel)
-	}
 	withModel := snapshot.ExecutionCandidates[protocol.OpenAIResponses][execution.OperationResponsesPassthrough]["public"]
 	if len(withModel) != 1 || withModel[0].UpstreamModelID != "official-upstream" {
 		t.Fatalf("model passthrough candidates = %#v", withModel)

--- a/internal/state/snapshot.go
+++ b/internal/state/snapshot.go
@@ -288,6 +288,10 @@ func appendExecutionTargets(
 	if !ok {
 		return fmt.Errorf("compile group %d channel: unknown channel %q", group.ID, group.ChannelID)
 	}
+	// 模型配置是分组进入数据面调度的统一门槛；无模型资源请求也不能绕过。
+	if len(group.Models) == 0 {
+		return nil
+	}
 	for _, clientProtocol := range descriptor.ClientProtocols {
 		for _, operation := range target.Operations(clientProtocol) {
 			if operation == execution.OperationListModels || operation == execution.OperationProbe {


### PR DESCRIPTION
### 关联 Issue / Related Issue

无 / None

### 变更内容 / Change Content

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

- 统一 Group 可用性规则：所有渠道只要未配置模型，均返回不可用并标记 `no_models`。
- 将模型配置作为数据面调度的统一门槛，阻止零模型 Group 进入 OpenAI Responses 资源请求候选集。
- 保留已配置模型 Group 对不携带模型的 Responses 资源请求支持，不改变凭据健康、权重、重试和执行逻辑。
- 兼容性影响：零模型 OpenAI Group 不再处理 Retrieve、Delete、Cancel、Input Items 和 Passthrough 请求；无需数据迁移。

### 自查清单 / Checklist

- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.