### PR TITLE
fix(settings): 复用更新检查缓存

### DIFF
--- a/web/src/features/settings/SystemInfoSection.vue
+++ b/web/src/features/settings/SystemInfoSection.vue
@@ -13,7 +13,11 @@ import {
   type DatabaseDriver,
   type SecretSource,
 } from '@/app/resources/system-info'
-import { getSystemUpdate, type ReleaseUpdateDto } from '@/app/resources/system-update'
+import {
+  getSystemUpdate,
+  systemUpdateQueryOptions,
+  type ReleaseUpdateDto,
+} from '@/app/resources/system-update'
 import AppButton from '@/components/ui/AppButton.vue'
 import CopyButton from '@/components/ui/CopyButton.vue'
 import AsyncRefreshIndicator from '@/components/ui/AsyncRefreshIndicator.vue'
@@ -32,14 +36,20 @@ const initialLoading = useStableLoading(
 const infoRefreshing = computed(
   () => infoQuery.data.value !== undefined && infoQuery.isFetching.value,
 )
+const updateQuery = useQuery(systemUpdateQueryOptions(client))
 type UpdateCheckState =
   | { kind: 'checking' }
   | { kind: 'latest' }
   | { kind: 'available'; update: ReleaseUpdateDto }
   | { kind: 'failed' }
 
-const updateCheck = ref<UpdateCheckState | null>(null)
+const manualUpdateCheck = ref<UpdateCheckState | null>(null)
 const updateCheckPending = ref(false)
+const updateCheck = computed<UpdateCheckState | null>(() => {
+  if (manualUpdateCheck.value) return manualUpdateCheck.value
+  const update = updateQuery.data.value?.update
+  return update ? { kind: 'available', update } : null
+})
 const updateCheckTone = computed<'info' | 'success' | 'warning' | 'danger'>(() => {
   switch (updateCheck.value?.kind) {
     case 'latest':
@@ -64,21 +74,21 @@ function databaseLabel(database: DatabaseDriver): string {
 async function checkForUpdate(): Promise<void> {
   if (updateCheckPending.value) return
   updateCheckPending.value = true
-  updateCheck.value = { kind: 'checking' }
+  manualUpdateCheck.value = { kind: 'checking' }
   try {
     const result = await getSystemUpdate(client, undefined, true)
     queryClient.setQueryData(controlQueryKeys.systemUpdate(), result)
-    updateCheck.value = result.update
+    manualUpdateCheck.value = result.update
       ? { kind: 'available', update: result.update }
       : { kind: 'latest' }
   } catch (error) {
     if (error instanceof RequestCancelledError) {
-      updateCheck.value = null
+      manualUpdateCheck.value = null
       return
     }
     // 后端失败时会清空更新结果；同步前端查询缓存，避免继续显示旧提示。
     queryClient.setQueryData(controlQueryKeys.systemUpdate(), { update: null })
-    updateCheck.value = { kind: 'failed' }
+    manualUpdateCheck.value = { kind: 'failed' }
   } finally {
     updateCheckPending.value = false
   }


### PR DESCRIPTION
### 关联 Issue / Related Issue
无 / None

### 变更内容 / Change Content
- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

设置页现在复用首页的非强制更新查询与缓存结果；检测到新版本时会直接显示提示。手动“检查更新”仍使用强制检查，不受缓存限制。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.

不涉及公开文档、兼容性或数据迁移变更。