### PR TITLE
fix(stream): 修复订阅流组帧并收口响应头

### DIFF
--- a/internal/execution/cpa/adapter.go
+++ b/internal/execution/cpa/adapter.go
@@ -26,17 +26,15 @@ import (
 	"gpt-load/internal/usage"
 )
 
-var convertedRepresentationHeaderNames = [...]string{
-	"Content-Encoding",
-	"Content-Length",
-	"ETag",
-	"Digest",
-	"Content-MD5",
-	"Content-Range",
-	"Content-Digest",
-	"Repr-Digest",
-	"Signature",
-	"Signature-Input",
+var subscriptionResponseHeaderNames = [...]string{
+	"Request-Id",
+	"X-Request-Id",
+	"Openai-Request-Id",
+	"X-Oai-Request-Id",
+	"Anthropic-Request-Id",
+	"X-Goog-Request-Id",
+	"X-Amzn-Requestid",
+	"Retry-After",
 }
 
 type Adapter struct {
@@ -181,8 +179,9 @@ func unaryProviderSuccess(
 	response providerResponse,
 ) execution.AttemptResult {
 	body := append([]byte(nil), response.Payload...)
-	headers := convertedResponseHeaders(response.Headers, "application/json")
+	headers := subscriptionResponseHeaders(response.Headers, "application/json")
 	if response.Local {
+		headers.Set(localTokenCountHeader, "local-estimate")
 		return execution.AttemptResult{
 			DispatchState: execution.DispatchLocal, ResponseStarted: true,
 			StatusCode: http.StatusOK, Header: headers, Body: body,
@@ -245,14 +244,48 @@ func (a *Adapter) ExecuteStream(ctx context.Context, spec execution.AttemptSpec,
 		}
 	}
 	applied := appliedReasoning(response.AppliedReasoningEffort)
-	headers := convertedResponseHeaders(response.Headers, "text/event-stream")
+	headers := subscriptionResponseHeaders(response.Headers, "text/event-stream")
 	sequence := uint64(1)
 	ready := false
+	upstreamStarted := false
 	openAIDone := false
 	geminiTerminal := false
+	var nativeResponsesAssembler *nativeResponsesSSEAssembler
+	if spec.ClientProtocol == protocol.OpenAIResponses && spec.RouteMode == execution.RouteNative {
+		nativeResponsesAssembler = &nativeResponsesSSEAssembler{}
+	}
+	emitPayloads := func(payloads [][]byte) *execution.StreamResult {
+		for _, unframed := range payloads {
+			payload := frameSSE(spec.ClientProtocol, unframed)
+			payload, rewriteErr := rewriteStreamModelAlias(spec, payload)
+			if rewriteErr != nil {
+				failure := streamInternalError(provider.UpstreamProtocol(), headers, applied, "rewrite subscription response model", ready)
+				return &failure
+			}
+			if spec.ClientProtocol == protocol.OpenAICompletions && isOpenAIDone(payload) {
+				openAIDone = true
+			}
+			if spec.ClientProtocol == protocol.Gemini && isGeminiTerminal(payload) {
+				geminiTerminal = true
+			}
+			if !ready {
+				if err := sink(execution.StreamEvent{Kind: execution.StreamEventReady, Sequence: sequence, StatusCode: http.StatusOK, Header: headers}); err != nil {
+					failure := streamConsumerStopped(provider.UpstreamProtocol(), headers, applied, false)
+					return &failure
+				}
+				ready = true
+			}
+			sequence++
+			if err := sink(execution.StreamEvent{Kind: execution.StreamEventData, Sequence: sequence, Data: payload}); err != nil {
+				failure := streamConsumerStopped(provider.UpstreamProtocol(), headers, applied, ready)
+				return &failure
+			}
+		}
+		return nil
+	}
 	for {
 		idleTimeout := spec.Timeouts.StreamIdle
-		if !ready {
+		if !ready && !upstreamStarted {
 			idleTimeout = 0
 		}
 		chunk, ok, idleErr := nextChunk(streamCtx, response.Chunks, idleTimeout)
@@ -262,6 +295,15 @@ func (a *Adapter) ExecuteStream(ctx context.Context, spec execution.AttemptSpec,
 		if !ok {
 			if err := context.Cause(streamCtx); err != nil {
 				return streamExecutionError(streamCtx, provider, headers, err, credential, applied, ready)
+			}
+			if nativeResponsesAssembler != nil {
+				payloads, finishErr := nativeResponsesAssembler.finish()
+				if finishErr != nil {
+					return streamInternalError(provider.UpstreamProtocol(), headers, applied, "invalid subscription SSE stream", ready)
+				}
+				if failure := emitPayloads(payloads); failure != nil {
+					return *failure
+				}
 			}
 			if !ready {
 				return streamInternalError(provider.UpstreamProtocol(), headers, applied, "subscription upstream stream ended without data", false)
@@ -283,33 +325,22 @@ func (a *Adapter) ExecuteStream(ctx context.Context, spec execution.AttemptSpec,
 		if chunk.Err != nil {
 			return streamExecutionError(streamCtx, provider, headers, chunk.Err, credential, applied, ready)
 		}
-		if len(chunk.Payload) == 0 {
-			continue
+		if len(chunk.Payload) > 0 {
+			firstByte.stop()
+			upstreamStarted = true
 		}
-		firstByte.stop()
 		if err := context.Cause(streamCtx); err != nil {
 			return streamExecutionError(streamCtx, provider, headers, err, credential, applied, false)
 		}
-		payload := frameSSE(spec.ClientProtocol, chunk.Payload)
-		payload, rewriteErr := rewriteStreamModelAlias(spec, payload)
-		if rewriteErr != nil {
-			return streamInternalError(provider.UpstreamProtocol(), headers, applied, "rewrite subscription response model", ready)
-		}
-		if spec.ClientProtocol == protocol.OpenAICompletions && isOpenAIDone(payload) {
-			openAIDone = true
-		}
-		if spec.ClientProtocol == protocol.Gemini && isGeminiTerminal(payload) {
-			geminiTerminal = true
-		}
-		if !ready {
-			if err := sink(execution.StreamEvent{Kind: execution.StreamEventReady, Sequence: sequence, StatusCode: http.StatusOK, Header: headers}); err != nil {
-				return streamConsumerStopped(provider.UpstreamProtocol(), headers, applied, false)
+		payloads := [][]byte{chunk.Payload}
+		if nativeResponsesAssembler != nil {
+			payloads, err = nativeResponsesAssembler.push(chunk.Payload)
+			if err != nil {
+				return streamInternalError(provider.UpstreamProtocol(), headers, applied, "invalid subscription SSE stream", ready)
 			}
-			ready = true
 		}
-		sequence++
-		if err := sink(execution.StreamEvent{Kind: execution.StreamEventData, Sequence: sequence, Data: payload}); err != nil {
-			return streamConsumerStopped(provider.UpstreamProtocol(), headers, applied, ready)
+		if failure := emitPayloads(payloads); failure != nil {
+			return *failure
 		}
 	}
 }
@@ -381,19 +412,32 @@ func formatFor(clientProtocol protocol.Protocol) string {
 	}
 }
 
-func convertedResponseHeaders(source http.Header, contentType string) http.Header {
-	headers := source.Clone()
-	if headers == nil {
-		headers = make(http.Header)
-	}
-	for _, name := range convertedRepresentationHeaderNames {
-		for key := range headers {
-			if strings.EqualFold(key, name) {
-				delete(headers, key)
+func subscriptionResponseHeaders(source http.Header, contentType string) http.Header {
+	headers := make(http.Header)
+	for actualName, values := range source {
+		allowed := false
+		for _, name := range subscriptionResponseHeaderNames {
+			if strings.EqualFold(actualName, name) {
+				allowed = true
+				break
 			}
+		}
+		if !allowed {
+			continue
+		}
+		for _, value := range values {
+			headers.Add(actualName, value)
 		}
 	}
 	headers.Set("Content-Type", contentType)
+	if contentType == "text/event-stream" {
+		headers.Set("Cache-Control", "no-cache")
+	}
+	if headers.Get("X-Request-Id") == "" {
+		if requestID := upstreamRequestID(headers); requestID != "" {
+			headers.Set("X-Request-Id", requestID)
+		}
+	}
 	return headers
 }
 
@@ -691,10 +735,20 @@ func usageEvidence(clientProtocol protocol.Protocol, body []byte) *execution.Usa
 }
 
 func upstreamRequestID(headers http.Header) string {
-	if value := headers.Get("X-Request-Id"); value != "" {
-		return value
+	for _, name := range []string{
+		"X-Request-Id",
+		"Request-Id",
+		"Openai-Request-Id",
+		"X-Oai-Request-Id",
+		"Anthropic-Request-Id",
+		"X-Goog-Request-Id",
+		"X-Amzn-Requestid",
+	} {
+		if value := headers.Get(name); value != "" {
+			return value
+		}
 	}
-	return headers.Get("Request-Id")
+	return ""
 }
 
 func withRequestTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {

--- a/internal/execution/cpa/adapter.go
+++ b/internal/execution/cpa/adapter.go
@@ -325,6 +325,9 @@ func (a *Adapter) ExecuteStream(ctx context.Context, spec execution.AttemptSpec,
 		if chunk.Err != nil {
 			return streamExecutionError(streamCtx, provider, headers, chunk.Err, credential, applied, ready)
 		}
+		if len(chunk.Payload) == 0 && nativeResponsesAssembler == nil {
+			continue
+		}
 		if len(chunk.Payload) > 0 {
 			firstByte.stop()
 			upstreamStarted = true

--- a/internal/execution/cpa/adapter_test.go
+++ b/internal/execution/cpa/adapter_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -210,6 +211,44 @@ func TestAdapterExecutesEverySupportedClientProtocolThroughCPA(t *testing.T) {
 	}
 }
 
+func TestSubscriptionResponseHeadersUseAllowlist(t *testing.T) {
+	source := http.Header{
+		"Content-Type":                         {"application/upstream"},
+		"X-Oai-Request-Id":                     {"oai-request-1"},
+		"Retry-After":                          {"3"},
+		"X-Codex-Turn-State":                   {"private-state"},
+		"X-Codex-Plan-Type":                    {"pro"},
+		"X-Codex-Primary-Used-Percent":         {"11"},
+		"X-Models-Etag":                        {"private-model-cache"},
+		"X-Openai-Proxy-Wasm":                  {"v0.1"},
+		"Cf-Ray":                               {"edge-trace"},
+		"Nel":                                  {`{"success_fraction":0.01}`},
+		"Report-To":                            {`{"group":"cf-nel"}`},
+		"Cross-Origin-Opener-Policy":           {"same-origin-allow-popups"},
+		"Referrer-Policy":                      {"strict-origin-when-cross-origin"},
+		"Strict-Transport-Security":            {"max-age=31536000"},
+		"Access-Control-Allow-Origin":          {"*"},
+		"Access-Control-Allow-Credentials":     {"true"},
+		"Access-Control-Expose-Headers":        {"X-Oai-Request-Id"},
+		"Access-Control-Allow-Private-Network": {"true"},
+	}
+	original := source.Clone()
+
+	headers := subscriptionResponseHeaders(source, "text/event-stream")
+	if !reflect.DeepEqual(headers, http.Header{
+		"Content-Type":     {"text/event-stream"},
+		"Cache-Control":    {"no-cache"},
+		"X-Oai-Request-Id": {"oai-request-1"},
+		"X-Request-Id":     {"oai-request-1"},
+		"Retry-After":      {"3"},
+	}) {
+		t.Fatalf("subscription response headers = %#v", headers)
+	}
+	if !reflect.DeepEqual(source, original) {
+		t.Fatalf("subscriptionResponseHeaders() mutated source: got %#v, want %#v", source, original)
+	}
+}
+
 func TestAdapterCountsCodexTokensForEverySupportedProtocol(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -389,7 +428,7 @@ func TestAdapterStreamsEverySupportedClientProtocolThroughCPA(t *testing.T) {
 		{
 			name: "OpenAI Responses", protocol: protocol.OpenAIResponses, operation: execution.OperationResponsesCreate,
 			wantFormat: "openai-response", wantAPI: protocol.OpenAIResponses,
-			payload:  `data: {"type":"response.completed","response":{"id":"resp_1"}}`,
+			payload:  `data: {"type":"response.completed","response":{"id":"resp_1"}}` + "\n\n",
 			wantData: []string{`data: {"type":"response.completed","response":{"id":"resp_1"}}` + "\n\n"},
 		},
 		{
@@ -437,6 +476,60 @@ func TestAdapterStreamsEverySupportedClientProtocolThroughCPA(t *testing.T) {
 				t.Fatalf("stream data = %q, want %q", data, test.wantData)
 			}
 		})
+	}
+}
+
+func TestAdapterGroupsNativeResponsesSSELinesIntoCompleteEvents(t *testing.T) {
+	adapter, _, _, keyService, row := newAdapterFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
+	chunks := make(chan codex.ExecuteStreamChunk, 5)
+	for _, payload := range []string{
+		"event: response.created",
+		`data: {"type":"response.created","response":{"id":"resp_1","model":"gpt-5"}}`,
+		"",
+		"event: response.completed",
+		`data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt-5"}}`,
+	} {
+		chunks <- codex.ExecuteStreamChunk{Payload: []byte(payload)}
+	}
+	close(chunks)
+	setCodexExecutor(t, adapter, &fakeExecutor{stream: &codex.ExecuteStreamResponse{
+		Headers: http.Header{
+			"X-Oai-Request-Id":   {"oai-request-1"},
+			"X-Codex-Turn-State": {"private-state"},
+		},
+		Chunks: chunks,
+	}})
+
+	var data []string
+	var readyHeader http.Header
+	result := adapter.ExecuteStream(t.Context(), validSpec(t, row, keyService), func(event execution.StreamEvent) error {
+		if event.Kind == execution.StreamEventReady {
+			readyHeader = event.Header.Clone()
+		}
+		if event.Kind == execution.StreamEventData {
+			data = append(data, string(event.Data))
+		}
+		return nil
+	})
+	if result.Error != nil {
+		t.Fatalf("ExecuteStream() error = %#v", result.Error)
+	}
+	if readyHeader.Get("X-Request-Id") != "oai-request-1" ||
+		readyHeader.Get("Cache-Control") != "no-cache" ||
+		readyHeader.Values("X-Codex-Turn-State") != nil {
+		t.Fatalf("ready headers = %#v", readyHeader)
+	}
+	want := []string{
+		"event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5\"}}\n\n",
+		"event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5\"}}\n\n",
+	}
+	if len(data) != len(want) {
+		t.Fatalf("stream data events = %q, want %q", data, want)
+	}
+	for index := range want {
+		if data[index] != want[index] {
+			t.Fatalf("stream data event %d = %q, want %q", index, data[index], want[index])
+		}
 	}
 }
 
@@ -490,7 +583,7 @@ func TestAdapterUsesFirstByteTimeoutBeforeFirstData(t *testing.T) {
 func TestAdapterSwitchesToStreamIdleTimeoutAfterFirstData(t *testing.T) {
 	adapter, _, _, keyService, row := newAdapterFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
 	chunks := make(chan codex.ExecuteStreamChunk, 1)
-	chunks <- codex.ExecuteStreamChunk{Payload: []byte(`data: {"type":"response.created","response":{"id":"resp_1"}}`)}
+	chunks <- codex.ExecuteStreamChunk{Payload: []byte("data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\"}}\n\n")}
 	setCodexExecutor(t, adapter, &fakeExecutor{stream: &codex.ExecuteStreamResponse{Chunks: chunks}})
 	spec := validSpec(t, row, keyService)
 	spec.Timeouts.FirstByte = 200 * time.Millisecond
@@ -507,6 +600,30 @@ func TestAdapterSwitchesToStreamIdleTimeoutAfterFirstData(t *testing.T) {
 	}
 	if len(events) != 2 || events[0].Kind != execution.StreamEventReady || events[1].Kind != execution.StreamEventData {
 		t.Fatalf("events = %#v", events)
+	}
+}
+
+func TestAdapterUsesStreamIdleTimeoutBetweenNativeResponsesLines(t *testing.T) {
+	adapter, _, _, keyService, row := newAdapterFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
+	chunks := make(chan codex.ExecuteStreamChunk, 1)
+	chunks <- codex.ExecuteStreamChunk{Payload: []byte("event: response.created")}
+	setCodexExecutor(t, adapter, &fakeExecutor{stream: &codex.ExecuteStreamResponse{Chunks: chunks}})
+	spec := validSpec(t, row, keyService)
+	spec.Timeouts.FirstByte = 200 * time.Millisecond
+	spec.Timeouts.StreamIdle = 20 * time.Millisecond
+	spec.Timeouts.Request = time.Second
+
+	started := time.Now()
+	var events []execution.StreamEvent
+	result := adapter.ExecuteStream(t.Context(), spec, func(event execution.StreamEvent) error {
+		events = append(events, event.Clone())
+		return nil
+	})
+	if elapsed := time.Since(started); elapsed >= 150*time.Millisecond {
+		t.Fatalf("stream idle timeout between SSE lines took %s", elapsed)
+	}
+	if result.Error == nil || result.Error.Kind != execution.ErrorKindTimeout || result.ResponseStarted || len(events) != 0 {
+		t.Fatalf("result = %#v, events = %#v", result, events)
 	}
 }
 
@@ -537,7 +654,7 @@ func TestAdapterRewritesStreamModelAliasForEveryProtocol(t *testing.T) {
 		payload   string
 	}{
 		{name: "OpenAI Chat", protocol: protocol.OpenAICompletions, operation: execution.OperationChatCompletion, payload: `{"model":"upstream-model","choices":[{"finish_reason":"stop"}]}`},
-		{name: "OpenAI Responses", protocol: protocol.OpenAIResponses, operation: execution.OperationResponsesCreate, payload: `data: {"type":"response.completed","response":{"model":"upstream-model"}}`},
+		{name: "OpenAI Responses", protocol: protocol.OpenAIResponses, operation: execution.OperationResponsesCreate, payload: "data: {\"type\":\"response.completed\",\"response\":{\"model\":\"upstream-model\"}}\n\n"},
 		{name: "Anthropic", protocol: protocol.Anthropic, operation: execution.OperationChatCompletion, payload: "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"model\":\"upstream-model\"}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}"},
 		{name: "Gemini", protocol: protocol.Gemini, operation: execution.OperationChatCompletion, payload: `{"modelVersion":"upstream-model","candidates":[{"finishReason":"STOP"}]}`},
 	}
@@ -671,6 +788,12 @@ func TestAdapterStreamsRealCPAResponsesAsCompleteClientSSE(t *testing.T) {
 		wantTerminal string
 	}{
 		{
+			name: "OpenAI Responses", protocol: protocol.OpenAIResponses,
+			body:         `{"model":"gpt-5.6-luna","input":"hello","stream":true}`,
+			wantFragment: "event: response.output_text.delta\ndata: ",
+			wantTerminal: "\n\n",
+		},
+		{
 			name: "OpenAI Chat", protocol: protocol.OpenAICompletions,
 			body:         `{"model":"gpt-5.6-luna","messages":[{"role":"user","content":"hello"}],"stream":true}`,
 			wantFragment: `"object":"chat.completion.chunk"`,
@@ -695,9 +818,9 @@ func TestAdapterStreamsRealCPAResponsesAsCompleteClientSSE(t *testing.T) {
 					Status:     "200 OK",
 					Header:     http.Header{"Content-Type": {"text/event-stream"}},
 					Body: io.NopCloser(strings.NewReader(strings.Join([]string{
-						`data: {"type":"response.created","response":{"id":"resp_1","object":"response","status":"in_progress","created_at":1,"model":"gpt-5.6-luna","output":[]}}`,
-						`data: {"type":"response.output_text.delta","response_id":"resp_1","output_index":0,"item_id":"msg_1","content_index":0,"delta":"hello"}`,
-						`data: {"type":"response.completed","response":{"id":"resp_1","object":"response","status":"completed","model":"gpt-5.6-luna","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`,
+						"event: response.created\n" + `data: {"type":"response.created","response":{"id":"resp_1","object":"response","status":"in_progress","created_at":1,"model":"gpt-5.6-luna","output":[]}}`,
+						"event: response.output_text.delta\n" + `data: {"type":"response.output_text.delta","response_id":"resp_1","output_index":0,"item_id":"msg_1","content_index":0,"delta":"hello"}`,
+						"event: response.completed\n" + `data: {"type":"response.completed","response":{"id":"resp_1","object":"response","status":"completed","model":"gpt-5.6-luna","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`,
 					}, "\n\n") + "\n\n")),
 					Request: request,
 				}, nil
@@ -705,8 +828,13 @@ func TestAdapterStreamsRealCPAResponsesAsCompleteClientSSE(t *testing.T) {
 			ctx := context.WithValue(t.Context(), "cliproxy.roundtripper", http.RoundTripper(transport))
 			spec := validSpec(t, row, keyService)
 			spec.ClientProtocol = test.protocol
-			spec.Operation = execution.OperationChatCompletion
-			spec.RouteMode = execution.RouteConverted
+			if test.protocol == protocol.OpenAIResponses {
+				spec.Operation = execution.OperationResponsesCreate
+				spec.RouteMode = execution.RouteNative
+			} else {
+				spec.Operation = execution.OperationChatCompletion
+				spec.RouteMode = execution.RouteConverted
+			}
 			spec.UpstreamModel = "gpt-5.6-luna"
 			spec.ClientModel = "gpt-5.6-luna"
 			spec.Body = []byte(test.body)
@@ -714,7 +842,11 @@ func TestAdapterStreamsRealCPAResponsesAsCompleteClientSSE(t *testing.T) {
 			var wire strings.Builder
 			result := adapter.ExecuteStream(ctx, spec, func(event execution.StreamEvent) error {
 				if event.Kind == execution.StreamEventData {
-					if !bytes.HasPrefix(event.Data, []byte("data:")) {
+					wantPrefix := []byte("data:")
+					if test.protocol == protocol.OpenAIResponses {
+						wantPrefix = []byte("event:")
+					}
+					if !bytes.HasPrefix(event.Data, wantPrefix) {
 						t.Errorf("unframed client event = %q", event.Data)
 					}
 					_, _ = wire.Write(event.Data)
@@ -727,6 +859,10 @@ func TestAdapterStreamsRealCPAResponsesAsCompleteClientSSE(t *testing.T) {
 			if !strings.Contains(wire.String(), test.wantFragment) || !strings.HasSuffix(wire.String(), test.wantTerminal) {
 				t.Fatalf("client wire = %q", wire.String())
 			}
+			if test.protocol == protocol.OpenAIResponses &&
+				!strings.Contains(wire.String(), "event: response.completed\ndata: ") {
+				t.Fatalf("Responses terminal event is incomplete: %q", wire.String())
+			}
 		})
 	}
 }
@@ -734,7 +870,7 @@ func TestAdapterStreamsRealCPAResponsesAsCompleteClientSSE(t *testing.T) {
 func TestAdapterStreamsReadyThenFramedData(t *testing.T) {
 	adapter, _, _, keyService, row := newAdapterFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
 	chunks := make(chan codex.ExecuteStreamChunk, 1)
-	chunks <- codex.ExecuteStreamChunk{Payload: []byte(`data: {"type":"response.completed","response":{"id":"resp_1"}}`)}
+	chunks <- codex.ExecuteStreamChunk{Payload: []byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\"}}\n\n")}
 	close(chunks)
 	setCodexExecutor(t, adapter, &fakeExecutor{stream: &codex.ExecuteStreamResponse{Headers: http.Header{"Content-Type": {"text/event-stream"}}, Chunks: chunks}})
 	var events []execution.StreamEvent

--- a/internal/execution/cpa/adapter_test.go
+++ b/internal/execution/cpa/adapter_test.go
@@ -533,6 +533,37 @@ func TestAdapterGroupsNativeResponsesSSELinesIntoCompleteEvents(t *testing.T) {
 	}
 }
 
+func TestAdapterSkipsEmptyChunksOutsideNativeResponsesFraming(t *testing.T) {
+	adapter, _, _, keyService, row := newAdapterFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
+	chunks := make(chan codex.ExecuteStreamChunk, 2)
+	chunks <- codex.ExecuteStreamChunk{}
+	chunks <- codex.ExecuteStreamChunk{Payload: []byte(`{"id":"chat_1","choices":[{"finish_reason":"stop"}]}`)}
+	close(chunks)
+	setCodexExecutor(t, adapter, &fakeExecutor{stream: &codex.ExecuteStreamResponse{Chunks: chunks}})
+	spec := validSpec(t, row, keyService)
+	spec.ClientProtocol = protocol.OpenAICompletions
+	spec.Operation = execution.OperationChatCompletion
+	spec.RouteMode = execution.RouteConverted
+
+	var data []string
+	result := adapter.ExecuteStream(t.Context(), spec, func(event execution.StreamEvent) error {
+		if event.Kind == execution.StreamEventData {
+			data = append(data, string(event.Data))
+		}
+		return nil
+	})
+	if result.Error != nil {
+		t.Fatalf("ExecuteStream() error = %#v", result.Error)
+	}
+	want := []string{
+		"data: {\"id\":\"chat_1\",\"choices\":[{\"finish_reason\":\"stop\"}]}\n\n",
+		"data: [DONE]\n\n",
+	}
+	if !reflect.DeepEqual(data, want) {
+		t.Fatalf("stream data = %q, want %q", data, want)
+	}
+}
+
 func TestAdapterDoesNotCompleteStreamAfterContextCancellation(t *testing.T) {
 	adapter, _, _, keyService, row := newAdapterFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
 	chunks := make(chan codex.ExecuteStreamChunk)

--- a/internal/execution/cpa/grok_adapter_stream_test.go
+++ b/internal/execution/cpa/grok_adapter_stream_test.go
@@ -1,0 +1,77 @@
+package cpa
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+	"gpt-load/internal/subscription/providers/grok"
+)
+
+type fakeGrokStreamExecutor struct {
+	stream *grok.ExecuteStreamResponse
+}
+
+func (*fakeGrokStreamExecutor) Execute(context.Context, string, grok.Credential, grok.ExecuteRequest) (grok.ExecuteResponse, error) {
+	return grok.ExecuteResponse{}, nil
+}
+
+func (*fakeGrokStreamExecutor) CountTokens(context.Context, grok.ExecuteRequest) (grok.ExecuteResponse, error) {
+	return grok.ExecuteResponse{}, nil
+}
+
+func (executor *fakeGrokStreamExecutor) ExecuteStream(context.Context, string, grok.Credential, grok.ExecuteRequest) (*grok.ExecuteStreamResponse, error) {
+	return executor.stream, nil
+}
+
+func TestGrokAdapterGroupsNativeResponsesSSELinesIntoCompleteEvents(t *testing.T) {
+	canonical, err := grok.MarshalCredential(grok.Credential{
+		Type: grok.Provider, AccessToken: "access", RefreshToken: "refresh", AccountID: "xai-account",
+		Email: "grok@example.com", Expire: "2030-01-01T00:00:00Z", TokenEndpoint: "https://auth.x.ai/oauth/token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter, _, _, keyService, row := newSubscriptionAdapterFixture(t, string(channel.Grok), canonical, "xai-account")
+	bridge, ok := adapter.providers[channel.ProviderGrok].(*grokProviderBridge)
+	if !ok {
+		t.Fatal("Grok provider bridge is unavailable")
+	}
+	chunks := make(chan grok.ExecuteStreamChunk, 2)
+	chunks <- grok.ExecuteStreamChunk{Payload: []byte("event: response.completed")}
+	chunks <- grok.ExecuteStreamChunk{Payload: []byte(`data: {"type":"response.completed","response":{"id":"resp_1"}}`)}
+	close(chunks)
+	bridge.executor = &fakeGrokStreamExecutor{stream: &grok.ExecuteStreamResponse{Chunks: chunks}}
+
+	plaintext, err := keyService.Decrypt(row.Data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	spec := execution.NewAttemptSpec(execution.AttemptSpec{
+		RequestID: "request-1", AttemptID: "attempt-1", Sequence: 1,
+		ChannelID: string(channel.Grok), RouteMode: execution.RouteNative,
+		ClientProtocol: protocol.OpenAIResponses, Operation: execution.OperationResponsesCreate,
+		ClientModel: "grok-4.3", UpstreamModel: "grok-4.3", Method: http.MethodPost, Path: "/v1/responses",
+		Body:       []byte(`{"model":"grok-4.3","input":"hi"}`),
+		Credential: execution.NewCredentialSnapshot(row.ID, row.SecretVersion, 1, []byte(plaintext)),
+	})
+	var wire string
+	result := adapter.ExecuteStream(t.Context(), spec, func(event execution.StreamEvent) error {
+		if event.Kind == execution.StreamEventData {
+			wire += string(event.Data)
+		}
+		return nil
+	})
+	if result.Error != nil {
+		t.Fatalf("ExecuteStream() error = %#v", result.Error)
+	}
+	want := "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\"}}\n\n"
+	if wire != want {
+		t.Fatalf("wire = %q, want %q", wire, want)
+	}
+}
+
+var _ grok.Executor = (*fakeGrokStreamExecutor)(nil)

--- a/internal/execution/cpa/stream_framing.go
+++ b/internal/execution/cpa/stream_framing.go
@@ -1,0 +1,96 @@
+package cpa
+
+import (
+	"bytes"
+	"fmt"
+)
+
+const maxSubscriptionSSEEventBytes = 10 << 20
+
+// nativeResponsesSSEAssembler restores complete SSE events from the line-level
+// chunks emitted by the embedded Codex and Grok executors.
+type nativeResponsesSSEAssembler struct {
+	pending []byte
+}
+
+func (assembler *nativeResponsesSSEAssembler) push(chunk []byte) ([][]byte, error) {
+	assembler.pending = append(assembler.pending, chunk...)
+	if len(chunk) == 0 || chunk[len(chunk)-1] != '\n' && chunk[len(chunk)-1] != '\r' {
+		assembler.pending = append(assembler.pending, '\n')
+	}
+
+	var events [][]byte
+	for {
+		eventEnd, found := firstCompleteSubscriptionSSEEvent(assembler.pending)
+		if !found {
+			if len(assembler.pending) > maxSubscriptionSSEEventBytes {
+				return nil, fmt.Errorf("subscription SSE event exceeds limit")
+			}
+			return events, nil
+		}
+		if eventEnd > maxSubscriptionSSEEventBytes {
+			return nil, fmt.Errorf("subscription SSE event exceeds limit")
+		}
+		event := bytes.Clone(assembler.pending[:eventEnd])
+		assembler.pending = assembler.pending[eventEnd:]
+		if subscriptionSSEEventHasData(event) {
+			events = append(events, event)
+		}
+	}
+}
+
+func (assembler *nativeResponsesSSEAssembler) finish() ([][]byte, error) {
+	if assembler == nil || len(bytes.TrimSpace(assembler.pending)) == 0 {
+		return nil, nil
+	}
+	events, err := assembler.push(nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(events) == 0 || len(bytes.TrimSpace(assembler.pending)) != 0 {
+		return nil, fmt.Errorf("subscription SSE stream ended with an incomplete event")
+	}
+	return events, nil
+}
+
+func firstCompleteSubscriptionSSEEvent(data []byte) (int, bool) {
+	lineStart := 0
+	for index := 0; index < len(data); {
+		if data[index] != '\r' && data[index] != '\n' {
+			index++
+			continue
+		}
+		terminatorStart := index
+		index++
+		if data[terminatorStart] == '\r' && index < len(data) && data[index] == '\n' {
+			index++
+		}
+		if terminatorStart == lineStart {
+			return index, true
+		}
+		lineStart = index
+	}
+	return 0, false
+}
+
+func subscriptionSSEEventHasData(event []byte) bool {
+	for offset := 0; offset < len(event); {
+		lineEnd := bytes.IndexAny(event[offset:], "\r\n")
+		line := event[offset:]
+		if lineEnd >= 0 {
+			lineEnd += offset
+			line = event[offset:lineEnd]
+		}
+		if bytes.Equal(line, []byte("data")) || bytes.HasPrefix(line, []byte("data:")) {
+			return true
+		}
+		if lineEnd < 0 {
+			return false
+		}
+		offset = lineEnd + 1
+		if event[lineEnd] == '\r' && offset < len(event) && event[offset] == '\n' {
+			offset++
+		}
+	}
+	return false
+}

--- a/internal/execution/cpa/stream_framing_test.go
+++ b/internal/execution/cpa/stream_framing_test.go
@@ -1,0 +1,65 @@
+package cpa
+
+import "testing"
+
+func TestNativeResponsesSSEAssemblerHandlesFragmentedAndCompleteEvents(t *testing.T) {
+	assembler := &nativeResponsesSSEAssembler{}
+	for _, chunk := range []string{
+		"event: response.created",
+		`data: {"type":"response.created"}`,
+	} {
+		events, err := assembler.push([]byte(chunk))
+		if err != nil || len(events) != 0 {
+			t.Fatalf("push(%q) = %q, %v", chunk, events, err)
+		}
+	}
+	events, err := assembler.push(nil)
+	if err != nil || len(events) != 1 || string(events[0]) != "event: response.created\ndata: {\"type\":\"response.created\"}\n\n" {
+		t.Fatalf("fragmented event = %q, %v", events, err)
+	}
+
+	events, err = assembler.push([]byte(
+		"event: response.in_progress\r\ndata: {\"type\":\"response.in_progress\"}\r\n\r\n" +
+			"event: response.completed\r\ndata: {\"type\":\"response.completed\"}\r\n\r\n",
+	))
+	if err != nil || len(events) != 2 {
+		t.Fatalf("complete events = %q, %v", events, err)
+	}
+	if trailing, err := assembler.finish(); err != nil || len(trailing) != 0 {
+		t.Fatal(err)
+	}
+}
+
+func TestNativeResponsesSSEAssemblerIgnoresEventsWithoutData(t *testing.T) {
+	assembler := &nativeResponsesSSEAssembler{}
+	events, err := assembler.push([]byte(": keepalive\n\nevent: response.created\n\n"))
+	if err != nil || len(events) != 0 {
+		t.Fatalf("events without data = %q, %v", events, err)
+	}
+}
+
+func TestNativeResponsesSSEAssemblerRejectsIncompleteEOF(t *testing.T) {
+	assembler := &nativeResponsesSSEAssembler{}
+	if events, err := assembler.push([]byte("event: response.created")); err != nil || len(events) != 0 {
+		t.Fatalf("push() = %q, %v", events, err)
+	}
+	if _, err := assembler.finish(); err == nil {
+		t.Fatal("finish() error = nil, want incomplete event error")
+	}
+}
+
+func TestNativeResponsesSSEAssemblerCompletesDataEventAtEOF(t *testing.T) {
+	assembler := &nativeResponsesSSEAssembler{}
+	for _, chunk := range []string{
+		"event: response.completed",
+		`data: {"type":"response.completed"}`,
+	} {
+		if events, err := assembler.push([]byte(chunk)); err != nil || len(events) != 0 {
+			t.Fatalf("push(%q) = %q, %v", chunk, events, err)
+		}
+	}
+	events, err := assembler.finish()
+	if err != nil || len(events) != 1 || string(events[0]) != "event: response.completed\ndata: {\"type\":\"response.completed\"}\n\n" {
+		t.Fatalf("finish() = %q, %v", events, err)
+	}
+}

--- a/internal/gateway/forward.go
+++ b/internal/gateway/forward.go
@@ -350,6 +350,67 @@ func headerValuesContainLiteral(values []string, literal string) bool {
 	return false
 }
 
+func isUpstreamOriginResponseHeader(name string) bool {
+	lowered := strings.ToLower(strings.TrimSpace(name))
+	if strings.HasPrefix(lowered, "access-control-") ||
+		strings.HasPrefix(lowered, "cross-origin-") ||
+		strings.HasPrefix(lowered, "cf-") ||
+		strings.HasPrefix(lowered, "x-codex-") ||
+		strings.HasPrefix(lowered, "x-envoy-") {
+		return true
+	}
+	switch lowered {
+	case "alt-svc",
+		"clear-site-data",
+		"content-security-policy",
+		"content-security-policy-report-only",
+		"date",
+		"nel",
+		"origin-agent-cluster",
+		"permissions-policy",
+		"referrer-policy",
+		"report-to",
+		"reporting-endpoints",
+		"server",
+		"server-timing",
+		"strict-transport-security",
+		"timing-allow-origin",
+		"via",
+		"x-cache",
+		"x-cache-hits",
+		"x-content-type-options",
+		"x-frame-options",
+		"x-models-etag",
+		"x-openai-proxy-wasm",
+		"x-served-by",
+		"x-xss-protection":
+		return true
+	default:
+		return false
+	}
+}
+
+func isConvertedResponseHeaderAllowed(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "cache-control",
+		"content-encoding",
+		"content-length",
+		"content-type",
+		"request-id",
+		"retry-after",
+		"x-amzn-requestid",
+		"x-gpt-load-token-count",
+		"x-goog-request-id",
+		"x-oai-request-id",
+		"x-request-id",
+		"anthropic-request-id",
+		"openai-request-id":
+		return true
+	default:
+		return false
+	}
+}
+
 func sanitizeForwardResponseHeaders(
 	source http.Header,
 	input ForwardInput,
@@ -361,6 +422,7 @@ func sanitizeForwardResponseHeaders(
 	namesToDelete := make([]string, 0)
 	for actualName, values := range headers {
 		deleteField := isResolvedCredentialHeaderName(actualName) ||
+			isUpstreamOriginResponseHeader(actualName) ||
 			strings.HasPrefix(strings.ToLower(actualName), "x-upstream-") ||
 			strings.EqualFold(actualName, "Set-Cookie") ||
 			strings.EqualFold(actualName, "Set-Cookie2") ||
@@ -381,6 +443,15 @@ func sanitizeForwardResponseHeaders(
 	deleted = deleted || len(namesToDelete) > 0
 	for _, name := range namesToDelete {
 		deleteHeaderField(headers, name)
+	}
+	if input.RouteMode == execution.RouteConverted {
+		for name := range headers {
+			if isConvertedResponseHeaderAllowed(name) {
+				continue
+			}
+			delete(headers, name)
+			deleted = true
+		}
 	}
 	if !needsModelRewrite(input) {
 		if deleted {

--- a/internal/gateway/forward.go
+++ b/internal/gateway/forward.go
@@ -395,6 +395,7 @@ func isConvertedResponseHeaderAllowed(name string) bool {
 	case "cache-control",
 		"content-encoding",
 		"content-length",
+		"content-range",
 		"content-type",
 		"request-id",
 		"retry-after",

--- a/internal/gateway/forward_header_test.go
+++ b/internal/gateway/forward_header_test.go
@@ -1,0 +1,105 @@
+package gateway
+
+import (
+	"net/http"
+	"testing"
+
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+)
+
+func TestSanitizeForwardResponseHeadersDropsUpstreamOriginPolicy(t *testing.T) {
+	source := http.Header{
+		"X-Request-Id":                  {"request-1"},
+		"X-Ratelimit-Remaining":         {"9"},
+		"Retry-After":                   {"3"},
+		"Location":                      {"/v1/responses/resp_1"},
+		"Etag":                          {`"response-1"`},
+		"Cache-Control":                 {"no-cache"},
+		"Server":                        {"upstream-edge"},
+		"Via":                           {"upstream-proxy"},
+		"Strict-Transport-Security":     {"max-age=31536000"},
+		"Cross-Origin-Opener-Policy":    {"same-origin"},
+		"Cross-Origin-Resource-Policy":  {"same-origin"},
+		"Referrer-Policy":               {"strict-origin"},
+		"Content-Security-Policy":       {"default-src 'none'"},
+		"Permissions-Policy":            {"camera=()"},
+		"Origin-Agent-Cluster":          {"?1"},
+		"Report-To":                     {`{"group":"upstream"}`},
+		"Nel":                           {`{"success_fraction":0.01}`},
+		"Cf-Ray":                        {"edge-trace"},
+		"Cf-Cache-Status":               {"DYNAMIC"},
+		"X-Codex-Turn-State":            {"private-state"},
+		"X-Codex-Plan-Type":             {"pro"},
+		"X-Models-Etag":                 {"private-model-cache"},
+		"X-Openai-Proxy-Wasm":           {"v0.1"},
+		"Access-Control-Allow-Origin":   {"*"},
+		"Access-Control-Expose-Headers": {"X-Request-Id"},
+		"X-Content-Type-Options":        {"nosniff"},
+		"X-Frame-Options":               {"DENY"},
+	}
+
+	headers := sanitizeForwardResponseHeaders(source, ForwardInput{
+		ClientProtocol: protocol.OpenAIResponses,
+		Operation:      execution.OperationResponsesRetrieve,
+		RouteMode:      execution.RouteNative,
+	})
+	for _, name := range []string{
+		"X-Request-Id", "X-Ratelimit-Remaining", "Retry-After", "Location", "Etag", "Cache-Control",
+	} {
+		if headers.Get(name) == "" {
+			t.Fatalf("safe response header %s was removed: %#v", name, headers)
+		}
+	}
+	for _, name := range []string{
+		"Server", "Via", "Strict-Transport-Security", "Cross-Origin-Opener-Policy",
+		"Cross-Origin-Resource-Policy", "Referrer-Policy", "Content-Security-Policy",
+		"Permissions-Policy", "Origin-Agent-Cluster", "Report-To", "Nel", "Cf-Ray",
+		"Cf-Cache-Status", "X-Codex-Turn-State", "X-Codex-Plan-Type", "X-Models-Etag",
+		"X-Openai-Proxy-Wasm", "Access-Control-Allow-Origin", "Access-Control-Expose-Headers",
+		"X-Content-Type-Options", "X-Frame-Options",
+	} {
+		if headers.Values(name) != nil {
+			t.Fatalf("upstream origin header %s survived: %#v", name, headers.Values(name))
+		}
+	}
+}
+
+func TestSanitizeForwardResponseHeadersNarrowsConvertedResponses(t *testing.T) {
+	source := http.Header{
+		"Content-Type":                 {"application/json"},
+		"Content-Length":               {"123"},
+		"Cache-Control":                {"no-cache"},
+		"X-Request-Id":                 {"request-1"},
+		"Retry-After":                  {"3"},
+		"X-Gpt-Load-Token-Count":       {"local-estimate"},
+		"X-Ratelimit-Remaining":        {"9"},
+		"Anthropic-Ratelimit-Requests": {"8"},
+		"X-Goog-Quota-Project":         {"upstream-project"},
+		"Location":                     {"/provider/resource"},
+		"Etag":                         {`"provider-representation"`},
+		"X-Provider-Debug":             {"private"},
+	}
+
+	headers := sanitizeForwardResponseHeaders(source, ForwardInput{
+		ClientProtocol: protocol.OpenAIResponses,
+		Operation:      execution.OperationResponsesCreate,
+		RouteMode:      execution.RouteConverted,
+	})
+	for _, name := range []string{
+		"Content-Type", "Content-Length", "Cache-Control", "X-Request-Id", "Retry-After",
+		"X-Gpt-Load-Token-Count",
+	} {
+		if headers.Get(name) == "" {
+			t.Fatalf("converted response header %s was removed: %#v", name, headers)
+		}
+	}
+	for _, name := range []string{
+		"X-Ratelimit-Remaining", "Anthropic-Ratelimit-Requests", "X-Goog-Quota-Project",
+		"Location", "Etag", "X-Provider-Debug",
+	} {
+		if headers.Values(name) != nil {
+			t.Fatalf("upstream-specific converted header %s survived: %#v", name, headers.Values(name))
+		}
+	}
+}

--- a/internal/gateway/forward_header_test.go
+++ b/internal/gateway/forward_header_test.go
@@ -69,6 +69,7 @@ func TestSanitizeForwardResponseHeadersNarrowsConvertedResponses(t *testing.T) {
 	source := http.Header{
 		"Content-Type":                 {"application/json"},
 		"Content-Length":               {"123"},
+		"Content-Range":                {"bytes 0-122/123"},
 		"Cache-Control":                {"no-cache"},
 		"X-Request-Id":                 {"request-1"},
 		"Retry-After":                  {"3"},
@@ -87,7 +88,7 @@ func TestSanitizeForwardResponseHeadersNarrowsConvertedResponses(t *testing.T) {
 		RouteMode:      execution.RouteConverted,
 	})
 	for _, name := range []string{
-		"Content-Type", "Content-Length", "Cache-Control", "X-Request-Id", "Retry-After",
+		"Content-Type", "Content-Length", "Content-Range", "Cache-Control", "X-Request-Id", "Retry-After",
 		"X-Gpt-Load-Token-Count",
 	} {
 		if headers.Get(name) == "" {


### PR DESCRIPTION
### 关联 Issue / Related Issue

无 / None

### 变更内容 / Change Content

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [x] 其他改动 / Other changes

- 将 Codex、Grok 原生 Responses 的行级 SSE 输出组装为完整 `event + data` 事件后再下发，避免客户端解析空 JSON。
- 保持 Responses、Chat Completions、Anthropic、Gemini 各自的终止语义，并覆盖真实 CPA Responses 到多协议转换链路。
- 订阅响应改用窄 Header 白名单，过滤账户、配额、Turn-State、上游 CDN/CORS/HSTS 等私有或边缘 Header。
- converted 响应仅保留下游必要 Header；native 资源接口继续保留 `Location`、ETag 和原生限流信息。
- 修正半个 SSE 事件到达后的 idle timeout，避免只收到 `event:` 行时等待到总请求超时。

验证：

- `go test -count=1 ./internal/execution/cpa ./internal/execution/bifrost ./internal/gateway`
- `make check`
- `git --no-pager diff --check`

兼容性：无数据迁移；converted 与订阅响应不再透传未声明的上游私有 Header，这是预期的安全收口。

### 自查清单 / Checklist

- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.
