### PR TITLE
fix: 限制健康页异常上游凭据提示数量

### DIFF
--- a/internal/control/health.go
+++ b/internal/control/health.go
@@ -122,9 +122,15 @@ type healthAccessKeyCostLimitResponse struct {
 	BlockingRules     []AccessKeyCostLimitRuleStatus `json:"blocking_rules"`
 }
 
-// healthLowQuotaRemainingRatio 是「额度快用完」的唯一阈值来源。
-// 与管理 UI 账号卡的 danger 档保持一致，避免同一句结论在两处算出不同答案。
-const healthLowQuotaRemainingRatio = 0.3
+const (
+	// healthLowQuotaRemainingRatio 是「额度快用完」的唯一阈值来源。
+	// 与管理 UI 账号卡的 danger 档保持一致，避免同一句结论在两处算出不同答案。
+	healthLowQuotaRemainingRatio = 0.3
+
+	// healthProblemCredentialDetailLimit 限制健康页「需要关注的凭据」中的
+	// 冷却和拉黑上游凭据明细，避免异常批量出现时放大接口响应和页面渲染。
+	healthProblemCredentialDetailLimit = 100
+)
 
 type healthBucket string
 
@@ -318,6 +324,10 @@ func (service *Service) RuntimeHealth() (runtimeHealthResponse, error) {
 			}
 		}
 		if bucket != healthBucketCooldown && bucket != healthBucketBlacklisted {
+			continue
+		}
+		if (bucket == healthBucketCooldown && len(result.CooldownCredentials) >= healthProblemCredentialDetailLimit) ||
+			(bucket == healthBucketBlacklisted && len(result.BlacklistedCredentials) >= healthProblemCredentialDetailLimit) {
 			continue
 		}
 		groupView := observation.snapshot.Groups[key.GroupID]

--- a/internal/control/health_test.go
+++ b/internal/control/health_test.go
@@ -3,6 +3,7 @@ package control
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -330,6 +331,76 @@ func TestRuntimeHealthSortsProblemKeysByGroupAndKey(t *testing.T) {
 		{1, 13}, {2, 21},
 	}; !reflect.DeepEqual(gotPairs, want) {
 		t.Fatalf("blacklisted order = %v, want %v", gotPairs, want)
+	}
+}
+
+func TestRuntimeHealthCapsProblemCredentialDetails(t *testing.T) {
+	const detailLimit = 100
+
+	fixture := newServiceFixture(t)
+	now := healthNow()
+	fixture.service.now = func() time.Time { return now }
+	if _, err := fixture.manager.Publish(state.CompileInput{
+		ChannelRegistry: fixture.channelRegistry,
+		Groups: []state.GroupConfig{{
+			ConnectionType: "api_key", ID: 1, Name: "one", ChannelID: channel.OpenAI,
+			Params: json.RawMessage(`{}`), Models: []state.ModelConfig{{ID: "model"}}, Enabled: true,
+		}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	ciphertext := encryptHealthKey(t, fixture, "health-detail-limit-secret")
+	entries := make([]state.CredentialEntry, 0, 2*(detailLimit+1))
+	for offset := range detailLimit + 1 {
+		cooldownID := uint(offset + 1)
+		blacklistedID := uint(detailLimit + 2 + offset)
+		entries = append(entries,
+			state.CredentialEntry{
+				ID: cooldownID, GroupID: 1, Version: 1, IdentityGeneration: uint64(cooldownID),
+				Fingerprint: fmt.Sprintf("cooldown-%d", cooldownID), Status: state.CredentialStatusActive,
+				CooldownUntil: now.Add(time.Minute), EncryptedValue: ciphertext,
+			},
+			state.CredentialEntry{
+				ID: blacklistedID, GroupID: 1, Version: 1, IdentityGeneration: uint64(blacklistedID),
+				Fingerprint: fmt.Sprintf("blacklisted-%d", blacklistedID), Status: state.CredentialStatusActive,
+				Blacklisted: true, EncryptedValue: ciphertext,
+			},
+		)
+	}
+	if err := fixture.registry.ReplaceCredentials(entries); err != nil {
+		t.Fatalf("ReplaceCredentials() error = %v", err)
+	}
+	remaining := 0.1
+	for credentialID := uint(1); credentialID <= detailLimit+1; credentialID++ {
+		if !fixture.registry.SetCredentialQuotaObservation(credentialID, &remaining, now.Add(time.Hour)) {
+			t.Fatalf("SetCredentialQuotaObservation(%d) = false", credentialID)
+		}
+	}
+	observation, err := fixture.service.captureRuntimeHealthObservation()
+	if err != nil {
+		t.Fatalf("captureRuntimeHealthObservation() error = %v", err)
+	}
+	if len(observation.problemCiphertexts) != 2*detailLimit {
+		t.Fatalf("problem ciphertexts = %d, want %d", len(observation.problemCiphertexts), 2*detailLimit)
+	}
+
+	got, err := fixture.service.RuntimeHealth()
+	if err != nil {
+		t.Fatalf("RuntimeHealth() error = %v", err)
+	}
+	if got.Counts != (healthCountsResponse{
+		Credentials: 2 * (detailLimit + 1), Cooldown: detailLimit + 1, Blacklisted: detailLimit + 1,
+	}) {
+		t.Fatalf("counts = %#v", got.Counts)
+	}
+	if len(got.CooldownCredentials) != detailLimit || len(got.BlacklistedCredentials) != detailLimit ||
+		len(got.LowQuotaCredentials) != detailLimit+1 {
+		t.Fatalf(
+			"detail lengths = cooldown:%d blacklisted:%d low_quota:%d, want %d/%d/%d",
+			len(got.CooldownCredentials), len(got.BlacklistedCredentials), len(got.LowQuotaCredentials),
+			detailLimit, detailLimit, detailLimit+1,
+		)
 	}
 }
 

--- a/internal/control/runtime_observation.go
+++ b/internal/control/runtime_observation.go
@@ -91,6 +91,8 @@ func (service *Service) captureRuntimeHealthObservation() (
 		}
 	}
 	problemCiphertexts := make(map[uint]string)
+	cooldownDetails := 0
+	blacklistedDetails := 0
 	for _, key := range keys {
 		group, exists := snapshot.GroupCatalog[key.GroupID]
 		if !exists {
@@ -102,7 +104,18 @@ func (service *Service) captureRuntimeHealthObservation() (
 			)
 		}
 		bucket := classifyHealthKey(group, key, observedAt)
-		if bucket != healthBucketCooldown && bucket != healthBucketBlacklisted {
+		switch bucket {
+		case healthBucketCooldown:
+			if cooldownDetails >= healthProblemCredentialDetailLimit {
+				continue
+			}
+			cooldownDetails++
+		case healthBucketBlacklisted:
+			if blacklistedDetails >= healthProblemCredentialDetailLimit {
+				continue
+			}
+			blacklistedDetails++
+		default:
 			continue
 		}
 		ciphertext, exists := service.registry.EncryptedCredentialData(key.ID)


### PR DESCRIPTION
### 关联 Issue / Related Issue
无

### 变更内容 / Change Content
- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

健康页的冷却和拉黑上游凭据提示各限制为最多 100 条。超过上限的凭据不再取密文、解密或生成掩码，减少管理接口响应和页面渲染压力；完整健康计数保持不变。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.（本次不涉及）
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.（不涉及数据迁移）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化运行时健康状态展示：冷却和黑名单凭据详情分别最多显示 100 条。
  * 凭据问题总数仍保持完整统计，低配额详情不受此次限制影响。
  * 优化健康观测数据，避免记录过多凭据详情。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->