### PR TITLE
feat(group): 默认按最近调用排序

### DIFF
--- a/internal/control/group_collection.go
+++ b/internal/control/group_collection.go
@@ -92,6 +92,7 @@ func cloneGroupRows(rows []models.Group) []models.Group {
 
 func (s *Service) captureGroupCollectionRecords(
 	ctx context.Context,
+	includeActivity bool,
 ) (int64, []groupCollectionRecord, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -115,7 +116,7 @@ func (s *Service) captureGroupCollectionRecords(
 	snapshot := s.manager.Current()
 	runtimeKeys := s.registrySnapshot()
 	observedAt := s.now().UTC()
-	rows, err := s.readGroupCollectionRows(ctx)
+	rows, err := s.readGroupCollectionRows(ctx, includeActivity)
 	s.writeMu.RUnlock()
 	if parentErr := ctx.Err(); parentErr != nil {
 		return 0, nil, parentErr
@@ -135,6 +136,7 @@ func (s *Service) captureGroupCollectionRecords(
 
 func (s *Service) readGroupCollectionRows(
 	ctx context.Context,
+	includeActivity bool,
 ) (groupCollectionRows, error) {
 	var rows groupCollectionRows
 	err := s.withReadSnapshot(ctx, func(tx *gorm.DB) error {
@@ -143,15 +145,11 @@ func (s *Service) readGroupCollectionRows(
 			return err
 		}
 		rows.groups = cloneGroupRows(groups)
-		groupIDs := make([]uint, 0, len(groups))
-		for _, group := range groups {
-			groupIDs = append(groupIDs, group.ID)
-		}
-		if len(groupIDs) > 0 {
+		if includeActivity && len(groups) > 0 {
 			latestActivity := tx.Model(&models.UsageStat{}).
-				Select("group_id, MAX(bucket_start_ms) AS last_active_at_ms").
-				Where("group_id IN ?", groupIDs).
-				Group("group_id")
+				Select("usage_stats.group_id, MAX(usage_stats.bucket_start_ms) AS last_active_at_ms").
+				Joins("JOIN groups ON groups.id = usage_stats.group_id").
+				Group("usage_stats.group_id")
 			if err := tx.Table("usage_stats").
 				Select(
 					"usage_stats.group_id, latest_activity.last_active_at_ms, "+

--- a/internal/control/group_collection.go
+++ b/internal/control/group_collection.go
@@ -52,13 +52,22 @@ type GroupCollectionItem struct {
 
 type groupCollectionRecord struct {
 	GroupCollectionItem
-	CreatedAtMS       int64
-	UnavailableReason *GroupUnavailableReason
+	CreatedAtMS                int64
+	LastActiveAtMS             *int64
+	LastActiveHourRequestCount int64
+	UnavailableReason          *GroupUnavailableReason
 }
 
 type groupCollectionRows struct {
 	groups      []models.Group
 	credentials []models.Credential
+	activity    []groupCollectionActivityRow
+}
+
+type groupCollectionActivityRow struct {
+	GroupID                    uint
+	LastActiveAtMS             int64
+	LastActiveHourRequestCount int64
 }
 
 func cloneGroupRows(rows []models.Group) []models.Group {
@@ -134,6 +143,31 @@ func (s *Service) readGroupCollectionRows(
 			return err
 		}
 		rows.groups = cloneGroupRows(groups)
+		groupIDs := make([]uint, 0, len(groups))
+		for _, group := range groups {
+			groupIDs = append(groupIDs, group.ID)
+		}
+		if len(groupIDs) > 0 {
+			latestActivity := tx.Model(&models.UsageStat{}).
+				Select("group_id, MAX(bucket_start_ms) AS last_active_at_ms").
+				Where("group_id IN ?", groupIDs).
+				Group("group_id")
+			if err := tx.Table("usage_stats").
+				Select(
+					"usage_stats.group_id, latest_activity.last_active_at_ms, "+
+						"COALESCE(SUM(usage_stats.request_count), 0) AS last_active_hour_request_count",
+				).
+				Joins(
+					"JOIN (?) AS latest_activity ON latest_activity.group_id = usage_stats.group_id "+
+						"AND latest_activity.last_active_at_ms = usage_stats.bucket_start_ms",
+					latestActivity,
+				).
+				Group("usage_stats.group_id, latest_activity.last_active_at_ms").
+				Order("usage_stats.group_id ASC").
+				Find(&rows.activity).Error; err != nil {
+				return err
+			}
+		}
 		var credentials []models.Credential
 		if err := tx.Model(&models.Credential{}).
 			Select("id", "group_id", "fingerprint", "identity_fingerprint", "secret_version", "status", "weight_manual").
@@ -219,6 +253,19 @@ func mapGroupCollectionRecords(
 		}
 	}
 	credentialsByGroup := make(map[uint][]models.Credential)
+	activityByGroup := make(map[uint]groupCollectionActivityRow, len(rows.activity))
+	for _, activity := range rows.activity {
+		if activity.GroupID == 0 || activity.LastActiveAtMS < 0 || activity.LastActiveHourRequestCount < 0 {
+			return nil, groupCollectionDataError("invalid group activity row")
+		}
+		if _, duplicate := activityByGroup[activity.GroupID]; duplicate {
+			return nil, groupCollectionDataError("duplicate group activity row for group %d", activity.GroupID)
+		}
+		if _, exists := persistedGroups[activity.GroupID]; !exists {
+			return nil, groupCollectionDataError("group activity references missing group %d", activity.GroupID)
+		}
+		activityByGroup[activity.GroupID] = activity
+	}
 	persistedCredentialByID := make(map[uint]models.Credential, len(rows.credentials))
 	for _, credential := range rows.credentials {
 		if credential.ID == 0 {
@@ -307,6 +354,11 @@ func mapGroupCollectionRecords(
 				ModelCount:     int64(len(groupModels)),
 			},
 			CreatedAtMS: group.CreatedAtMS,
+		}
+		if activity, exists := activityByGroup[group.ID]; exists {
+			lastActiveAtMS := activity.LastActiveAtMS
+			record.LastActiveAtMS = &lastActiveAtMS
+			record.LastActiveHourRequestCount = activity.LastActiveHourRequestCount
 		}
 		for _, persistedCredential := range credentialsByGroup[group.ID] {
 			bucket := classifyHealthKey(catalog, runtimeByID[persistedCredential.ID], observedAt)

--- a/internal/control/group_collection.go
+++ b/internal/control/group_collection.go
@@ -146,10 +146,7 @@ func (s *Service) readGroupCollectionRows(
 		}
 		rows.groups = cloneGroupRows(groups)
 		if includeActivity && len(groups) > 0 {
-			latestActivity := tx.Model(&models.UsageStat{}).
-				Select("usage_stats.group_id, MAX(usage_stats.bucket_start_ms) AS last_active_at_ms").
-				Joins("JOIN groups ON groups.id = usage_stats.group_id").
-				Group("usage_stats.group_id")
+			latestActivity := groupCollectionLatestActivityScope(tx)
 			if err := tx.Table("usage_stats").
 				Select(
 					"usage_stats.group_id, latest_activity.last_active_at_ms, "+
@@ -176,6 +173,16 @@ func (s *Service) readGroupCollectionRows(
 		return nil
 	})
 	return rows, err
+}
+
+func groupCollectionLatestActivityScope(db *gorm.DB) *gorm.DB {
+	existingGroups := db.Session(&gorm.Session{NewDB: true}).
+		Model(&models.Group{}).
+		Select("id")
+	return db.Model(&models.UsageStat{}).
+		Select("usage_stats.group_id, MAX(usage_stats.bucket_start_ms) AS last_active_at_ms").
+		Where("usage_stats.group_id IN (?)", existingGroups).
+		Group("usage_stats.group_id")
 }
 
 func mapGroupCollectionRecords(

--- a/internal/control/group_collection_http.go
+++ b/internal/control/group_collection_http.go
@@ -55,7 +55,7 @@ func parseGroupCollectionQuery(
 	forceQuery bool,
 ) (GroupCollectionQuery, *app_errors.APIError) {
 	query := GroupCollectionQuery{
-		Sort:     GroupCollectionSortStatus,
+		Sort:     GroupCollectionSortRecent,
 		Page:     groupCollectionDefaultPage,
 		PageSize: groupCollectionDefaultPageSize,
 	}
@@ -100,7 +100,8 @@ func parseGroupCollectionQuery(
 	if entries, exists := values["sort"]; exists {
 		sortValue := GroupCollectionSort(entries[0])
 		switch sortValue {
-		case GroupCollectionSortStatus,
+		case GroupCollectionSortRecent,
+			GroupCollectionSortStatus,
 			GroupCollectionSortName,
 			GroupCollectionSortCredentials,
 			GroupCollectionSortCreated:

--- a/internal/control/group_collection_http_test.go
+++ b/internal/control/group_collection_http_test.go
@@ -32,56 +32,63 @@ func TestParseGroupCollectionQueryAcceptsStrictContract(t *testing.T) {
 		{
 			name: "no query uses defaults",
 			want: GroupCollectionQuery{
-				Sort: GroupCollectionSortStatus, Page: 1, PageSize: 20,
+				Sort: GroupCollectionSortRecent, Page: 1, PageSize: 20,
 			},
 		},
 		{
 			name:     "q is trimmed",
 			rawQuery: "q=++needle++",
 			want: GroupCollectionQuery{
-				Query: "needle", Sort: GroupCollectionSortStatus, Page: 1, PageSize: 20,
+				Query: "needle", Sort: GroupCollectionSortRecent, Page: 1, PageSize: 20,
 			},
 		},
 		{
 			name:     "q may trim to empty",
 			rawQuery: "q=+++",
 			want: GroupCollectionQuery{
-				Sort: GroupCollectionSortStatus, Page: 1, PageSize: 20,
+				Sort: GroupCollectionSortRecent, Page: 1, PageSize: 20,
 			},
 		},
 		{
 			name:     "q accepts 200 Unicode code points",
 			rawQuery: "q=" + q200,
 			want: GroupCollectionQuery{
-				Query: q200, Sort: GroupCollectionSortStatus, Page: 1, PageSize: 20,
+				Query: q200, Sort: GroupCollectionSortRecent, Page: 1, PageSize: 20,
 			},
 		},
 		{
 			name:     "status available",
 			rawQuery: "status=available",
 			want: GroupCollectionQuery{
-				Status: &available, Sort: GroupCollectionSortStatus, Page: 1, PageSize: 20,
+				Status: &available, Sort: GroupCollectionSortRecent, Page: 1, PageSize: 20,
 			},
 		},
 		{
 			name:     "status unavailable",
 			rawQuery: "status=unavailable",
 			want: GroupCollectionQuery{
-				Status: &unavailable, Sort: GroupCollectionSortStatus, Page: 1, PageSize: 20,
+				Status: &unavailable, Sort: GroupCollectionSortRecent, Page: 1, PageSize: 20,
 			},
 		},
 		{
 			name:     "status disabled",
 			rawQuery: "status=disabled",
 			want: GroupCollectionQuery{
-				Status: &disabled, Sort: GroupCollectionSortStatus, Page: 1, PageSize: 20,
+				Status: &disabled, Sort: GroupCollectionSortRecent, Page: 1, PageSize: 20,
 			},
 		},
 		{
 			name:     "connection type subscription",
 			rawQuery: "connection_type=subscription",
 			want: GroupCollectionQuery{
-				ConnectionType: &subscription, Sort: GroupCollectionSortStatus, Page: 1, PageSize: 20,
+				ConnectionType: &subscription, Sort: GroupCollectionSortRecent, Page: 1, PageSize: 20,
+			},
+		},
+		{
+			name:     "sort recent",
+			rawQuery: "sort=recent",
+			want: GroupCollectionQuery{
+				Sort: GroupCollectionSortRecent, Page: 1, PageSize: 20,
 			},
 		},
 		{
@@ -116,21 +123,21 @@ func TestParseGroupCollectionQueryAcceptsStrictContract(t *testing.T) {
 			name:     "page accepts positive integer",
 			rawQuery: "page=9223372036854775807",
 			want: GroupCollectionQuery{
-				Sort: GroupCollectionSortStatus, Page: 9223372036854775807, PageSize: 20,
+				Sort: GroupCollectionSortRecent, Page: 9223372036854775807, PageSize: 20,
 			},
 		},
 		{
 			name:     "page size accepts one",
 			rawQuery: "page_size=1",
 			want: GroupCollectionQuery{
-				Sort: GroupCollectionSortStatus, Page: 1, PageSize: 1,
+				Sort: GroupCollectionSortRecent, Page: 1, PageSize: 1,
 			},
 		},
 		{
 			name:     "page size accepts one hundred",
 			rawQuery: "page_size=100",
 			want: GroupCollectionQuery{
-				Sort: GroupCollectionSortStatus, Page: 1, PageSize: 100,
+				Sort: GroupCollectionSortRecent, Page: 1, PageSize: 100,
 			},
 		},
 		{
@@ -151,6 +158,16 @@ func TestParseGroupCollectionQueryAcceptsStrictContract(t *testing.T) {
 			}
 			assertGroupCollectionQueryEqual(t, got, test.want)
 		})
+	}
+}
+
+func TestParseGroupCollectionQueryDefaultsToRecentActivity(t *testing.T) {
+	got, apiErr := parseGroupCollectionQuery("", false)
+	if apiErr != nil {
+		t.Fatalf("parseGroupCollectionQuery() error = %v", apiErr)
+	}
+	if got.Sort != GroupCollectionSortRecent {
+		t.Fatalf("default sort = %q, want recent", got.Sort)
 	}
 }
 

--- a/internal/control/group_collection_query.go
+++ b/internal/control/group_collection_query.go
@@ -56,7 +56,10 @@ func (s *Service) ListGroupCollection(
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	observedAtMS, records, err := s.captureGroupCollectionRecords(ctx)
+	observedAtMS, records, err := s.captureGroupCollectionRecords(
+		ctx,
+		groupCollectionSortUsesActivity(query.Sort),
+	)
 	if parentErr := ctx.Err(); parentErr != nil {
 		return GroupCollectionResponse{}, parentErr
 	}
@@ -64,6 +67,18 @@ func (s *Service) ListGroupCollection(
 		return GroupCollectionResponse{}, err
 	}
 	return queryGroupCollectionRecords(observedAtMS, records, query), nil
+}
+
+func groupCollectionSortUsesActivity(sortBy GroupCollectionSort) bool {
+	switch sortBy {
+	case GroupCollectionSortStatus,
+		GroupCollectionSortName,
+		GroupCollectionSortCredentials,
+		GroupCollectionSortCreated:
+		return false
+	default:
+		return true
+	}
 }
 
 func queryGroupCollectionRecords(

--- a/internal/control/group_collection_query.go
+++ b/internal/control/group_collection_query.go
@@ -12,6 +12,7 @@ import (
 type GroupCollectionSort string
 
 const (
+	GroupCollectionSortRecent      GroupCollectionSort = "recent"
 	GroupCollectionSortStatus      GroupCollectionSort = "status"
 	GroupCollectionSortName        GroupCollectionSort = "name"
 	GroupCollectionSortCredentials GroupCollectionSort = "credentials"
@@ -162,6 +163,8 @@ func sortGroupCollectionRecords(
 	sort.Slice(records, func(leftIndex, rightIndex int) bool {
 		left, right := records[leftIndex], records[rightIndex]
 		switch sortBy {
+		case GroupCollectionSortRecent:
+			return compareGroupCollectionRecentActivity(left, right)
 		case GroupCollectionSortName:
 			return compareGroupCollectionNames(left, right)
 		case GroupCollectionSortCredentials:
@@ -176,14 +179,30 @@ func sortGroupCollectionRecords(
 			}
 			return left.ID > right.ID
 		case GroupCollectionSortStatus:
-			fallthrough
-		default:
 			if leftStatus, rightStatus := groupCollectionStatusOrder(left.Status), groupCollectionStatusOrder(right.Status); leftStatus != rightStatus {
 				return leftStatus < rightStatus
 			}
 			return compareGroupCollectionNames(left, right)
+		default:
+			return compareGroupCollectionRecentActivity(left, right)
 		}
 	})
+}
+
+func compareGroupCollectionRecentActivity(left, right groupCollectionRecord) bool {
+	if left.LastActiveAtMS != nil && right.LastActiveAtMS != nil {
+		if *left.LastActiveAtMS != *right.LastActiveAtMS {
+			return *left.LastActiveAtMS > *right.LastActiveAtMS
+		}
+		if left.LastActiveHourRequestCount != right.LastActiveHourRequestCount {
+			return left.LastActiveHourRequestCount > right.LastActiveHourRequestCount
+		}
+	} else if left.LastActiveAtMS != nil {
+		return true
+	} else if right.LastActiveAtMS != nil {
+		return false
+	}
+	return compareGroupCollectionNames(left, right)
 }
 
 func groupCollectionCredentialTotal(record groupCollectionRecord) int64 {

--- a/internal/control/group_collection_query_test.go
+++ b/internal/control/group_collection_query_test.go
@@ -83,6 +83,26 @@ func TestListGroupCollectionSortsRecentActivityByHourThenRequestCount(t *testing
 	}
 }
 
+func TestListGroupCollectionSkipsActivityReadForNonRecentSort(t *testing.T) {
+	fixture := newServiceFixture(t)
+	group := createGroupCollectionGroup(t, fixture, "name sort", true, nil)
+	entry := createGroupCollectionKey(t, fixture, group.ID, models.CredentialStatusActive, nil)
+	publishGroupCollectionRuntime(t, fixture, []state.CredentialEntry{entry})
+	if err := fixture.db.Migrator().DropTable(&models.UsageStat{}); err != nil {
+		t.Fatalf("drop usage_stats: %v", err)
+	}
+
+	result, err := fixture.service.ListGroupCollection(t.Context(), GroupCollectionQuery{
+		Sort: GroupCollectionSortName, Page: 1, PageSize: 20,
+	})
+	if err != nil {
+		t.Fatalf("ListGroupCollection() error = %v", err)
+	}
+	if got, want := groupCollectionItemIDs(result.Items), []uint{group.ID}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("name-sort IDs = %#v, want %#v", got, want)
+	}
+}
+
 func TestListGroupCollectionQueryDoesNotSearchPersistedModelIDOrAlias(t *testing.T) {
 	fixture := newServiceFixture(t)
 	group := createGroupCollectionGroup(t, fixture, "not a model", true, nil)
@@ -236,6 +256,29 @@ func TestGroupCollectionQueryRecentActivityFallsBackToNameWithoutUsage(t *testin
 	result := queryGroupCollectionRecords(1_700, records, GroupCollectionQuery{Page: 1, PageSize: 20})
 	if got, want := groupCollectionItemIDs(result.Items), []uint{1, 2}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("recent activity fallback IDs = %#v, want %#v", got, want)
+	}
+}
+
+func TestGroupCollectionSortUsesActivityOnlyForRecentOrdering(t *testing.T) {
+	tests := []struct {
+		name   string
+		sortBy GroupCollectionSort
+		want   bool
+	}{
+		{name: "default", sortBy: "", want: true},
+		{name: "recent", sortBy: GroupCollectionSortRecent, want: true},
+		{name: "status", sortBy: GroupCollectionSortStatus, want: false},
+		{name: "name", sortBy: GroupCollectionSortName, want: false},
+		{name: "credentials", sortBy: GroupCollectionSortCredentials, want: false},
+		{name: "created", sortBy: GroupCollectionSortCreated, want: false},
+		{name: "unknown defaults to recent", sortBy: "unknown", want: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := groupCollectionSortUsesActivity(test.sortBy); got != test.want {
+				t.Fatalf("groupCollectionSortUsesActivity(%q) = %t, want %t", test.sortBy, got, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/control/group_collection_query_test.go
+++ b/internal/control/group_collection_query_test.go
@@ -45,6 +45,44 @@ func TestListGroupCollectionCapturesThenQueries(t *testing.T) {
 	}
 }
 
+func TestListGroupCollectionSortsRecentActivityByHourThenRequestCount(t *testing.T) {
+	fixture := newServiceFixture(t)
+	older := createGroupCollectionGroup(t, fixture, "older", true, nil)
+	recentLow := createGroupCollectionGroup(t, fixture, "alpha recent", true, nil)
+	recentHigh := createGroupCollectionGroup(t, fixture, "zulu recent", true, nil)
+	unusedZulu := createGroupCollectionGroup(t, fixture, "zulu unused", true, nil)
+	unusedAlpha := createGroupCollectionGroup(t, fixture, "alpha unused", true, nil)
+	entries := []state.CredentialEntry{
+		createGroupCollectionKey(t, fixture, older.ID, models.CredentialStatusActive, nil),
+		createGroupCollectionKey(t, fixture, recentLow.ID, models.CredentialStatusActive, nil),
+		createGroupCollectionKey(t, fixture, recentHigh.ID, models.CredentialStatusActive, nil),
+		createGroupCollectionKey(t, fixture, unusedZulu.ID, models.CredentialStatusActive, nil),
+		createGroupCollectionKey(t, fixture, unusedAlpha.ID, models.CredentialStatusActive, nil),
+	}
+	publishGroupCollectionRuntime(t, fixture, entries)
+
+	const (
+		olderHour  = int64(1_700_000_000_000)
+		recentHour = olderHour + 3_600_000
+	)
+	createGroupCollectionUsageStat(t, fixture, older.ID, olderHour, 50, "older")
+	createGroupCollectionUsageStat(t, fixture, recentLow.ID, recentHour, 3, "recent-low")
+	createGroupCollectionUsageStat(t, fixture, recentHigh.ID, recentHour, 2, "recent-high-a")
+	createGroupCollectionUsageStat(t, fixture, recentHigh.ID, recentHour, 7, "recent-high-b")
+
+	result, err := fixture.service.ListGroupCollection(t.Context(), GroupCollectionQuery{
+		Sort: GroupCollectionSortRecent, Page: 1, PageSize: 20,
+	})
+	if err != nil {
+		t.Fatalf("ListGroupCollection() error = %v", err)
+	}
+	if got, want := groupCollectionItemIDs(result.Items), []uint{
+		recentHigh.ID, recentLow.ID, older.ID, unusedAlpha.ID, unusedZulu.ID,
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("recent activity IDs = %#v, want %#v", got, want)
+	}
+}
+
 func TestListGroupCollectionQueryDoesNotSearchPersistedModelIDOrAlias(t *testing.T) {
 	fixture := newServiceFixture(t)
 	group := createGroupCollectionGroup(t, fixture, "not a model", true, nil)
@@ -186,6 +224,18 @@ func TestGroupCollectionQueryUsesFixedSortsWithIDTieBreak(t *testing.T) {
 				t.Fatalf("sort %q item IDs = %#v, want %#v", test.sort, got, test.want)
 			}
 		})
+	}
+}
+
+func TestGroupCollectionQueryRecentActivityFallsBackToNameWithoutUsage(t *testing.T) {
+	records := []groupCollectionRecord{
+		groupCollectionQueryRecord(2, "Zulu", GroupCollectionStatusUnavailable, "https://zulu.example/v1", nil, 1, 200),
+		groupCollectionQueryRecord(1, "Alpha", GroupCollectionStatusDisabled, "https://alpha.example/v1", nil, 1, 100),
+	}
+
+	result := queryGroupCollectionRecords(1_700, records, GroupCollectionQuery{Page: 1, PageSize: 20})
+	if got, want := groupCollectionItemIDs(result.Items), []uint{1, 2}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("recent activity fallback IDs = %#v, want %#v", got, want)
 	}
 }
 
@@ -350,4 +400,28 @@ func groupCollectionItemIDs(items []GroupCollectionItem) []uint {
 		result[index] = items[index].ID
 	}
 	return result
+}
+
+func createGroupCollectionUsageStat(
+	t *testing.T,
+	fixture serviceFixture,
+	groupID uint,
+	bucketStartMS int64,
+	requestCount int64,
+	model string,
+) {
+	t.Helper()
+	row := models.UsageStat{
+		BucketStartMS: bucketStartMS,
+		AccessKeyID:   1,
+		ChannelID:     string(channel.OpenAICompatible),
+		GroupID:       groupID,
+		CredentialID:  1,
+		Model:         model,
+		RequestCount:  requestCount,
+		SuccessCount:  requestCount,
+	}
+	if err := fixture.db.Create(&row).Error; err != nil {
+		t.Fatalf("create usage stat for group %d: %v", groupID, err)
+	}
 }

--- a/internal/control/group_collection_query_test.go
+++ b/internal/control/group_collection_query_test.go
@@ -5,8 +5,13 @@ import (
 	"encoding/json"
 	"math"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
+
+	gormmysql "gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 
 	"gpt-load/internal/channel"
 	"gpt-load/internal/protocol"
@@ -80,6 +85,33 @@ func TestListGroupCollectionSortsRecentActivityByHourThenRequestCount(t *testing
 		recentHigh.ID, recentLow.ID, older.ID, unusedAlpha.ID, unusedZulu.ID,
 	}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("recent activity IDs = %#v, want %#v", got, want)
+	}
+}
+
+func TestGroupCollectionLatestActivityScopeQuotesGroupsForMySQL(t *testing.T) {
+	db, err := gorm.Open(gormmysql.New(gormmysql.Config{
+		DSN:                       "user:password@tcp(127.0.0.1:3306)/gpt_load",
+		SkipInitializeWithVersion: true,
+	}), &gorm.Config{
+		DryRun:                 true,
+		DisableAutomaticPing:   true,
+		SkipDefaultTransaction: true,
+		Logger:                 logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("gorm.Open() error = %v", err)
+	}
+
+	result := groupCollectionLatestActivityScope(db).Find(&[]groupCollectionActivityRow{})
+	if result.Error != nil {
+		t.Fatalf("latest activity query error = %v", result.Error)
+	}
+	sql := result.Statement.SQL.String()
+	if strings.Contains(sql, "JOIN groups") {
+		t.Fatalf("generated SQL = %q, must not contain an unquoted groups join", sql)
+	}
+	if !strings.Contains(sql, "FROM `groups`") {
+		t.Fatalf("generated SQL = %q, want GORM-quoted groups subquery", sql)
 	}
 }
 

--- a/internal/control/group_detail.go
+++ b/internal/control/group_detail.go
@@ -42,7 +42,7 @@ func (s *Service) GetGroupSummary(ctx context.Context, groupID uint) (GroupSumma
 	if groupID == 0 {
 		return GroupSummaryResponse{}, app_errors.ErrBadRequest
 	}
-	_, records, err := s.captureGroupCollectionRecords(ctx)
+	_, records, err := s.captureGroupCollectionRecords(ctx, false)
 	if err != nil {
 		return GroupSummaryResponse{}, err
 	}

--- a/internal/storage/database_integration_test.go
+++ b/internal/storage/database_integration_test.go
@@ -119,10 +119,14 @@ func TestExternalDatabaseLifecycle(t *testing.T) {
 	if err := db.Table("schema_migrations").Order("id").Pluck("id", &migrationIDs).Error; err != nil {
 		t.Fatalf("read migration ledger: %v", err)
 	}
-	if len(migrationIDs) != 3 || migrationIDs[0] != "0001_initial" ||
+	if len(migrationIDs) != 4 || migrationIDs[0] != "0001_initial" ||
 		migrationIDs[1] != "0002_access_key_cost_limits" ||
-		migrationIDs[2] != "0003_remove_observation_fresh_until" {
-		t.Fatalf("migration ledger = %v, want complete 0001-0003 chain", migrationIDs)
+		migrationIDs[2] != "0003_remove_observation_fresh_until" ||
+		migrationIDs[3] != "0004_usage_stats_group_activity_index" {
+		t.Fatalf("migration ledger = %v, want complete 0001-0004 chain", migrationIDs)
+	}
+	if !db.Migrator().HasIndex("usage_stats", "idx_usage_stats_group_bucket") {
+		t.Fatal("usage_stats group activity index is missing")
 	}
 
 	accessKey := models.AccessKey{

--- a/internal/storage/db_test.go
+++ b/internal/storage/db_test.go
@@ -628,6 +628,7 @@ func TestAutoMigrateCreatesUsageJournalAndMigrationLedger(t *testing.T) {
 		"0001_initial",
 		"0002_access_key_cost_limits",
 		"0003_remove_observation_fresh_until",
+		"0004_usage_stats_group_activity_index",
 	}
 	if !reflect.DeepEqual(migrationIDs, wantMigrationIDs) {
 		t.Fatalf("schema_migrations IDs = %v, want %v", migrationIDs, wantMigrationIDs)

--- a/internal/storage/migration.go
+++ b/internal/storage/migration.go
@@ -57,6 +57,12 @@ var migrations = []migration{
 		Validate:            migrationfiles.Validate0003,
 		ValidateRecoverable: migrationfiles.ValidateRecoverable0003,
 	},
+	{
+		ID:                  migrationfiles.ID0004,
+		Up:                  migrationfiles.Up0004,
+		Validate:            migrationfiles.Validate0004,
+		ValidateRecoverable: migrationfiles.ValidateRecoverable0004,
+	},
 }
 
 func applyMigrations(db *gorm.DB) error {

--- a/internal/storage/migration_recovery_test.go
+++ b/internal/storage/migration_recovery_test.go
@@ -247,7 +247,7 @@ func TestExternalDatabaseMySQLInterruptedBaselineRecovery(t *testing.T) {
 				_ = restartedSQL.Close()
 				t.Fatalf("resume MySQL schema prefix %d: %v", boundary, err)
 			}
-			assertInternalMigrationComplete(t, restarted, []string{migrations[0].ID, migrations[1].ID, migrations[2].ID})
+			assertInternalMigrationComplete(t, restarted, []string{migrations[0].ID, migrations[1].ID, migrations[2].ID, migrations[3].ID})
 			if err := restartedSQL.Close(); err != nil {
 				t.Fatalf("close recovered database: %v", err)
 			}
@@ -281,7 +281,7 @@ func TestExternalDatabaseIncrementalMigrations(t *testing.T) {
 	if err := AutoMigrate(db); err != nil {
 		t.Fatalf("repeat migrated schema validation: %v", err)
 	}
-	assertInternalMigrationComplete(t, db, []string{migrations[0].ID, migrations[1].ID, migrations[2].ID})
+	assertInternalMigrationComplete(t, db, []string{migrations[0].ID, migrations[1].ID, migrations[2].ID, migrations[3].ID})
 }
 
 func TestExternalDatabaseMySQLRecoversObservationFreshnessCheckDrop(t *testing.T) {
@@ -320,7 +320,7 @@ func TestExternalDatabaseMySQLRecoversObservationFreshnessCheckDrop(t *testing.T
 	if err := AutoMigrate(db); err != nil {
 		t.Fatalf("resume observation freshness removal: %v", err)
 	}
-	assertInternalMigrationComplete(t, db, []string{migrations[0].ID, migrations[1].ID, migrations[2].ID})
+	assertInternalMigrationComplete(t, db, []string{migrations[0].ID, migrations[1].ID, migrations[2].ID, migrations[3].ID})
 }
 
 func openExternalIncrementalMigrationDatabase(t *testing.T, rawDSN string) *gorm.DB {
@@ -443,7 +443,7 @@ func runExternalMySQLCostLimitRecovery(t *testing.T, admin *gorm.DB, parsed *url
 				_ = restartedSQL.Close()
 				t.Fatalf("resume MySQL cost-limit schema prefix %d: %v", boundary, err)
 			}
-			assertInternalMigrationComplete(t, restarted, []string{migrations[0].ID, migrations[1].ID, migrations[2].ID})
+			assertInternalMigrationComplete(t, restarted, []string{migrations[0].ID, migrations[1].ID, migrations[2].ID, migrations[3].ID})
 			if err := restartedSQL.Close(); err != nil {
 				t.Fatalf("close recovered database: %v", err)
 			}
@@ -483,6 +483,9 @@ func assertInternalMigrationComplete(t *testing.T, db *gorm.DB, wantIDs []string
 	}
 	if len(wantIDs) >= 3 && db.Migrator().HasColumn("credential_observations", "fresh_until_ms") {
 		t.Error("credential_observations.fresh_until_ms remains after migration 0003")
+	}
+	if len(wantIDs) >= 4 && !db.Migrator().HasIndex("usage_stats", "idx_usage_stats_group_bucket") {
+		t.Error("usage_stats group activity index is missing after migration 0004")
 	}
 	var ids []string
 	if err := db.Table(migrationLedgerTable).Order("id").Pluck("id", &ids).Error; err != nil {

--- a/internal/storage/migration_test.go
+++ b/internal/storage/migration_test.go
@@ -11,7 +11,12 @@ import (
 )
 
 func TestMigrationRegistryContainsOrderedMigrations(t *testing.T) {
-	wantIDs := []string{migrationfiles.ID0001, migrationfiles.ID0002, migrationfiles.ID0003}
+	wantIDs := []string{
+		migrationfiles.ID0001,
+		migrationfiles.ID0002,
+		migrationfiles.ID0003,
+		migrationfiles.ID0004,
+	}
 	if len(migrations) != len(wantIDs) {
 		t.Fatalf("migration registry length = %d, want %d", len(migrations), len(wantIDs))
 	}

--- a/internal/storage/migrations/0004_usage_stats_group_activity_index.go
+++ b/internal/storage/migrations/0004_usage_stats_group_activity_index.go
@@ -1,0 +1,56 @@
+package migrations
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+const (
+	// ID0004 adds the index used to find each Group's most recent usage hour.
+	ID0004 = "0004_usage_stats_group_activity_index"
+
+	usageStatsGroupBucketIndex0004 = "idx_usage_stats_group_bucket"
+)
+
+type usageStat0004 struct {
+	GroupID       uint  `gorm:"column:group_id;index:idx_usage_stats_group_bucket,priority:1"`
+	BucketStartMS int64 `gorm:"column:bucket_start_ms;index:idx_usage_stats_group_bucket,priority:2,sort:desc"`
+}
+
+func (usageStat0004) TableName() string {
+	return "usage_stats"
+}
+
+// Up0004 adds a Group-first activity index without changing usage data.
+func Up0004(db *gorm.DB) error {
+	if !db.Migrator().HasTable(&usageStat0004{}) {
+		return fmt.Errorf("add usage stats group activity index: table %q is missing", usageStat0004{}.TableName())
+	}
+	if db.Migrator().HasIndex(&usageStat0004{}, usageStatsGroupBucketIndex0004) {
+		return nil
+	}
+	if err := db.Migrator().CreateIndex(&usageStat0004{}, usageStatsGroupBucketIndex0004); err != nil {
+		return fmt.Errorf("add usage stats group activity index: %w", err)
+	}
+	return nil
+}
+
+// ValidateRecoverable0004 accepts either side of this idempotent index creation.
+func ValidateRecoverable0004(db *gorm.DB) error {
+	if !db.Migrator().HasTable(&usageStat0004{}) {
+		return fmt.Errorf("validate recoverable usage stats group activity index: table %q is missing", usageStat0004{}.TableName())
+	}
+	return nil
+}
+
+// Validate0004 verifies the activity lookup index is present.
+func Validate0004(db *gorm.DB) error {
+	if !db.Migrator().HasTable(&usageStat0004{}) {
+		return fmt.Errorf("validate usage stats group activity index: table %q is missing", usageStat0004{}.TableName())
+	}
+	if !db.Migrator().HasIndex(&usageStat0004{}, usageStatsGroupBucketIndex0004) {
+		return fmt.Errorf("validate usage stats group activity index: index %q is missing", usageStatsGroupBucketIndex0004)
+	}
+	return nil
+}

--- a/internal/storage/migrations/0004_usage_stats_group_activity_index_test.go
+++ b/internal/storage/migrations/0004_usage_stats_group_activity_index_test.go
@@ -1,0 +1,54 @@
+package migrations_test
+
+import (
+	"testing"
+
+	"gpt-load/internal/storage/migrations"
+)
+
+func TestUsageStatsGroupActivityIndexMigrationCreatesAndValidatesIndex(t *testing.T) {
+	db := openInitialTestDatabase(t)
+	if err := migrations.Up0001(db); err != nil {
+		t.Fatal(err)
+	}
+	if err := migrations.Up0002(db); err != nil {
+		t.Fatal(err)
+	}
+	if err := migrations.Up0003(db); err != nil {
+		t.Fatal(err)
+	}
+	if db.Migrator().HasIndex("usage_stats", "idx_usage_stats_group_bucket") {
+		t.Fatal("usage_stats group activity index exists before migration")
+	}
+	if err := migrations.ValidateRecoverable0004(db); err != nil {
+		t.Fatalf("ValidateRecoverable0004() before index = %v", err)
+	}
+	if err := migrations.Up0004(db); err != nil {
+		t.Fatalf("Up0004() error = %v", err)
+	}
+	if !db.Migrator().HasIndex("usage_stats", "idx_usage_stats_group_bucket") {
+		t.Fatal("usage_stats group activity index is missing")
+	}
+	if err := migrations.Validate0004(db); err != nil {
+		t.Fatalf("Validate0004() error = %v", err)
+	}
+	if err := migrations.Up0004(db); err != nil {
+		t.Fatalf("repeated Up0004() error = %v", err)
+	}
+}
+
+func TestUsageStatsGroupActivityIndexMigrationRejectsMissingIndex(t *testing.T) {
+	db := openInitialTestDatabase(t)
+	if err := migrations.Up0001(db); err != nil {
+		t.Fatal(err)
+	}
+	if err := migrations.Up0002(db); err != nil {
+		t.Fatal(err)
+	}
+	if err := migrations.Up0003(db); err != nil {
+		t.Fatal(err)
+	}
+	if err := migrations.Validate0004(db); err == nil {
+		t.Fatal("Validate0004() error = nil, want missing index error")
+	}
+}

--- a/internal/storage/models/request.go
+++ b/internal/storage/models/request.go
@@ -119,10 +119,10 @@ func (UsageAggregationJournal) TableName() string {
 // credential, and upstream model.
 type UsageStat struct {
 	ID                      uint   `gorm:"primaryKey;autoIncrement"`
-	BucketStartMS           int64  `gorm:"column:bucket_start_ms;not null;check:chk_usage_stat_bucket,bucket_start_ms >= 0;uniqueIndex:idx_usage_stats_identity,priority:1;index:idx_usage_stats_credential_bucket,priority:2"`
+	BucketStartMS           int64  `gorm:"column:bucket_start_ms;not null;check:chk_usage_stat_bucket,bucket_start_ms >= 0;uniqueIndex:idx_usage_stats_identity,priority:1;index:idx_usage_stats_credential_bucket,priority:2;index:idx_usage_stats_group_bucket,priority:2,sort:desc"`
 	AccessKeyID             uint   `gorm:"not null;uniqueIndex:idx_usage_stats_identity,priority:2"`
 	ChannelID               string `gorm:"type:varchar(64);not null;default:'';uniqueIndex:idx_usage_stats_identity,priority:3"`
-	GroupID                 uint   `gorm:"not null;uniqueIndex:idx_usage_stats_identity,priority:4"`
+	GroupID                 uint   `gorm:"not null;uniqueIndex:idx_usage_stats_identity,priority:4;index:idx_usage_stats_group_bucket,priority:1"`
 	CredentialID            uint   `gorm:"not null;default:0;uniqueIndex:idx_usage_stats_identity,priority:5;index:idx_usage_stats_credential_bucket,priority:1"`
 	Model                   string `gorm:"type:varchar(255);not null;uniqueIndex:idx_usage_stats_identity,priority:6"`
 	RequestCount            int64  `gorm:"not null;default:0;check:chk_usage_stat_request_count,request_count >= 0;check:chk_usage_stat_request_outcome,request_count = success_count + failure_count"`

--- a/web/src/api/control/types.ts
+++ b/web/src/api/control/types.ts
@@ -14,7 +14,7 @@ export type FailureCategory =
 
 export type GroupCollectionStatus = 'available' | 'unavailable' | 'disabled'
 export type GroupUnavailableReason = 'no_available_credentials' | 'no_models'
-export type GroupCollectionSort = 'status' | 'name' | 'credentials' | 'created'
+export type GroupCollectionSort = 'recent' | 'status' | 'name' | 'credentials' | 'created'
 export type ModelPricingStatus = 'pending' | 'configured'
 export type ChannelParamsDto = Record<string, string>
 export type ConnectionType = 'api_key' | 'subscription'

--- a/web/src/features/groups/GroupsView.vue
+++ b/web/src/features/groups/GroupsView.vue
@@ -47,7 +47,13 @@ import {
   serializeGroupCollectionRouteQuery,
 } from './group-collection-route'
 
-const sortOptions: readonly GroupCollectionSort[] = ['status', 'name', 'credentials', 'created']
+const sortOptions: readonly GroupCollectionSort[] = [
+  'recent',
+  'status',
+  'name',
+  'credentials',
+  'created',
+]
 
 const client = useApiClient()
 const route = useRoute()
@@ -72,7 +78,7 @@ const hasFilterCriteria = computed(
     filters.value.connection_type !== undefined,
 )
 const hasChangedConditions = computed(
-  () => hasFilterCriteria.value || filters.value.sort !== 'status',
+  () => hasFilterCriteria.value || filters.value.sort !== 'recent',
 )
 const collectionBusy = computed(() => data.value !== undefined && groupsQuery.isFetching.value)
 const {
@@ -207,7 +213,7 @@ function setSort(value: string): void {
 function resetConditions(): void {
   searchDebounce.cancel()
   searchDraft.value = ''
-  routeWithFilters({ sort: 'status', page: 1, page_size: 20 })
+  routeWithFilters({ sort: 'recent', page: 1, page_size: 20 })
 }
 
 function setPage(page: number): void {

--- a/web/src/features/groups/group-collection-route.ts
+++ b/web/src/features/groups/group-collection-route.ts
@@ -15,13 +15,13 @@ import {
 } from '@/app/route-query'
 
 const defaultFilters: GroupCollectionFilters = {
-  sort: 'status',
+  sort: 'recent',
   page: 1,
   page_size: 20,
 }
 const statuses = new Set<GroupCollectionStatus>(['available', 'unavailable', 'disabled'])
 const connectionTypes = new Set<ConnectionType>(['api_key', 'subscription'])
-const sorts = new Set<GroupCollectionSort>(['status', 'name', 'credentials', 'created'])
+const sorts = new Set<GroupCollectionSort>(['recent', 'status', 'name', 'credentials', 'created'])
 
 export function normalizeGroupCollectionSearchQuery(value: string | undefined): string | undefined {
   return normalizeCollectionSearch(value)

--- a/web/src/i18n/locales/en-US/group.ts
+++ b/web/src/i18n/locales/en-US/group.ts
@@ -36,6 +36,7 @@ export default {
         subscription: 'Subscription account',
       },
       sort: {
+        recent: 'Recently used',
         status: 'Status first',
         name: 'Name A–Z',
         credentials: 'Credential count',

--- a/web/src/i18n/locales/ja-JP/group.ts
+++ b/web/src/i18n/locales/ja-JP/group.ts
@@ -36,6 +36,7 @@ export default {
         subscription: 'サブスクリプションアカウント',
       },
       sort: {
+        recent: '最近利用',
         status: 'ステータス優先',
         name: '名前 A–Z',
         credentials: '認証情報数',

--- a/web/src/i18n/locales/zh-CN/group.ts
+++ b/web/src/i18n/locales/zh-CN/group.ts
@@ -36,6 +36,7 @@ export default {
         subscription: '订阅账号',
       },
       sort: {
+        recent: '最近调用',
         status: '状态优先',
         name: '名称 A–Z',
         credentials: '凭据数量',


### PR DESCRIPTION
### 关联 Issue / Related Issue
无

### 变更内容 / Change Content
- [ ] Bug 修复 / Bug fix
- [x] 新功能 / New feature
- [ ] 其他改动 / Other changes

- 分组列表新增并默认使用“最近调用”排序：按最近活跃小时降序、同小时按请求数降序、无调用记录按名称兜底。
- 聚合读取仅复用 `usage_stats`，不查询原始请求日志；新增 `0004_usage_stats_group_activity_index` 为分组最近活跃查询建立索引。
- 非“最近调用”排序和分组详情不读取活动聚合；活动查询改为关联现有 `groups`，避免全量 ID 参数列表。
- 同步更新 URL 默认值、筛选重置行为和中英日文案，并补充控制面与迁移回归测试。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [ ] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.

兼容性：`sort=recent` 为新增参数，既有显式排序值保持可用；未携带 `sort` 的分组列表默认顺序改为最近调用优先。新增 `0004` 索引迁移，不改写已有数据。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 群组列表新增“最近调用”排序，按最近活跃时间、请求数及名称排列。
  - 展示群组最近活动时间和近期请求统计。
  - 支持中文、英文和日文排序名称。

- **改进**
  - 群组列表默认按最近调用排序。
  - 无活动记录的群组仍可正常显示，并按名称排序。

- **问题修复**
  - 增强活动数据校验，拒绝无效或重复记录。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->