### PR TITLE
ci(release): 消除 CI 与发布流水线中的耗时浪费

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,21 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Mark race-instrumented Go cache scope
+        # race-tests、test、database-contract(*) 默认共用同一个基于 go.sum 的
+        # setup-go 缓存 key；命中即不保存，race-instrumented GOCACHE 永远无法
+        # 写回，每次都要重新编译。加入这个 marker 文件参与 cache-dependency-path
+        # 哈希，让 race-tests 拥有独立 key 命名空间。
+        run: echo race-tests > .go-cache-scope
+
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true
+          cache-dependency-path: |
+            go.sum
+            .go-cache-scope
 
       - name: Run race-enabled tests
         run: go test -race -count=1 -timeout=15m . ./internal/...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,11 +192,21 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Mark race-instrumented Go cache scope
+        # race-tests、test、database-contract(*) 默认共用同一个基于 go.sum 的
+        # setup-go 缓存 key；命中即不保存，race-instrumented GOCACHE 永远无法
+        # 写回，每次都要重新编译。加入这个 marker 文件参与 cache-dependency-path
+        # 哈希，让 race-tests 拥有独立 key 命名空间。
+        run: echo race-tests > .go-cache-scope
+
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true
+          cache-dependency-path: |
+            go.sum
+            .go-cache-scope
 
       - name: Run race-enabled tests
         run: go test -race -count=1 -timeout=15m . ./internal/...
@@ -424,6 +434,15 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+      - name: Upload release checksums
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-checksums
+          path: release/SHA256SUMS
+          if-no-files-found: error
+          # 仅供 native-artifact-smoke 按需下载单个校验和文件，不作为发布产物单独保留。
+          retention-days: 1
+
   native-artifact-smoke:
     # package-checksums 已经依赖 build-binaries，无需重复声明。
     needs: package-checksums
@@ -450,10 +469,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Download complete release assets
+      - name: Download release binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: release-assets
+          name: binary-${{ matrix.filename }}
+          path: native-smoke
+
+      - name: Download release checksums
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-checksums
           path: native-smoke
 
       - name: Smoke POSIX native artifact
@@ -581,9 +606,6 @@ jobs:
           done
           gh auth status
           gh api "repos/${GITHUB_REPOSITORY}" --silent
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR for read-only inventory
         uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
@@ -838,10 +860,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ github.ref_name }}
-          # 复用上一次发布的依赖层（go mod download / pnpm install）；
-          # Go 与 Web 源码层每个 tag 必然失效，这里只回收不变的依赖安装成本。
-          cache-from: type=gha,scope=release-image
-          cache-to: type=gha,scope=release-image,mode=max
 
       - name: Verify exact published images
         shell: bash
@@ -1085,9 +1103,6 @@ jobs:
             exit 1
           fi
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
       - name: Log in to GHCR for manifest verification
         uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
         with:
@@ -1185,11 +1200,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-
-      - name: Set up Docker Buildx for read-only reconciliation
-        if: ${{ always() }}
-        continue-on-error: true
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR for read-only reconciliation
         if: ${{ always() }}

--- a/internal/webui/workflow_test.go
+++ b/internal/webui/workflow_test.go
@@ -1430,7 +1430,8 @@ func TestReleaseWorkflowVerifiesDownloadedNativeChecksumsAndGeneratedKeys(t *tes
 	nativePowerShellImplementation := readRepositoryFile(t, ".github/scripts/release-native-smoke.ps1")
 	nativeImplementation := nativeJob + nativeShellImplementation + nativePowerShellImplementation
 	for _, required := range []string{
-		"name: release-assets",
+		"name: binary-${{ matrix.filename }}",
+		"name: release-checksums",
 		"SHA256SUMS",
 		"sha256sum",
 		"shasum -a 256",


### PR DESCRIPTION
### 关联 Issue / Related Issue
N/A

### 变更内容 / Change Content
- [ ] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [x] 其他改动 / Other changes

针对 CI（约 9 分钟）与 Release（约 13 分钟）流水线的耗时排查后，做以下四项独立、低风险的 workflow 结构优化：

- `race-tests` 建立独立的 `setup-go` 缓存命名空间：此前与 `test`/`database-contract(*)` 共用同一个基于 `go.sum` 的缓存 key，命中即不保存，race-instrumented `GOCACHE` 永远无法写回，每次都要重新完整编译（约 124s）。改动依据 `actions/setup-go` 官方文档的 "Parallel builds"/"Multi-target builds" 章节。
  - **注意**：这个改动的收益需要两次连续运行才能体现——第一次运行 cache key 是新的，必然 miss，会完整编译并建立新缓存；从第二次运行起才会命中。另外 `release.yml` 中的 `race-tests` 有 `if: needs.validate-tag.outputs.ci_verified != 'true'`，如果打 tag 前对应 commit 已经在 `v2` 分支跑过一次 CI 并成功，打 tag 时这个 job 会被跳过（复用 CI 结论），看不到效果。**要观察这项收益，应该看 `ci.yml` 在 `v2` 分支上连续两次的运行耗时，而不是 release 流程。**
- 移除 `publish-images` 中零命中的 GHA buildx image cache：两次真实 beta 发布实测均为 0 命中层，且 cache 导出子步骤失败会拖累整个推送步骤失败，导致下游 job 不运行、下次被判定为 `partial`/`blocked` 卡住重试。直接移除后这个失败模式也一并消失。
- 三个只读 job（`publication-preflight`、`post-publish-verify`、`reconcile-publication`，均只用 `docker buildx imagetools` 做只读查询）移除多余的 `docker/setup-buildx-action` 初始化——已确认 `ubuntu-24.04` runner 默认预装 Buildx，且三者用到的都是不需要专用 builder 的只读命令。
- `native-artifact-smoke`（5 个平台并行 smoke）改为按需下载单个 binary + 独立的 checksums artifact，不再下载完整 `release-assets`（145MB）。同步更新了 `internal/webui/workflow_test.go` 中对下载方式的既有硬编码断言。

验证：
- `make check`
- `go test -count=1 -run TestReleaseWorkflow ./internal/webui/...`
- `ruby -ryaml` 校验两份 workflow YAML 语法有效（未引入新依赖）

无法本地验证的部分：GHA cache 的实际命中率与 `publish-images` 等 job 的真实墙钟耗时收益，依赖 GitHub 云端基础设施状态，需通过后续真实 tag 推送观测。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.（本次为 CI/CD 内部配置调整，不涉及用户可见功能或公开文档）
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.（不涉及数据迁移或对外契约变更）