### PR TITLE
ci(release): 消除 CI 与发布流水线中的耗时浪费

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,21 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Mark race-instrumented Go cache scope
+        # race-tests、test、database-contract(*) 默认共用同一个基于 go.sum 的
+        # setup-go 缓存 key；命中即不保存，race-instrumented GOCACHE 永远无法
+        # 写回，每次都要重新编译。加入这个 marker 文件参与 cache-dependency-path
+        # 哈希，让 race-tests 拥有独立 key 命名空间。
+        run: echo race-tests > .go-cache-scope
+
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true
+          cache-dependency-path: |
+            go.sum
+            .go-cache-scope
 
       - name: Run race-enabled tests
         run: go test -race -count=1 -timeout=15m . ./internal/...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,11 +192,21 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Mark race-instrumented Go cache scope
+        # race-tests、test、database-contract(*) 默认共用同一个基于 go.sum 的
+        # setup-go 缓存 key；命中即不保存，race-instrumented GOCACHE 永远无法
+        # 写回，每次都要重新编译。加入这个 marker 文件参与 cache-dependency-path
+        # 哈希，让 race-tests 拥有独立 key 命名空间。
+        run: echo race-tests > .go-cache-scope
+
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true
+          cache-dependency-path: |
+            go.sum
+            .go-cache-scope
 
       - name: Run race-enabled tests
         run: go test -race -count=1 -timeout=15m . ./internal/...
@@ -424,6 +434,15 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+      - name: Upload release checksums
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-checksums
+          path: release/SHA256SUMS
+          if-no-files-found: error
+          # 仅供 native-artifact-smoke 按需下载单个校验和文件，不作为发布产物单独保留。
+          retention-days: 1
+
   native-artifact-smoke:
     # package-checksums 已经依赖 build-binaries，无需重复声明。
     needs: package-checksums
@@ -450,10 +469,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Download complete release assets
+      - name: Download release binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: release-assets
+          name: binary-${{ matrix.filename }}
+          path: native-smoke
+
+      - name: Download release checksums
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-checksums
           path: native-smoke
 
       - name: Smoke POSIX native artifact
@@ -581,9 +606,6 @@ jobs:
           done
           gh auth status
           gh api "repos/${GITHUB_REPOSITORY}" --silent
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR for read-only inventory
         uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
@@ -838,10 +860,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ github.ref_name }}
-          # 复用上一次发布的依赖层（go mod download / pnpm install）；
-          # Go 与 Web 源码层每个 tag 必然失效，这里只回收不变的依赖安装成本。
-          cache-from: type=gha,scope=release-image
-          cache-to: type=gha,scope=release-image,mode=max
 
       - name: Verify exact published images
         shell: bash
@@ -1085,9 +1103,6 @@ jobs:
             exit 1
           fi
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
       - name: Log in to GHCR for manifest verification
         uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
         with:
@@ -1185,11 +1200,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-
-      - name: Set up Docker Buildx for read-only reconciliation
-        if: ${{ always() }}
-        continue-on-error: true
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR for read-only reconciliation
         if: ${{ always() }}

--- a/internal/webui/workflow_test.go
+++ b/internal/webui/workflow_test.go
@@ -1430,7 +1430,8 @@ func TestReleaseWorkflowVerifiesDownloadedNativeChecksumsAndGeneratedKeys(t *tes
 	nativePowerShellImplementation := readRepositoryFile(t, ".github/scripts/release-native-smoke.ps1")
 	nativeImplementation := nativeJob + nativeShellImplementation + nativePowerShellImplementation
 	for _, required := range []string{
-		"name: release-assets",
+		"name: binary-${{ matrix.filename }}",
+		"name: release-checksums",
 		"SHA256SUMS",
 		"sha256sum",
 		"shasum -a 256",


### PR DESCRIPTION
- race-tests 独立 setup-go 缓存命名空间，避免与 test/database-contract 共用 key 导致 race-instrumented GOCACHE 永远无法写回
- 移除 publish-images 中零命中的 GHA buildx image cache，同时消除其 失败会拖累发布状态判定为 partial/blocked 的关联风险
- 三个只读 job（仅用 buildx imagetools 查询）移除多余的 buildx 初始化
- native-artifact-smoke 改为按需下载单个 binary + 独立 checksums， 不再下载完整 release-assets

### 关联 Issue / Related Issue
<!-- 请填写此 PR 关联的 issue 编号，例如：Closes #123 / Please link the issue number, e.g., Closes #123 -->
Closes #

### 变更内容 / Change Content
<!-- 请简要描述本次变更的核心内容 / Please briefly describe the core changes of this PR -->
- [ ] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

<!-- 请在下方详细描述你的变更 / Please describe your changes in detail below -->


### 自查清单 / Checklist
- [ ] 我已在本地测试过我的变更。 / I have tested my changes locally.
- [ ] 我已更新了必要的文档。 / I have updated the necessary documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **发布流程改进**
  - 优化竞态测试与发布流程的缓存隔离，提升构建稳定性。
  - 发布产物与校验和文件现分别提供和验证，便于下载及完整性检查。
  - 精简发布前检查、发布后验证和协调流程，减少不必要的构建步骤。

- **测试**
  - 更新原生发布冒烟测试，覆盖新的二进制产物及校验和文件。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->