### PR TITLE
perf: 优化测试性能与 CI/发布流水线耗时

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,21 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Mark race-instrumented Go cache scope
+        # race-tests、test、database-contract(*) 默认共用同一个基于 go.sum 的
+        # setup-go 缓存 key；命中即不保存，race-instrumented GOCACHE 永远无法
+        # 写回，每次都要重新编译。加入这个 marker 文件参与 cache-dependency-path
+        # 哈希，让 race-tests 拥有独立 key 命名空间。
+        run: echo race-tests > .go-cache-scope
+
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true
+          cache-dependency-path: |
+            go.sum
+            .go-cache-scope
 
       - name: Run race-enabled tests
         run: go test -race -count=1 -timeout=15m . ./internal/...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,11 +192,21 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Mark race-instrumented Go cache scope
+        # race-tests、test、database-contract(*) 默认共用同一个基于 go.sum 的
+        # setup-go 缓存 key；命中即不保存，race-instrumented GOCACHE 永远无法
+        # 写回，每次都要重新编译。加入这个 marker 文件参与 cache-dependency-path
+        # 哈希，让 race-tests 拥有独立 key 命名空间。
+        run: echo race-tests > .go-cache-scope
+
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true
+          cache-dependency-path: |
+            go.sum
+            .go-cache-scope
 
       - name: Run race-enabled tests
         run: go test -race -count=1 -timeout=15m . ./internal/...
@@ -424,6 +434,15 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+      - name: Upload release checksums
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-checksums
+          path: release/SHA256SUMS
+          if-no-files-found: error
+          # 仅供 native-artifact-smoke 按需下载单个校验和文件，不作为发布产物单独保留。
+          retention-days: 1
+
   native-artifact-smoke:
     # package-checksums 已经依赖 build-binaries，无需重复声明。
     needs: package-checksums
@@ -450,10 +469,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Download complete release assets
+      - name: Download release binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: release-assets
+          name: binary-${{ matrix.filename }}
+          path: native-smoke
+
+      - name: Download release checksums
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-checksums
           path: native-smoke
 
       - name: Smoke POSIX native artifact
@@ -581,9 +606,6 @@ jobs:
           done
           gh auth status
           gh api "repos/${GITHUB_REPOSITORY}" --silent
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR for read-only inventory
         uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
@@ -838,10 +860,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ github.ref_name }}
-          # 复用上一次发布的依赖层（go mod download / pnpm install）；
-          # Go 与 Web 源码层每个 tag 必然失效，这里只回收不变的依赖安装成本。
-          cache-from: type=gha,scope=release-image
-          cache-to: type=gha,scope=release-image,mode=max
 
       - name: Verify exact published images
         shell: bash
@@ -1085,9 +1103,6 @@ jobs:
             exit 1
           fi
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
       - name: Log in to GHCR for manifest verification
         uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
         with:
@@ -1185,11 +1200,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-
-      - name: Set up Docker Buildx for read-only reconciliation
-        if: ${{ always() }}
-        continue-on-error: true
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR for read-only reconciliation
         if: ${{ always() }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -350,8 +350,9 @@ jobs:
           name: binary-${{ matrix.filename }}
           path: release/${{ matrix.filename }}
           if-no-files-found: error
-          # 仅在本次 run 内汇总进 release-assets，不单独保留。
-          retention-days: 1
+          # native-artifact-smoke 按需下载此产物；保留期需与 release-assets
+          # 一致，否则失败的 run 在超过较短保留期后重试会因产物过期而无法下载。
+          retention-days: 14
 
   package-metadata:
     needs: validate-tag
@@ -440,8 +441,9 @@ jobs:
           name: release-checksums
           path: release/SHA256SUMS
           if-no-files-found: error
-          # 仅供 native-artifact-smoke 按需下载单个校验和文件，不作为发布产物单独保留。
-          retention-days: 1
+          # 供 native-artifact-smoke 按需下载单个校验和文件；保留期需与
+          # release-assets 一致，否则失败的 run 延迟重试时可能已过期。
+          retention-days: 14
 
   native-artifact-smoke:
     # package-checksums 已经依赖 build-binaries，无需重复声明。

--- a/internal/control/access_key_collection_http_test.go
+++ b/internal/control/access_key_collection_http_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestParseAccessKeyCollectionQueryAcceptsStrictContract(t *testing.T) {
+	t.Parallel()
 	active := state.AccessKeyStatusActive
 	disabled := state.AccessKeyStatusDisabled
 	q200 := strings.Repeat("猫", 200)
@@ -49,6 +50,7 @@ func TestParseAccessKeyCollectionQueryAcceptsStrictContract(t *testing.T) {
 }
 
 func TestParseAccessKeyCollectionQueryRejectsEveryInvalidForm(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		rawQuery   string
@@ -92,6 +94,7 @@ func TestParseAccessKeyCollectionQueryRejectsEveryInvalidForm(t *testing.T) {
 }
 
 func TestAccessKeyCollectionHTTPReturnsAuthenticatedCollectionEnvelope(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	fixture.service.random = bytes.NewReader(append(make([]byte, 16), bytes.Repeat([]byte{1}, 16)...))
@@ -155,6 +158,7 @@ func TestAccessKeyCollectionHTTPReturnsAuthenticatedCollectionEnvelope(t *testin
 }
 
 func TestAccessKeyCollectionHTTPReturnsLatestRequestTimeAndOmitsCollectionScope(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	fixture.service.random = bytes.NewReader(append(make([]byte, 16), bytes.Repeat([]byte{1}, 16)...))
@@ -219,6 +223,7 @@ func TestAccessKeyCollectionHTTPReturnsLatestRequestTimeAndOmitsCollectionScope(
 }
 
 func TestAccessKeyCollectionHTTPRejectsInvalidQueryBeforeServiceAccess(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	engine := gin.New()

--- a/internal/control/access_key_collection_query_test.go
+++ b/internal/control/access_key_collection_query_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestQueryAccessKeyCollectionRecordsSummarizesBeforeFiltering(t *testing.T) {
+	t.Parallel()
 	active := state.AccessKeyStatusActive
 	records := []accessKeyCollectionRecord{
 		accessKeyCollectionQueryRecord(1, "Alpha", "0001", active, 100),
@@ -33,6 +34,7 @@ func TestQueryAccessKeyCollectionRecordsSummarizesBeforeFiltering(t *testing.T) 
 }
 
 func TestQueryAccessKeyCollectionRecordsFiltersCaseFoldedNameAndMaskedSuffix(t *testing.T) {
+	t.Parallel()
 	records := []accessKeyCollectionRecord{
 		accessKeyCollectionQueryRecord(1, "München", "cafe", state.AccessKeyStatusActive, 100),
 		accessKeyCollectionQueryRecord(2, "Other", "beef", state.AccessKeyStatusActive, 200),
@@ -59,6 +61,7 @@ func TestQueryAccessKeyCollectionRecordsFiltersCaseFoldedNameAndMaskedSuffix(t *
 }
 
 func TestQueryAccessKeyCollectionRecordsFiltersStatus(t *testing.T) {
+	t.Parallel()
 	active := state.AccessKeyStatusActive
 	disabled := state.AccessKeyStatusDisabled
 	records := []accessKeyCollectionRecord{
@@ -87,6 +90,7 @@ func TestQueryAccessKeyCollectionRecordsFiltersStatus(t *testing.T) {
 }
 
 func TestQueryAccessKeyCollectionRecordsSortsByUpdatedAtThenIDDescending(t *testing.T) {
+	t.Parallel()
 	records := []accessKeyCollectionRecord{
 		accessKeyCollectionQueryRecord(1, "one", "0001", state.AccessKeyStatusActive, 100),
 		accessKeyCollectionQueryRecord(4, "four", "0004", state.AccessKeyStatusDisabled, 300),
@@ -101,6 +105,7 @@ func TestQueryAccessKeyCollectionRecordsSortsByUpdatedAtThenIDDescending(t *test
 }
 
 func TestQueryAccessKeyCollectionRecordsPaginatesAndHandlesZeroRecords(t *testing.T) {
+	t.Parallel()
 	records := []accessKeyCollectionRecord{
 		accessKeyCollectionQueryRecord(1, "one", "0001", state.AccessKeyStatusActive, 100),
 		accessKeyCollectionQueryRecord(2, "two", "0002", state.AccessKeyStatusActive, 200),
@@ -144,6 +149,7 @@ func TestQueryAccessKeyCollectionRecordsPaginatesAndHandlesZeroRecords(t *testin
 }
 
 func TestListAccessKeyCollectionReadsMappedMetadataWithoutDecrypting(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.random = bytes.NewReader(make([]byte, 16))
 	created, err := fixture.service.CreateAccessKey(t.Context(), AccessKeyCreateRequest{Name: "collection"})
@@ -166,6 +172,7 @@ func TestListAccessKeyCollectionReadsMappedMetadataWithoutDecrypting(t *testing.
 }
 
 func TestListAccessKeyCollectionRejectsCanceledContextAndInvalidMappedMetadata(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/internal/control/access_key_cost_limit_projection_test.go
+++ b/internal/control/access_key_cost_limit_projection_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestAccessKeyCostLimitRuntimeProjectionIsSharedByCollectionHomeAndHealth(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	created, err := fixture.service.CreateAccessKey(t.Context(), AccessKeyCreateRequest{
 		Name: "limited",

--- a/internal/control/access_key_cost_limits_test.go
+++ b/internal/control/access_key_cost_limits_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestAccessKeyCostLimitRulesCreateAndReconcileDesiredList(t *testing.T) {
+	t.Parallel()
 	fixture, engine := newAccessKeyCostLimitHTTPFixture(t)
 	created := serveAccessKeyCostLimitRequest(t, engine, http.MethodPost, "/api/access-keys", `{
 		"name":"limited",
@@ -126,6 +127,7 @@ func TestAccessKeyCostLimitRulesCreateAndReconcileDesiredList(t *testing.T) {
 }
 
 func TestAccessKeyCostLimitRulesResetOnlySelectedRules(t *testing.T) {
+	t.Parallel()
 	fixture, engine := newAccessKeyCostLimitHTTPFixture(t)
 	created := serveAccessKeyCostLimitRequest(t, engine, http.MethodPost, "/api/access-keys", `{
 		"name":"resettable",
@@ -209,6 +211,7 @@ func TestAccessKeyCostLimitRulesResetOnlySelectedRules(t *testing.T) {
 }
 
 func TestAccessKeyCostLimitRulesResetRejectsInvalidSelection(t *testing.T) {
+	t.Parallel()
 	_, engine := newAccessKeyCostLimitHTTPFixture(t)
 	created := serveAccessKeyCostLimitRequest(
 		t,
@@ -244,6 +247,7 @@ func TestAccessKeyCostLimitRulesResetRejectsInvalidSelection(t *testing.T) {
 }
 
 func TestAccessKeyCostLimitRulesAreValidatedAndIdempotent(t *testing.T) {
+	t.Parallel()
 	fixture, engine := newAccessKeyCostLimitHTTPFixture(t)
 	const idempotencyKey = "00000000-0000-4000-8000-000000009002"
 	payload := `{"name":"idempotent","cost_limit_rules":[{"kind":"total","limit_usd":"10"}]}`
@@ -283,6 +287,7 @@ func TestAccessKeyCostLimitRulesAreValidatedAndIdempotent(t *testing.T) {
 }
 
 func TestAccessKeyCostLimitRuleKindCannotBeChangedInPlace(t *testing.T) {
+	t.Parallel()
 	fixture, engine := newAccessKeyCostLimitHTTPFixture(t)
 	created := serveAccessKeyCostLimitRequest(
 		t,
@@ -324,6 +329,7 @@ func TestAccessKeyCostLimitRuleKindCannotBeChangedInPlace(t *testing.T) {
 }
 
 func TestAccessKeyCostLimitRulesAllowRetainedPeriodPermutations(t *testing.T) {
+	t.Parallel()
 	for _, test := range []struct {
 		name    string
 		initial []int64

--- a/internal/control/access_keys_phase1_test.go
+++ b/internal/control/access_keys_phase1_test.go
@@ -26,6 +26,7 @@ func (spy *decryptCountingEncryption) Decrypt(ciphertext string) (string, error)
 }
 
 func TestAccessKeyMetadataListAndUpdateNeverDecryptCiphertext(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.random = bytes.NewReader(make([]byte, 16))
 	created, err := fixture.service.CreateAccessKey(
@@ -80,6 +81,7 @@ func TestAccessKeyMetadataListAndUpdateNeverDecryptCiphertext(t *testing.T) {
 }
 
 func TestCreateAccessKeyIdempotentReplaysMetadataWithoutPersistingSecret(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.random = bytes.NewReader(make([]byte, 16))
 	fixture.service.operationRandom = bytes.NewReader(bytes.Repeat([]byte{0x61}, 16))
@@ -129,6 +131,7 @@ func TestCreateAccessKeyIdempotentReplaysMetadataWithoutPersistingSecret(t *test
 }
 
 func TestAccessKeyMetadataFailsClosedForInvalidPersistedSuffix(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	created, err := fixture.service.CreateAccessKey(
 		t.Context(),
@@ -165,6 +168,7 @@ func TestAccessKeyMetadataFailsClosedForInvalidPersistedSuffix(t *testing.T) {
 }
 
 func TestRevealAccessKeyIsTheExplicitMetadataDecryptPath(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	created, err := fixture.service.CreateAccessKey(
 		t.Context(),
@@ -190,6 +194,7 @@ func TestRevealAccessKeyIsTheExplicitMetadataDecryptPath(t *testing.T) {
 }
 
 func TestListAccessKeyOptionsContainsOnlySelectorMetadata(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	first, err := fixture.service.CreateAccessKey(
 		t.Context(),
@@ -229,6 +234,7 @@ func TestListAccessKeyOptionsContainsOnlySelectorMetadata(t *testing.T) {
 }
 
 func TestAccessKeyFilterUpdateCanPreserveOrRemoveButNotAddDanglingScope(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	row := models.AccessKey{
 		Name:      "historical-scope",

--- a/internal/control/access_keys_test.go
+++ b/internal/control/access_keys_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestCreateAccessKeyGeneratesEncryptedSKGLToken(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.random = bytes.NewReader([]byte{
 		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
@@ -86,6 +87,7 @@ func TestCreateAccessKeyGeneratesEncryptedSKGLToken(t *testing.T) {
 }
 
 func TestAccessKeyFiltersNormalizeAndAcceptExistingDisabledGroups(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	enabled := validControlGroup("filter-enabled")
 	if err := fixture.db.Create(enabled).Error; err != nil {
@@ -142,6 +144,7 @@ func TestAccessKeyFiltersNormalizeAndAcceptExistingDisabledGroups(t *testing.T) 
 }
 
 func TestAccessKeyCreateAcceptsAllEnabledProtocolsInCanonicalOrder(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.random = bytes.NewReader(make([]byte, 16))
 
@@ -167,6 +170,7 @@ func TestAccessKeyCreateAcceptsAllEnabledProtocolsInCanonicalOrder(t *testing.T)
 }
 
 func TestAccessKeyFiltersRejectInvalidCurrentInputWithoutPublishing(t *testing.T) {
+	t.Parallel()
 	blank := "   "
 	tooLong := strings.Repeat("名", 86)
 	controlName := "bad\nname"
@@ -205,6 +209,7 @@ func TestAccessKeyFiltersRejectInvalidCurrentInputWithoutPublishing(t *testing.T
 }
 
 func TestListAccessKeyCollectionReturnsMaskedMetadataWithoutDecrypting(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	randomBytes := make([]byte, 32)
@@ -269,6 +274,7 @@ func TestListAccessKeyCollectionReturnsMaskedMetadataWithoutDecrypting(t *testin
 }
 
 func TestListAccessKeyCollectionPaginatesBeyondDefaultPageSize(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	rows := make([]models.AccessKey, 21)
 	for index := range rows {
@@ -303,6 +309,7 @@ func TestListAccessKeyCollectionPaginatesBeyondDefaultPageSize(t *testing.T) {
 }
 
 func TestUpdateAccessKeyPreservesCredentialAcrossPointerPatches(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	group := validControlGroup("access-key-update")
 	if err := fixture.db.Create(group).Error; err != nil {
@@ -378,6 +385,7 @@ func TestUpdateAccessKeyPreservesCredentialAcrossPointerPatches(t *testing.T) {
 }
 
 func TestUpdateAccessKeyStatusAndDeletePublishWithoutMutatingRegistry(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.random = bytes.NewReader(make([]byte, 16))
 	created, err := fixture.service.CreateAccessKey(context.Background(), AccessKeyCreateRequest{Name: "toggle"})
@@ -457,6 +465,7 @@ func TestUpdateAccessKeyStatusAndDeletePublishWithoutMutatingRegistry(t *testing
 }
 
 func TestUpdateAccessKeyDoesNotReadCredentialCiphertext(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.random = bytes.NewReader(make([]byte, 16))
 	created, err := fixture.service.CreateAccessKey(context.Background(), AccessKeyCreateRequest{Name: "before"})
@@ -481,6 +490,7 @@ func TestUpdateAccessKeyDoesNotReadCredentialCiphertext(t *testing.T) {
 }
 
 func TestAccessKeyDanglingFiltersDoNotBlockUnrelatedUpdate(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	danglingPlaintext := "gl-dangling-test-value"
 	danglingCiphertext, err := fixture.encryption.Encrypt(danglingPlaintext)
@@ -514,6 +524,7 @@ func TestAccessKeyDanglingFiltersDoNotBlockUnrelatedUpdate(t *testing.T) {
 }
 
 func TestConcurrentAccessKeyCRUDPublishesDatabaseTruth(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	rows := make([]AccessKeyCreateResult, 4)
 	for index := range rows {
@@ -584,6 +595,7 @@ func TestConcurrentAccessKeyCRUDPublishesDatabaseTruth(t *testing.T) {
 }
 
 func TestAccessKeyServiceRPMLimit(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.random = bytes.NewReader(make([]byte, 16))
 	created, err := fixture.service.CreateAccessKey(context.Background(), AccessKeyCreateRequest{
@@ -622,6 +634,7 @@ func TestAccessKeyServiceRPMLimit(t *testing.T) {
 }
 
 func TestAccessKeyEndpointsDistinguishRPMLimit(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	const authKey = "test-auth-key"
 

--- a/internal/control/auth_events_test.go
+++ b/internal/control/auth_events_test.go
@@ -19,6 +19,7 @@ import (
 func TestAuthenticateEventsCountLockedRequestsWithoutRepeatingTransition(
 	t *testing.T,
 ) {
+	t.Parallel()
 	initControlI18n(t)
 	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
 	var logs bytes.Buffer
@@ -144,6 +145,7 @@ func TestAuthenticateEventsCountLockedRequestsWithoutRepeatingTransition(
 }
 
 func TestAuthenticateLockRequestCanEmitBothEventsWhenGateOpens(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
 	var logs bytes.Buffer
@@ -208,6 +210,7 @@ func TestAuthenticateLockRequestCanEmitBothEventsWhenGateOpens(t *testing.T) {
 }
 
 func TestAuthenticateValidCredentialAddsNormalizedPeerToContext(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	server := NewServer(&config.Config{AuthKey: authTestKey}, nil)
 	engine := gin.New()
@@ -240,6 +243,7 @@ func TestAuthenticateValidCredentialAddsNormalizedPeerToContext(t *testing.T) {
 }
 
 func TestAuthenticateMalformedPeerDoesNotEmitSecurityEvent(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	const rawPeer = "malformed:peer:raw-secret"
 	var logs bytes.Buffer
@@ -274,6 +278,7 @@ func (controlPanicLogHook) Fire(*logrus.Entry) error {
 }
 
 func TestAuthenticateLoggerPanicDoesNotChangeResponses(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	server, engine := newAuthProbeServer(t)
 	server.logger = logrus.New()

--- a/internal/control/auth_limiter_test.go
+++ b/internal/control/auth_limiter_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestAuthFailureLimiterMarksOnlyNewLockTransition(t *testing.T) {
+	t.Parallel()
 	limiter := newAuthFailureLimiter()
 	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
 	limiter.now = func() time.Time { return now }
@@ -28,6 +29,7 @@ func TestAuthFailureLimiterMarksOnlyNewLockTransition(t *testing.T) {
 }
 
 func TestAuthFailureLimiterLocksOnFifthFailure(t *testing.T) {
+	t.Parallel()
 	current := time.Date(2026, 7, 23, 0, 0, 0, 0, time.UTC)
 	limiter := newAuthFailureLimiter()
 	limiter.now = func() time.Time { return current }
@@ -46,6 +48,7 @@ func TestAuthFailureLimiterLocksOnFifthFailure(t *testing.T) {
 }
 
 func TestAuthFailureLimiterUsesRollingThirtyMinuteWindow(t *testing.T) {
+	t.Parallel()
 	firstFailure := time.Date(2026, 7, 23, 0, 0, 0, 0, time.UTC)
 	current := firstFailure
 	limiter := newAuthFailureLimiter()
@@ -70,6 +73,7 @@ func TestAuthFailureLimiterUsesRollingThirtyMinuteWindow(t *testing.T) {
 }
 
 func TestAuthFailureLimiterSuccessBeforeThresholdClearsFailures(t *testing.T) {
+	t.Parallel()
 	current := time.Date(2026, 7, 23, 0, 0, 0, 0, time.UTC)
 	limiter := newAuthFailureLimiter()
 	limiter.now = func() time.Time { return current }
@@ -88,6 +92,7 @@ func TestAuthFailureLimiterSuccessBeforeThresholdClearsFailures(t *testing.T) {
 }
 
 func TestAuthFailureLimiterValidCredentialClearsLockedPeer(t *testing.T) {
+	t.Parallel()
 	current := time.Date(2026, 7, 23, 0, 0, 0, 0, time.UTC)
 	limiter := newAuthFailureLimiter()
 	limiter.now = func() time.Time { return current }
@@ -105,6 +110,7 @@ func TestAuthFailureLimiterValidCredentialClearsLockedPeer(t *testing.T) {
 }
 
 func TestAuthFailureLimiterUnlocksAfterThirtyMinutes(t *testing.T) {
+	t.Parallel()
 	current := time.Date(2026, 7, 23, 0, 0, 0, 0, time.UTC)
 	limiter := newAuthFailureLimiter()
 	limiter.now = func() time.Time { return current }
@@ -120,6 +126,7 @@ func TestAuthFailureLimiterUnlocksAfterThirtyMinutes(t *testing.T) {
 }
 
 func TestAuthFailureLimiterKeepsPeersIsolated(t *testing.T) {
+	t.Parallel()
 	current := time.Date(2026, 7, 23, 0, 0, 0, 0, time.UTC)
 	limiter := newAuthFailureLimiter()
 	limiter.now = func() time.Time { return current }
@@ -136,6 +143,7 @@ func TestAuthFailureLimiterKeepsPeersIsolated(t *testing.T) {
 }
 
 func TestAuthFailureLimiterLazilyRemovesExpiredEntries(t *testing.T) {
+	t.Parallel()
 	firstFailure := time.Date(2026, 7, 23, 0, 0, 0, 0, time.UTC)
 	current := firstFailure
 	limiter := newAuthFailureLimiter()
@@ -164,6 +172,7 @@ func TestAuthFailureLimiterLazilyRemovesExpiredEntries(t *testing.T) {
 }
 
 func TestAuthFailureLimiterConcurrentEvaluation(t *testing.T) {
+	t.Parallel()
 	current := time.Date(2026, 7, 23, 0, 0, 0, 0, time.UTC)
 	limiter := newAuthFailureLimiter()
 	limiter.now = func() time.Time { return current }

--- a/internal/control/autoweight_test.go
+++ b/internal/control/autoweight_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestCalculateAutoWeight(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		stats health.CredentialStats

--- a/internal/control/bootstrap_test.go
+++ b/internal/control/bootstrap_test.go
@@ -26,6 +26,7 @@ const bootstrapMarkerForTest = models.InternalSystemSettingPrefix + "bootstrap.d
 var errBootstrapEncryption = errors.New("forced bootstrap encryption failure")
 
 func TestEnsureInitialStateCreatesDefaultAccessKeyAndMarker(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.random = bytes.NewReader([]byte{
 		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
@@ -83,6 +84,7 @@ func TestEnsureInitialStateCreatesDefaultAccessKeyAndMarker(t *testing.T) {
 }
 
 func TestEnsureInitialStateWithExistingAccessKeyOnlyWritesMarker(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	const plaintext = "gl-existing-access-key"
 	ciphertext, err := fixture.encryption.Encrypt(plaintext)
@@ -120,6 +122,7 @@ func TestEnsureInitialStateWithExistingAccessKeyOnlyWritesMarker(t *testing.T) {
 }
 
 func TestEnsureInitialStateDoesNotLogExpectedMarkerMissAsError(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	var logs bytes.Buffer
 	fixture.service.db = fixture.db.Session(&gorm.Session{
@@ -140,6 +143,7 @@ func TestEnsureInitialStateDoesNotLogExpectedMarkerMissAsError(t *testing.T) {
 }
 
 func TestEnsureInitialStateIsIdempotentWhenMarkerExists(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	if err := fixture.db.Create(&models.SystemSetting{
 		Key: bootstrapMarkerForTest, Value: "true",
@@ -157,6 +161,7 @@ func TestEnsureInitialStateIsIdempotentWhenMarkerExists(t *testing.T) {
 }
 
 func TestEnsureInitialStateDoesNotRecreateDeletedFinalKey(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.random = bytes.NewReader(make([]byte, 16))
 	if err := fixture.service.EnsureInitialState(context.Background()); err != nil {
@@ -174,6 +179,7 @@ func TestEnsureInitialStateDoesNotRecreateDeletedFinalKey(t *testing.T) {
 }
 
 func TestEnsureInitialStateRollsBackWhenEncryptionFails(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.random = bytes.NewReader(make([]byte, 16))
 	fixture.service.encryption = bootstrapFailingEncryptService{Service: fixture.encryption}
@@ -187,6 +193,7 @@ func TestEnsureInitialStateRollsBackWhenEncryptionFails(t *testing.T) {
 }
 
 func TestEnsureInitialStateRollsBackAccessKeyWhenMarkerWriteFails(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.random = bytes.NewReader(make([]byte, 16))
 	if err := fixture.db.Exec(`

--- a/internal/control/bootstrap_test.go
+++ b/internal/control/bootstrap_test.go
@@ -215,6 +215,7 @@ func TestEnsureInitialStateRollsBackAccessKeyWhenMarkerWriteFails(t *testing.T) 
 }
 
 func TestEnsureInitialStateDoesNotLogPlaintext(t *testing.T) {
+	// 不标记 t.Parallel()：本测试劫持了全局 logrus 输出/格式，与其他并行测试同时运行会互相覆盖断言。
 	fixture := newServiceFixture(t)
 	randomBytes := bytes.Repeat([]byte{0xab}, 16)
 	fixture.service.random = bytes.NewReader(randomBytes)

--- a/internal/control/catalog_discovery_merge_test.go
+++ b/internal/control/catalog_discovery_merge_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestCodexDiscoveryUsesOnlySubscriptionModelsAndReferencePrices(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.catalogRuntime.Publish(&catalog.Snapshot{Providers: map[string]catalog.Provider{
 		"openai": {
@@ -56,6 +57,7 @@ func TestCodexDiscoveryUsesOnlySubscriptionModelsAndReferencePrices(t *testing.T
 }
 
 func TestClaudeDiscoveryUsesOnlySubscriptionModelsAndReferencePrices(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.catalogRuntime.Publish(&catalog.Snapshot{Providers: map[string]catalog.Provider{
 		"anthropic": {
@@ -105,6 +107,7 @@ func TestClaudeDiscoveryUsesOnlySubscriptionModelsAndReferencePrices(t *testing.
 }
 
 func TestAntigravityDiscoveryUsesOnlySubscriptionModelsAndReferencePrices(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.catalogRuntime.Publish(&catalog.Snapshot{Providers: map[string]catalog.Provider{
 		"google": {
@@ -167,6 +170,7 @@ func TestAntigravityDiscoveryUsesOnlySubscriptionModelsAndReferencePrices(t *tes
 }
 
 func TestGrokDiscoveryUsesOnlySubscriptionModelsAndReferencePrices(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.catalogRuntime.Publish(&catalog.Snapshot{Providers: map[string]catalog.Provider{
 		"xai": {
@@ -229,6 +233,7 @@ func TestGrokDiscoveryUsesOnlySubscriptionModelsAndReferencePrices(t *testing.T)
 }
 
 func TestDraftDiscoveryMergesLiveAndLocalCatalogByExactIDWithoutURLInference(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.catalogRuntime.Publish(&catalog.Snapshot{Providers: map[string]catalog.Provider{
 		"openai": {
@@ -294,6 +299,7 @@ func TestDraftDiscoveryMergesLiveAndLocalCatalogByExactIDWithoutURLInference(t *
 }
 
 func TestDiscoveryPricingStatusUsesAutomaticPriceReferenceForDraftScopes(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	openAI := "openai"
 	fixture.catalogRuntime.Publish(&catalog.Snapshot{Providers: map[string]catalog.Provider{
@@ -384,6 +390,7 @@ func TestDiscoveryPricingStatusUsesAutomaticPriceReferenceForDraftScopes(t *test
 }
 
 func TestSavedGroupDiscoveryUsesPersistedProviderAndSharedPricingStatus(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.catalogRuntime.Publish(&catalog.Snapshot{Providers: map[string]catalog.Provider{
 		"openai": {

--- a/internal/control/catalog_sync_test.go
+++ b/internal/control/catalog_sync_test.go
@@ -32,6 +32,7 @@ func (function catalogSyncClientFunc) Sync(
 }
 
 func TestCatalogSyncEmitsLifecycleLogsWithoutLeakingFailureDetails(t *testing.T) {
+	// 不标记 t.Parallel()：本测试劫持了全局 logrus 输出/格式，与其他并行测试同时运行会互相覆盖断言。
 	fixture := newServiceFixture(t)
 	var logs bytes.Buffer
 	standardLogger := logrus.StandardLogger()
@@ -107,6 +108,7 @@ func TestCatalogSyncEmitsLifecycleLogsWithoutLeakingFailureDetails(t *testing.T)
 }
 
 func TestApplyCatalogSnapshotLogsMissingAutomaticPricePriorityProviders(t *testing.T) {
+	// 不标记 t.Parallel()：本测试劫持了全局 logrus 输出/格式，与其他并行测试同时运行会互相覆盖断言。
 	fixture := newServiceFixture(t)
 	var logs bytes.Buffer
 	standardLogger := logrus.StandardLogger()
@@ -163,6 +165,7 @@ func TestApplyCatalogSnapshotLogsMissingAutomaticPricePriorityProviders(t *testi
 }
 
 func TestApplyCatalogSnapshotDoesNotLogCompletePriorityAndLogsEachSuccess(t *testing.T) {
+	// 不标记 t.Parallel()：本测试劫持了全局 logrus 输出/格式，与其他并行测试同时运行会互相覆盖断言。
 	t.Run("complete priority", func(t *testing.T) {
 		fixture := newServiceFixture(t)
 		var logs bytes.Buffer
@@ -226,6 +229,7 @@ func TestApplyCatalogSnapshotDoesNotLogCompletePriorityAndLogsEachSuccess(t *tes
 }
 
 func TestApplyCatalogSnapshotFailureDoesNotLogPriorityWarningOrPublishRuntime(t *testing.T) {
+	// 不标记 t.Parallel()：本测试劫持了全局 logrus 输出/格式，与其他并行测试同时运行会互相覆盖断言。
 	fixture := newServiceFixture(t)
 	seedCatalogPriceGroup(t, fixture, "failure", nil, []string{"gpt"})
 	oldPrice := int64(1)

--- a/internal/control/catalog_sync_test.go
+++ b/internal/control/catalog_sync_test.go
@@ -286,6 +286,7 @@ func TestApplyCatalogSnapshotFailureDoesNotLogPriorityWarningOrPublishRuntime(t 
 }
 
 func TestCatalogBootstrapLoadsLKGAndFallsBackToOfficialCatalog(t *testing.T) {
+	t.Parallel()
 	missing := loadCatalogBootstrap(filepath.Join(t.TempDir(), "missing.json"))
 	if missing.HasLKG || missing.Runtime == nil || missing.Runtime.Load() == nil {
 		t.Fatalf("missing bootstrap = %#v, want official-only runtime", missing)
@@ -323,6 +324,7 @@ func TestCatalogBootstrapLoadsLKGAndFallsBackToOfficialCatalog(t *testing.T) {
 }
 
 func TestCatalogStartupReconcilesDurableLKGBeforeAnyNetworkSync(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	providerID := "openai"
 	seedCatalogPriceGroup(t, fixture, "startup-lkg", &providerID, []string{"gpt"})
@@ -360,6 +362,7 @@ func TestCatalogStartupReconcilesDurableLKGBeforeAnyNetworkSync(t *testing.T) {
 }
 
 func TestCatalogSyncSingleFlightJoinsManualStartupAndGroupTriggers(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	started := make(chan struct{})
 	release := make(chan struct{})
@@ -421,6 +424,7 @@ func TestCatalogSyncSingleFlightJoinsManualStartupAndGroupTriggers(t *testing.T)
 }
 
 func TestCatalogSyncCallerCancellationStopsWaitingWithoutCancelingSharedOperation(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	operationContexts := make(chan context.Context, 1)
 	release := make(chan struct{})
@@ -470,6 +474,7 @@ func TestCatalogSyncCallerCancellationStopsWaitingWithoutCancelingSharedOperatio
 }
 
 func TestCatalogSync304PreservesPublishedGenerationsAndDoesNotStoreCache(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	oldSnapshot := &catalog.Snapshot{Providers: map[string]catalog.Provider{
 		"openai": catalogProviderFixture("openai", "Old", "old", 1_000_000_000),
@@ -518,6 +523,7 @@ func TestCatalogSync304PreservesPublishedGenerationsAndDoesNotStoreCache(t *test
 }
 
 func TestCatalogSyncRejects304WithoutLastKnownGoodGeneration(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	previous := catalog.Metadata{}
 	client := catalogSyncClientFunc(func(context.Context, catalog.Metadata) (catalog.SyncResult, error) {
@@ -546,6 +552,7 @@ func TestCatalogSyncRejects304WithoutLastKnownGoodGeneration(t *testing.T) {
 }
 
 func TestCatalogSyncFailuresRefreshLastCheckAndPreserveLastSuccessfulFetch(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	previous := catalog.Metadata{
 		ETag:                    "last-good",
@@ -575,6 +582,7 @@ func TestCatalogSyncFailuresRefreshLastCheckAndPreserveLastSuccessfulFetch(t *te
 }
 
 func TestCatalogSyncCacheFailureUsesCurrentCheckWithoutAdvancingSuccessfulFetch(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	previous := catalog.Metadata{SuccessfulFetchAtMillis: 90, CheckedAtMillis: 100}
 	client := catalogSyncClientFunc(func(context.Context, catalog.Metadata) (catalog.SyncResult, error) {
@@ -595,6 +603,7 @@ func TestCatalogSyncCacheFailureUsesCurrentCheckWithoutAdvancingSuccessfulFetch(
 }
 
 func TestCatalogSyncDisabledAutomaticTriggersDoNotCallNetworkButManualStillWorks(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	disabled := false
 	fixture.service.modelsDevAutoSyncOverride = &disabled
@@ -631,6 +640,7 @@ func TestCatalogSyncDisabledAutomaticTriggersDoNotCallNetworkButManualStillWorks
 }
 
 func TestCatalogSyncSchedulerRetriesNoLKGAfterOneHourAndKeepsLKGOnDailyCadence(t *testing.T) {
+	t.Parallel()
 	for _, test := range []struct {
 		name             string
 		hasLKG           bool
@@ -705,6 +715,7 @@ func TestCatalogSyncSchedulerRetriesNoLKGAfterOneHourAndKeepsLKGOnDailyCadence(t
 }
 
 func TestCatalogSyncSchedulerDebouncesGroupChangeBursts(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	calls := make(chan struct{}, 4)
 	client := catalogSyncClientFunc(func(context.Context, catalog.Metadata) (catalog.SyncResult, error) {
@@ -761,6 +772,7 @@ func TestCatalogSyncSchedulerDebouncesGroupChangeBursts(t *testing.T) {
 }
 
 func TestCatalogSyncSchedulerRunsImmediateSettingsTrigger(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	calls := make(chan struct{}, 2)
 	client := catalogSyncClientFunc(func(context.Context, catalog.Metadata) (catalog.SyncResult, error) {
@@ -802,6 +814,7 @@ func TestCatalogSyncSchedulerRunsImmediateSettingsTrigger(t *testing.T) {
 }
 
 func TestCatalogSyncSchedulerRetries304WithoutLKGAfterOneHour(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	calls := make(chan struct{}, 2)
 	client := catalogSyncClientFunc(func(context.Context, catalog.Metadata) (catalog.SyncResult, error) {
@@ -839,6 +852,7 @@ func TestCatalogSyncSchedulerRetries304WithoutLKGAfterOneHour(t *testing.T) {
 }
 
 func TestCatalogSyncShutdownWaitsForBlockedCacheAndPreventsLateReconcile(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	result := catalogResultFixture(100, "shutdown", nil)
 	var calls atomic.Int32
@@ -898,6 +912,7 @@ func TestCatalogSyncShutdownWaitsForBlockedCacheAndPreventsLateReconcile(t *test
 }
 
 func TestCatalogSyncShutdownWaitsForBlockedReconcile(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	result := catalogResultFixture(100, "shutdown", nil)
 	client := catalogSyncClientFunc(func(context.Context, catalog.Metadata) (catalog.SyncResult, error) {
@@ -941,6 +956,7 @@ func TestCatalogSyncShutdownWaitsForBlockedReconcile(t *testing.T) {
 }
 
 func TestCatalogSyncRunShutdownCancelsPreRuntimeManualOperation(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	started := make(chan struct{})
 	canceled := make(chan struct{})
@@ -1010,6 +1026,7 @@ func TestCatalogSyncRunShutdownCancelsPreRuntimeManualOperation(t *testing.T) {
 }
 
 func TestCatalogSyncReconcilesSlotsLKGManualCleanupAndStableTimestamps(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	openAI := "openai"
 	missingProvider := "missing-provider"
@@ -1085,6 +1102,7 @@ func TestCatalogSyncReconcilesSlotsLKGManualCleanupAndStableTimestamps(t *testin
 }
 
 func TestCatalogSyncReconcilesGroupAutomaticPricesAndPreservesManualRows(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	group := createPriceTestGroup(t, fixture.db, models.Group{
 		Name: "custom", ChannelID: string(channel.OpenAICompatible),
@@ -1201,6 +1219,7 @@ func TestCatalogSyncReconcilesGroupAutomaticPricesAndPreservesManualRows(t *test
 }
 
 func TestCatalogSyncScopesSameModelByChannelAndPreservesManualOverride(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	for _, group := range []models.Group{
 		{
@@ -1276,6 +1295,7 @@ func TestCatalogSyncScopesSameModelByChannelAndPreservesManualOverride(t *testin
 }
 
 func TestCatalogSyncReconcileFailurePublishesNeitherRuntimeAndKeepsPendingLKG(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	providerID := "openai"
 	seedCatalogPriceGroup(t, fixture, "openai", &providerID, []string{"gpt"})

--- a/internal/control/channel_group_foundation_test.go
+++ b/internal/control/channel_group_foundation_test.go
@@ -87,6 +87,7 @@ func TestParseChannelQueryIsStrict(t *testing.T) {
 }
 
 func TestChannelsHTTPIsAuthenticatedAndStrict(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	engine := gin.New()
@@ -252,6 +253,7 @@ func TestSameTargetIncludesConnectionType(t *testing.T) {
 }
 
 func TestCreateChannelGroupPersistsCanonicalCredentialsAndPublishes(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.now = func() time.Time { return time.UnixMilli(1_786_000_000_000) }
 	beforeRevision := fixture.manager.Current().Revision
@@ -325,6 +327,7 @@ func TestCreateChannelGroupPersistsCanonicalCredentialsAndPublishes(t *testing.T
 }
 
 func TestCreateChannelGroupUsesChannelAndCanonicalParamsForSimilarity(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	first, err := fixture.service.CreateGroup(t.Context(), GroupCreateRequest{
 		ChannelID:   channel.OpenAICompatible,
@@ -374,6 +377,7 @@ func TestCreateChannelGroupUsesChannelAndCanonicalParamsForSimilarity(t *testing
 }
 
 func TestCreateChannelGroupIdempotencyReplaysCredentialCounts(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	request := GroupCreateRequest{
 		Name:        stringPointer("idempotent channel"),
@@ -404,6 +408,7 @@ func TestCreateChannelGroupIdempotencyReplaysCredentialCounts(t *testing.T) {
 }
 
 func TestChannelGroupSettingsExposeImmutableChannelAndEditableParams(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	created, err := fixture.service.CreateGroup(t.Context(), GroupCreateRequest{
 		Name:        stringPointer("settings channel"),
@@ -458,6 +463,7 @@ func TestChannelGroupSettingsExposeImmutableChannelAndEditableParams(t *testing.
 }
 
 func TestChannelGroupCollectionDetailAndOptionsUseChannelCredentialContract(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	created, err := fixture.service.CreateGroup(t.Context(), GroupCreateRequest{
 		Name:      stringPointer("collection channel"),

--- a/internal/control/credential_actions_test.go
+++ b/internal/control/credential_actions_test.go
@@ -40,6 +40,7 @@ func TestDownloadGroupCredentialReturnsCanonicalJSONAndSafeFilename(t *testing.T
 }
 
 func TestSubscriptionCredentialFilenameFallsBackToCredentialID(t *testing.T) {
+	t.Parallel()
 	if got := subscriptionCredentialFilename("Claude", "", 42); got != "claude-credential-42.json" {
 		t.Fatalf("filename = %q", got)
 	}
@@ -49,6 +50,7 @@ func TestSubscriptionCredentialFilenameFallsBackToCredentialID(t *testing.T) {
 }
 
 func TestDownloadGroupCredentialHTTPReturnsJSONObjectAndNoStoreHeaders(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	server := NewServer(&config.Config{AuthKey: "credential-download-auth"}, fixture.service)
@@ -86,6 +88,7 @@ func TestDownloadGroupCredentialHTTPReturnsJSONObjectAndNoStoreHeaders(t *testin
 }
 
 func TestDownloadAllGroupCredentialsReturnsEveryAccountAndNoStoreHeaders(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture, groupID, _ := newSubscriptionCredentialFixture(t)
 	stageIDs := make([]string, 0, 24)

--- a/internal/control/credential_api_foundation_test.go
+++ b/internal/control/credential_api_foundation_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestRestoreGroupCredentialLogsRuntimeRecovery(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	created, err := fixture.service.CreateGroup(t.Context(), GroupCreateRequest{
@@ -74,6 +75,7 @@ func TestRestoreGroupCredentialLogsRuntimeRecovery(t *testing.T) {
 }
 
 func TestCredentialRoutesReplaceLegacyGroupKeyRoutes(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	module := NewServer(&config.Config{AuthKey: "credential-auth"}, fixture.service).HTTPModule()
 	want := map[string]string{
@@ -110,6 +112,7 @@ func TestCredentialRoutesReplaceLegacyGroupKeyRoutes(t *testing.T) {
 }
 
 func TestImportAndListGroupCredentialsUseCanonicalCredentialStorage(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	created, err := fixture.service.CreateGroup(t.Context(), GroupCreateRequest{
 		Name: stringPointer("credential api"), ChannelID: channel.OpenAI,
@@ -150,6 +153,7 @@ func TestImportAndListGroupCredentialsUseCanonicalCredentialStorage(t *testing.T
 }
 
 func TestCloudCredentialImportAcceptsOneStrictJSONObjectPerLine(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	tests := []struct {
 		name        string
@@ -206,6 +210,7 @@ func TestCloudCredentialImportAcceptsOneStrictJSONObjectPerLine(t *testing.T) {
 }
 
 func TestCredentialValidationReturnsSafeFieldDiagnostic(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	const secret = "sensitive-client-id"
 	_, err := fixture.service.normalizeCredentials(
@@ -229,6 +234,7 @@ func TestCredentialValidationReturnsSafeFieldDiagnostic(t *testing.T) {
 }
 
 func TestVertexCredentialImportAcceptsPastedServiceAccountJSON(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	raw := `{
   "type": "service_account",
@@ -262,6 +268,7 @@ func TestVertexCredentialImportAcceptsPastedServiceAccountJSON(t *testing.T) {
 }
 
 func TestVertexCredentialImportAcceptsOneRawServiceAccountPerLine(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	credentials := strings.Join([]string{
 		`{"type":"service_account","project_id":"project-one","client_email":"first@example.iam.gserviceaccount.com","private_key":"first-secret"}`,
@@ -281,6 +288,7 @@ func TestVertexCredentialImportAcceptsOneRawServiceAccountPerLine(t *testing.T) 
 }
 
 func TestGroupCredentialMutationsPreserveRuntimeIdentityAndHealthContracts(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	runtime := &recordingCredentialRuntimeExecutor{}
 	fixture.service.executor = runtime
@@ -385,6 +393,7 @@ func TestGroupCredentialMutationsPreserveRuntimeIdentityAndHealthContracts(t *te
 }
 
 func TestCredentialHTTPUsesCanonicalWireAndRejectsLegacyFields(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	created, err := fixture.service.CreateGroup(t.Context(), GroupCreateRequest{
@@ -460,6 +469,7 @@ func TestCredentialHTTPUsesCanonicalWireAndRejectsLegacyFields(t *testing.T) {
 }
 
 func TestAPIKeyCredentialImportRejectsSubscriptionGroup(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, _ := newSubscriptionCredentialFixture(t)
 	before, err := fixture.service.ListGroupCredentials(t.Context(), groupID, CredentialCollectionQuery{Page: 1, PageSize: 20})
 	if err != nil {

--- a/internal/control/credential_batch_order_test.go
+++ b/internal/control/credential_batch_order_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestBatchEnableDoesNotExposeCredentialsBeforeDatabaseCommit(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	groupID := createGroupWithCredentials(t, fixture, "first-secret\nsecond-secret")
 
@@ -64,6 +65,7 @@ func TestBatchEnableDoesNotExposeCredentialsBeforeDatabaseCommit(t *testing.T) {
 }
 
 func TestBatchEnableRuntimeFailureReloadsCommittedDatabaseTruth(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	groupID := createGroupWithCredentials(t, fixture, "runtime-recovery-secret")
 	var row models.Credential
@@ -102,6 +104,7 @@ func TestBatchEnableRuntimeFailureReloadsCommittedDatabaseTruth(t *testing.T) {
 }
 
 func TestBatchDeleteRetiresCommittedCredentialRuntimes(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	runtime := &recordingCredentialRuntimeExecutor{}
 	fixture.service.executor = runtime
@@ -123,6 +126,7 @@ func TestBatchDeleteRetiresCommittedCredentialRuntimes(t *testing.T) {
 }
 
 func TestBatchAllCredentialsAffectsOnlyCurrentGroup(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	groupID := createGroupWithCredentials(t, fixture, "first-secret\nsecond-secret")
 	otherGroupName := "other-credential-group"
@@ -165,6 +169,7 @@ func TestBatchAllCredentialsAffectsOnlyCurrentGroup(t *testing.T) {
 }
 
 func TestBatchAllCredentialsRejectsDeleteAndExplicitIDs(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	groupID := createGroupWithCredentials(t, fixture, "first-secret")
 

--- a/internal/control/credential_observations_test.go
+++ b/internal/control/credential_observations_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestObservationPlanSummaryPreservesPresentationLevel(t *testing.T) {
+	t.Parallel()
 	var snapshot CredentialObservationSnapshot
 	if err := json.Unmarshal([]byte(`{"plan_summary":{"name":"Team","level":"premium"},"quota_windows":[]}`), &snapshot); err != nil {
 		t.Fatal(err)
@@ -68,6 +69,7 @@ func TestNormalizeCodexObservationKeepsDynamicWindowsAndStableOrder(t *testing.T
 }
 
 func TestMapCredentialObservationKeepsSafeAccountSummary(t *testing.T) {
+	t.Parallel()
 	createdAt := time.Date(2025, time.January, 2, 3, 4, 5, 0, time.UTC).UnixMilli()
 	row := models.CredentialObservation{
 		CredentialID: 1, ObservationVersion: 1, State: models.CredentialObservationFresh,
@@ -143,6 +145,7 @@ func TestNormalizeCodexObservationDoesNotInventMissingFiveHourWindow(t *testing.
 }
 
 func TestNormalizeCodexObservationDoesNotTreatMeterNameAsModelID(t *testing.T) {
+	t.Parallel()
 	snapshot, err := normalizeCodexObservation([]byte(`{
 		"additional_rate_limits":[
 			{"metered_feature":"codex_other_models","rate_limit":{"primary_window":{"used_percent":12}}},
@@ -203,6 +206,7 @@ func TestRefreshCredentialObservationPersistsLKGAndAllowsImmediateManualRefresh(
 }
 
 func TestRefreshCredentialObservationKeepsFreshQuotaWhenPartialUsageIsMissing(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	now := time.Date(2026, time.August, 17, 10, 0, 0, 0, time.UTC)
 	fixture.service.now = func() time.Time { return now }
@@ -249,6 +253,7 @@ func TestRefreshCredentialObservationKeepsFreshQuotaWhenPartialUsageIsMissing(t 
 }
 
 func TestRefreshCredentialObservationMergesSparseAccountWithFreshQuota(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	now := time.Date(2026, time.August, 17, 10, 0, 0, 0, time.UTC)
 	fixture.service.now = func() time.Time { return now }
@@ -304,6 +309,7 @@ func TestRefreshCredentialObservationMergesSparseAccountWithFreshQuota(t *testin
 }
 
 func TestRefreshCredentialObservationMergesCoveredQuotaScopes(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		observation   subscriptionruntime.Observation
@@ -400,6 +406,7 @@ func TestRefreshCredentialObservationMergesCoveredQuotaScopes(t *testing.T) {
 }
 
 func TestRefreshCredentialObservationRetriesOnceAfterUnauthorized(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	originalPrepare := fixture.service.prepareSubscriptionCredential
 	forcedRefreshes := 0
@@ -435,6 +442,7 @@ func TestRefreshCredentialObservationRetriesOnceAfterUnauthorized(t *testing.T) 
 }
 
 func TestRefreshCredentialObservationClassifiesRepeatedAuthorizationFailure(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	originalPrepare := fixture.service.prepareSubscriptionCredential
 	forcedRefreshes := 0
@@ -477,6 +485,7 @@ func TestRefreshCredentialObservationClassifiesRepeatedAuthorizationFailure(t *t
 }
 
 func TestRefreshCredentialObservationClassifiesNonRefreshableHTTPFailure(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		statusCode int
@@ -521,6 +530,7 @@ func TestRefreshCredentialObservationClassifiesNonRefreshableHTTPFailure(t *test
 }
 
 func TestRefreshCredentialObservationPersistsPartialSnapshotAsStale(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	fixture.service.observeSubscriptionAccount = func(
 		context.Context,
@@ -545,6 +555,7 @@ func TestRefreshCredentialObservationPersistsPartialSnapshotAsStale(t *testing.T
 }
 
 func TestRefreshCredentialObservationEnrichesResetCreditDetails(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	setCodexAccountObservation(fixture.service, func(context.Context, codex.Credential) (codex.AccountObservation, error) {
 		return codex.AccountObservation{Payload: []byte(`{
@@ -575,6 +586,7 @@ func TestRefreshCredentialObservationEnrichesResetCreditDetails(t *testing.T) {
 }
 
 func TestRefreshCredentialObservationKeepsUsageWhenResetCreditDetailsFail(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	setCodexAccountObservation(fixture.service, func(context.Context, codex.Credential) (codex.AccountObservation, error) {
 		return codex.AccountObservation{Payload: []byte(`{"rate_limit_reset_credits":{"available_count":2}}`)}, nil
@@ -594,6 +606,7 @@ func TestRefreshCredentialObservationKeepsUsageWhenResetCreditDetailsFail(t *tes
 }
 
 func TestRefreshClaudeCredentialObservationPublishesAccountAndQuota(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := time.Date(2026, time.August, 16, 8, 0, 0, 0, time.UTC)
 	fixture.service.now = func() time.Time { return now }
@@ -657,6 +670,7 @@ func TestRefreshClaudeCredentialObservationPublishesAccountAndQuota(t *testing.T
 }
 
 func TestEnrichCredentialObservationUsageUsesHourlyStatsForEveryWindow(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := time.Date(2026, time.August, 14, 12, 0, 0, 0, time.UTC)
 	fixture.service.now = func() time.Time { return now }
@@ -710,6 +724,7 @@ func TestEnrichCredentialObservationUsageUsesHourlyStatsForEveryWindow(t *testin
 }
 
 func TestEnrichCredentialObservationUsageUsesRecordedWindowBoundaries(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := time.Date(2026, time.August, 14, 12, 0, 0, 0, time.UTC)
 	fixture.service.now = func() time.Time { return now }
@@ -740,6 +755,7 @@ func TestEnrichCredentialObservationUsageUsesRecordedWindowBoundaries(t *testing
 }
 
 func TestPresentCredentialObservationDoesNotExpireByTime(t *testing.T) {
+	t.Parallel()
 	result := presentCredentialObservation(models.CredentialObservation{
 		CredentialID: 1, IdentityFingerprint: "identity", SchemaVersion: 1,
 		ObservationVersion: 1, SnapshotJSON: models.JSON(`{"quota_windows":[]}`),
@@ -751,6 +767,7 @@ func TestPresentCredentialObservationDoesNotExpireByTime(t *testing.T) {
 }
 
 func TestEnrichCredentialObservationUsageSkipsNonCurrentObservation(t *testing.T) {
+	t.Parallel()
 	now := time.Date(2026, time.August, 14, 12, 0, 0, 0, time.UTC)
 	resetAt := now.Add(2 * time.Hour).UnixMilli()
 	windowSeconds := int64((5 * time.Hour) / time.Second)
@@ -785,6 +802,7 @@ func TestEnrichCredentialObservationUsageSkipsNonCurrentObservation(t *testing.T
 }
 
 func TestRefreshCredentialObservationDoesNotAffectRoutingState(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	now := time.Date(2026, time.August, 14, 15, 0, 0, 0, time.UTC)
 	fixture.service.now = func() time.Time { return now }
@@ -814,6 +832,7 @@ func TestRefreshCredentialObservationDoesNotAffectRoutingState(t *testing.T) {
 }
 
 func TestApplyCredentialQuotaObservationUsesBottleneckReset(t *testing.T) {
+	t.Parallel()
 	fixture, _, credentialID := newSubscriptionCredentialFixture(t)
 	now := time.Date(2026, time.August, 14, 15, 0, 0, 0, time.UTC)
 	fixture.service.now = func() time.Time { return now }
@@ -837,6 +856,7 @@ func TestApplyCredentialQuotaObservationUsesBottleneckReset(t *testing.T) {
 }
 
 func TestApplyCredentialQuotaObservationDoesNotBlockAccountForModelGroupExhaustion(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	now := time.Date(2026, time.August, 14, 15, 0, 0, 0, time.UTC)
 	fixture.service.now = func() time.Time { return now }
@@ -857,6 +877,7 @@ func TestApplyCredentialQuotaObservationDoesNotBlockAccountForModelGroupExhausti
 }
 
 func TestDrainCommittedOperationsRestoresQuotaDisplayStateWithoutAffectingRouting(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	now := time.Date(2026, time.August, 14, 16, 0, 0, 0, time.UTC)
 	fixture.service.now = func() time.Time { return now }
@@ -885,6 +906,7 @@ func TestDrainCommittedOperationsRestoresQuotaDisplayStateWithoutAffectingRoutin
 }
 
 func TestRecoverCommittedRuntimeRestoresQuotaDisplayStateWithoutAffectingRouting(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	now := time.Date(2026, time.August, 14, 16, 30, 0, 0, time.UTC)
 	fixture.service.now = func() time.Time { return now }
@@ -939,6 +961,7 @@ func (reader *recordingCredentialActivityReader) QueryCredentialActivity(
 }
 
 func TestEnrichCredentialDailyUsageQueriesAttemptActivity(t *testing.T) {
+	t.Parallel()
 	fixture, _, _ := newSubscriptionCredentialFixture(t)
 	now := time.UnixMilli(1_800_000_000_000)
 	fixture.service.now = func() time.Time { return now }
@@ -974,6 +997,7 @@ func TestEnrichCredentialDailyUsageQueriesAttemptActivity(t *testing.T) {
 }
 
 func TestEnrichCredentialDailyUsageLeavesItemUntouchedOnQueryFailure(t *testing.T) {
+	t.Parallel()
 	fixture, _, _ := newSubscriptionCredentialFixture(t)
 	fixture.service.now = func() time.Time { return time.UnixMilli(1_800_000_000_000) }
 	fixture.service.credentialActivity = &recordingCredentialActivityReader{err: errors.New("activity unavailable")}
@@ -989,6 +1013,7 @@ func TestEnrichCredentialDailyUsageLeavesItemUntouchedOnQueryFailure(t *testing.
 }
 
 func TestEnrichCredentialActivitiesBatchesSubscriptionItems(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := time.UnixMilli(1_800_000_000_000)
 	fixture.service.now = func() time.Time { return now }
@@ -1017,6 +1042,7 @@ func TestEnrichCredentialActivitiesBatchesSubscriptionItems(t *testing.T) {
 }
 
 func TestRefreshCredentialObservationPersistsNormalizationFailure(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	now := time.UnixMilli(1_800_000_000_000)
 	fixture.service.now = func() time.Time { return now }
@@ -1040,6 +1066,7 @@ func TestRefreshCredentialObservationPersistsNormalizationFailure(t *testing.T) 
 }
 
 func TestRefreshCredentialObservationUsesBoundedUpstreamContext(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	hasBoundedDeadline := false
 	setCodexAccountObservation(fixture.service, func(ctx context.Context, _ codex.Credential) (codex.AccountObservation, error) {
@@ -1055,6 +1082,7 @@ func TestRefreshCredentialObservationUsesBoundedUpstreamContext(t *testing.T) {
 }
 
 func TestRefreshCredentialObservationRejectsNonReadyCredentialBeforeUpstream(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	if err := fixture.db.Model(&models.Credential{}).Where("id = ?", credentialID).
 		Update("auth_state", models.CredentialAuthStateOutcomeUnknown).Error; err != nil {
@@ -1122,6 +1150,7 @@ func TestConcurrentObservationRefreshIsSingleflight(t *testing.T) {
 }
 
 func TestObservationSingleflightKeepsGroupAndCredentialBoundTogether(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	started := make(chan struct{})
 	release := make(chan struct{})

--- a/internal/control/credential_reset_credits_test.go
+++ b/internal/control/credential_reset_credits_test.go
@@ -21,6 +21,7 @@ import (
 const resetCreditTestKey = "9f0f4c32-89d2-4bcb-9e19-052940dc2f16"
 
 func TestConsumeCredentialResetCreditRefreshesObservationAndRemainsIdempotent(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	consumeCalls := 0
 	setCodexResetCreditConsume(t, fixture.service, func(_ context.Context, _ codex.Credential, redeemRequestID string) (codex.AccountObservation, error) {
@@ -61,6 +62,7 @@ func TestConsumeCredentialResetCreditRefreshesObservationAndRemainsIdempotent(t 
 }
 
 func TestConsumeCredentialResetCreditReportsPendingForPartialObservation(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	setCodexResetCreditConsume(t, fixture.service, func(context.Context, codex.Credential, string) (codex.AccountObservation, error) {
 		return codex.AccountObservation{Payload: []byte(`{"code":"reset","windows_reset":1}`)}, nil
@@ -103,6 +105,7 @@ func TestConsumeCredentialResetCreditReportsPendingForPartialObservation(t *test
 }
 
 func TestConsumeCredentialResetCreditRefreshesObservationAfterClientCancellation(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	now := time.Date(2026, time.August, 14, 11, 0, 0, 0, time.UTC)
 	fixture.service.now = func() time.Time { return now }
@@ -148,6 +151,7 @@ func TestConsumeCredentialResetCreditRefreshesObservationAfterClientCancellation
 }
 
 func TestConsumeCredentialResetCreditRunsFollowUpAfterInFlightObservation(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	firstStarted := make(chan struct{})
 	releaseFirst := make(chan struct{})
@@ -206,6 +210,7 @@ func TestConsumeCredentialResetCreditRunsFollowUpAfterInFlightObservation(t *tes
 }
 
 func TestConsumeCredentialResetCreditRunsFollowUpAfterInFlightResetObservation(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	firstObservationStarted := make(chan struct{})
 	releaseFirstObservation := make(chan struct{})
@@ -268,6 +273,7 @@ func TestConsumeCredentialResetCreditRunsFollowUpAfterInFlightResetObservation(t
 }
 
 func TestConsumeCredentialResetCreditReplayReportsPendingWhileObservationRefreshRuns(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	observationStarted := make(chan struct{})
 	releaseObservation := make(chan struct{})
@@ -306,6 +312,7 @@ func TestConsumeCredentialResetCreditReplayReportsPendingWhileObservationRefresh
 }
 
 func TestConsumeCredentialResetCreditRestoresRuntimeHealth(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	now := time.Date(2026, time.August, 14, 11, 30, 0, 0, time.UTC)
 	fixture.service.now = func() time.Time { return now }
@@ -347,6 +354,7 @@ func TestConsumeCredentialResetCreditRestoresRuntimeHealth(t *testing.T) {
 }
 
 func TestConsumeCredentialResetCreditRetriesAmbiguousOutcomeOnlyWithSameKey(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	consumeCalls := 0
 	setCodexResetCreditConsume(t, fixture.service, func(_ context.Context, _ codex.Credential, redeemRequestID string) (codex.AccountObservation, error) {
@@ -389,6 +397,7 @@ func TestConsumeCredentialResetCreditRetriesAmbiguousOutcomeOnlyWithSameKey(t *t
 }
 
 func TestConsumeCredentialResetCreditRecoversStalePreparedOperationWithSameKey(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	now := time.Date(2026, time.August, 14, 12, 0, 0, 0, time.UTC)
 	fixture.service.now = func() time.Time { return now }
@@ -421,6 +430,7 @@ func TestConsumeCredentialResetCreditRecoversStalePreparedOperationWithSameKey(t
 }
 
 func TestConsumeCredentialResetCreditAllowsNewKeyAfterSuccessWhenObservationRefreshFails(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	consumeCalls := 0
 	setCodexResetCreditConsume(t, fixture.service, func(context.Context, codex.Credential, string) (codex.AccountObservation, error) {
@@ -454,6 +464,7 @@ func TestConsumeCredentialResetCreditAllowsNewKeyAfterSuccessWhenObservationRefr
 }
 
 func TestConsumeCredentialResetCreditAllowsNewKeyImmediatelyAfterSuccess(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	fixedNow := time.Date(2026, time.August, 14, 13, 30, 0, 0, time.UTC)
 	fixture.service.now = func() time.Time { return fixedNow }
@@ -481,6 +492,7 @@ func TestConsumeCredentialResetCreditAllowsNewKeyImmediatelyAfterSuccess(t *test
 }
 
 func TestConsumeCredentialResetCreditRejectsReusedKeyForAnotherCredential(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	setCodexResetCreditConsume(t, fixture.service, func(context.Context, codex.Credential, string) (codex.AccountObservation, error) {
 		return codex.AccountObservation{Payload: []byte(`{"code":"reset","windows_reset":1}`)}, nil
@@ -508,6 +520,7 @@ func TestConsumeCredentialResetCreditRejectsReusedKeyForAnotherCredential(t *tes
 }
 
 func TestConsumeCredentialResetCreditRejectsReusedKeyAfterIdentityChanges(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	setCodexResetCreditConsume(t, fixture.service, func(context.Context, codex.Credential, string) (codex.AccountObservation, error) {
 		return codex.AccountObservation{Payload: []byte(`{"code":"reset","windows_reset":1}`)}, nil
@@ -531,6 +544,7 @@ func TestConsumeCredentialResetCreditRejectsReusedKeyAfterIdentityChanges(t *tes
 }
 
 func TestConsumeCredentialResetCreditReplaysSuccessWithoutPreparingCredential(t *testing.T) {
+	t.Parallel()
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	setCodexResetCreditConsume(t, fixture.service, func(context.Context, codex.Credential, string) (codex.AccountObservation, error) {
 		return codex.AccountObservation{Payload: []byte(`{"code":"reset","windows_reset":1}`)}, nil

--- a/internal/control/credential_stage_routes_test.go
+++ b/internal/control/credential_stage_routes_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestCredentialStageRoutesRequireAuthAndNeverReturnSecrets(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	useEphemeralOAuthCallbackListeners(fixture.service.oauthCallback)
@@ -81,6 +82,7 @@ func TestCredentialStageRoutesRequireAuthAndNeverReturnSecrets(t *testing.T) {
 }
 
 func TestCredentialStageRoutesUseExistingGroupProxy(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	useEphemeralOAuthCallbackListeners(fixture.service.oauthCallback)
@@ -171,6 +173,7 @@ func TestCredentialStageRoutesUseExistingGroupProxy(t *testing.T) {
 }
 
 func TestDeviceAuthorizationRouteReturnsSafeChallengeAndPollsByPOST(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	now := fixture.service.now().UTC()
@@ -225,6 +228,7 @@ func TestDeviceAuthorizationRouteReturnsSafeChallengeAndPollsByPOST(t *testing.T
 }
 
 func TestBeginCredentialAuthorizationAllowsManualCallbackWhenListenerIsUnavailable(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	fixture.service.oauthCallback.listen = func(string, string) (net.Listener, error) {
@@ -244,6 +248,7 @@ func TestBeginCredentialAuthorizationAllowsManualCallbackWhenListenerIsUnavailab
 }
 
 func TestBeginCredentialAuthorizationStartsOnlyTheCallbackRequestedByTheDriver(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	originalBegin := fixture.service.beginSubscriptionAuthorization
@@ -275,6 +280,7 @@ func TestBeginCredentialAuthorizationStartsOnlyTheCallbackRequestedByTheDriver(t
 }
 
 func TestManualOAuthCallbackCompletesOnlyItsBoundStageOnce(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	first, err := fixture.service.BeginCredentialAuthorization(t.Context(), "codex")
@@ -319,6 +325,7 @@ func TestManualOAuthCallbackCompletesOnlyItsBoundStageOnce(t *testing.T) {
 }
 
 func TestParseManualOAuthCallbackURLRequiresFixedLocalCallback(t *testing.T) {
+	t.Parallel()
 	valid := "http://localhost:1455/auth/callback?code=authorization-code&state=state-one"
 	parsed, err := parseManualOAuthCallbackURL(valid, subscriptionruntime.LocalCallbackSpec{
 		RedirectURI: "http://localhost:1455/auth/callback",
@@ -344,6 +351,7 @@ func TestParseManualOAuthCallbackURLRequiresFixedLocalCallback(t *testing.T) {
 }
 
 func TestParseManualOAuthCallbackURLUsesDriverCallback(t *testing.T) {
+	t.Parallel()
 	claudeCallback := subscriptionruntime.LocalCallbackSpec{
 		RedirectURI: "http://localhost:54545/callback",
 	}
@@ -363,6 +371,7 @@ func TestParseManualOAuthCallbackURLUsesDriverCallback(t *testing.T) {
 }
 
 func TestOAuthCallbackServerStartsIndependentDriverEndpoints(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	useEphemeralOAuthCallbackListeners(fixture.service.oauthCallback)
 	callbacks := []subscriptionruntime.LocalCallbackSpec{
@@ -410,6 +419,7 @@ func postManualOAuthCallback(engine *gin.Engine, stageID string, callbackURL str
 }
 
 func TestOAuthFileImportRouteStreamsOneFileIntoReadyStage(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	engine := gin.New()
@@ -448,6 +458,7 @@ func TestOAuthFileImportRouteStreamsOneFileIntoReadyStage(t *testing.T) {
 }
 
 func TestOAuthFileImportRouteRequiresChannelID(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	engine := gin.New()
@@ -474,6 +485,7 @@ func TestOAuthFileImportRouteRequiresChannelID(t *testing.T) {
 }
 
 func TestOAuthCallbackServerIsPublicStateBoundAndNoStore(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	started, err := fixture.service.BeginCredentialAuthorization(t.Context(), "codex")
 	if err != nil {
@@ -515,6 +527,7 @@ func TestOAuthCallbackServerIsPublicStateBoundAndNoStore(t *testing.T) {
 }
 
 func TestOAuthCallbackServerRejectsStateFromAnotherDriverEndpoint(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	started, err := fixture.service.BeginCredentialAuthorization(t.Context(), channel.Codex)
 	if err != nil {
@@ -553,6 +566,7 @@ func TestOAuthCallbackServerRejectsStateFromAnotherDriverEndpoint(t *testing.T) 
 }
 
 func TestOAuthCallbackServerMarksDeniedAuthorizationFailed(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	started, err := fixture.service.BeginCredentialAuthorization(t.Context(), "codex")
 	if err != nil {
@@ -593,6 +607,7 @@ func TestOAuthCallbackServerMarksDeniedAuthorizationFailed(t *testing.T) {
 }
 
 func TestOAuthCallbackExchangeFailureDoesNotOfferConsumedCallbackRetry(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	started, err := fixture.service.BeginCredentialAuthorization(t.Context(), channel.Codex)
 	if err != nil {
@@ -659,6 +674,7 @@ func useEphemeralOAuthCallbackListeners(manager *OAuthCallbackManager) {
 }
 
 func TestNewServerConfiguresOAuthCallbackForWildcardContainerHost(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	NewServer(&config.Config{AuthKey: "test-auth-key", Server: config.ServerConfig{Host: "0.0.0.0"}}, fixture.service)
 	if got := fixture.service.oauthCallback.host; got != "0.0.0.0" {
@@ -667,6 +683,7 @@ func TestNewServerConfiguresOAuthCallbackForWildcardContainerHost(t *testing.T) 
 }
 
 func TestCredentialObservationRoutesReadCacheAndRefreshExplicitly(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	setCodexAccountObservation(fixture.service, func(context.Context, codex.Credential) (codex.AccountObservation, error) {
@@ -705,6 +722,7 @@ func TestCredentialObservationRoutesReadCacheAndRefreshExplicitly(t *testing.T) 
 }
 
 func TestCredentialResetCreditRouteRequiresIdempotencyAndReplays(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
 	consumeCalls := 0

--- a/internal/control/credential_stages_test.go
+++ b/internal/control/credential_stages_test.go
@@ -30,6 +30,7 @@ func (credentialImportNetworkError) Timeout() bool   { return true }
 func (credentialImportNetworkError) Temporary() bool { return true }
 
 func TestCredentialImportUsesBoundedContextAndClassifiesTransientFailures(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := credentialImportContext(t.Context())
 	defer cancel()
 	deadline, known := ctx.Deadline()
@@ -102,6 +103,7 @@ func TestImportCodexOAuthJSONCreatesEncryptedReadyStage(t *testing.T) {
 }
 
 func TestImportCodexOAuthJSONRefreshesExpiredCredentialBeforeReady(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := time.Date(2026, time.August, 14, 8, 0, 0, 0, time.UTC)
 	fixture.service.now = func() time.Time { return now }
@@ -150,6 +152,7 @@ func TestImportCodexOAuthJSONRejectsInvalidInput(t *testing.T) {
 }
 
 func TestImportClaudeOAuthJSONRequiresExpiredTimestamp(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	_, err := fixture.service.ImportCredentialStage(t.Context(), channel.Claude, []byte(
 		`{"type":"claude","access_token":"access","refresh_token":"refresh","account_uuid":"account"}`,
@@ -185,6 +188,7 @@ func TestBeginBrowserAuthorizationCreatesPendingStage(t *testing.T) {
 }
 
 func TestBeginDeviceAuthorizationCreatesEncryptedPendingStage(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := time.UnixMilli(1_800_000_000_000).UTC()
 	fixture.service.now = func() time.Time { return now }
@@ -222,6 +226,7 @@ func TestBeginDeviceAuthorizationCreatesEncryptedPendingStage(t *testing.T) {
 }
 
 func TestBeginDeviceAuthorizationRejectsUnsafeChallenge(t *testing.T) {
+	t.Parallel()
 	now := time.UnixMilli(1_800_000_000_000).UTC()
 	for _, test := range []struct {
 		name         string
@@ -253,6 +258,7 @@ func TestBeginDeviceAuthorizationRejectsUnsafeChallenge(t *testing.T) {
 }
 
 func TestPollDeviceAuthorizationHonorsIntervalAndPersistsPendingState(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := time.UnixMilli(1_800_000_000_000).UTC()
 	fixture.service.now = func() time.Time { return now }
@@ -312,6 +318,7 @@ func TestPollDeviceAuthorizationHonorsIntervalAndPersistsPendingState(t *testing
 }
 
 func TestPollDeviceAuthorizationConcurrentRequestDoesNotDispatchTwice(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := time.UnixMilli(1_800_000_000_000).UTC()
 	fixture.service.now = func() time.Time { return now }
@@ -355,6 +362,7 @@ func TestPollDeviceAuthorizationConcurrentRequestDoesNotDispatchTwice(t *testing
 }
 
 func TestPollDeviceAuthorizationCompletesReadyStage(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := time.UnixMilli(1_800_000_000_000).UTC()
 	fixture.service.now = func() time.Time { return now }
@@ -388,6 +396,7 @@ func TestPollDeviceAuthorizationCompletesReadyStage(t *testing.T) {
 }
 
 func TestPollDeviceAuthorizationPersistsTerminalStatesAndClearsSecrets(t *testing.T) {
+	t.Parallel()
 	for _, test := range []struct {
 		name      string
 		poll      subscriptionruntime.DeviceAuthorizationStatus
@@ -497,6 +506,7 @@ func TestCompleteBrowserAuthorizationConsumesStateOnce(t *testing.T) {
 }
 
 func TestCompleteBrowserAuthorizationAcceptsVersionOnePendingStage(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := time.UnixMilli(1_800_000_000_000)
 	fixture.service.now = func() time.Time { return now }
@@ -558,6 +568,7 @@ func TestCompleteBrowserAuthorizationAcceptsVersionOnePendingStage(t *testing.T)
 }
 
 func TestCompleteBrowserAuthorizationMarksDefinitiveExchangeRejectionFailed(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	started, err := fixture.service.BeginCredentialAuthorization(t.Context(), channel.Codex)
 	if err != nil {
@@ -595,6 +606,7 @@ func TestCompleteBrowserAuthorizationMarksDefinitiveExchangeRejectionFailed(t *t
 }
 
 func TestCompleteBrowserAuthorizationUsesBoundedUpstreamContext(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	started, err := fixture.service.BeginCredentialAuthorization(t.Context(), channel.Codex)
 	if err != nil {
@@ -626,6 +638,7 @@ func TestCompleteBrowserAuthorizationUsesBoundedUpstreamContext(t *testing.T) {
 }
 
 func TestCompleteBrowserAuthorizationSurvivesCallbackCancellationAfterClaim(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	started, err := fixture.service.BeginCredentialAuthorization(t.Context(), channel.Codex)
 	if err != nil {
@@ -664,6 +677,7 @@ func TestCompleteBrowserAuthorizationSurvivesCallbackCancellationAfterClaim(t *t
 }
 
 func TestCompleteBrowserAuthorizationTreatsTransientEndpointRejectionAsUnknown(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	started, err := fixture.service.BeginCredentialAuthorization(t.Context(), channel.Codex)
 	if err != nil {
@@ -931,6 +945,7 @@ func TestCleanupCredentialStagesExpiresSecretsAndRemovesOldTombstones(t *testing
 }
 
 func TestGetCredentialStageFinalizesExpiredExchange(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := time.Date(2026, time.August, 14, 8, 0, 0, 0, time.UTC)
 	fixture.service.now = func() time.Time { return now }

--- a/internal/control/discover_executor_test.go
+++ b/internal/control/discover_executor_test.go
@@ -120,6 +120,7 @@ func encodeDiscoveryModelsForTest(value protocol.Protocol, models []string) []by
 }
 
 func TestUtilityRequestShapeUsesSelectedProtocol(t *testing.T) {
+	t.Parallel()
 	for _, test := range []struct {
 		clientProtocol protocol.Protocol
 		path           string
@@ -352,6 +353,7 @@ func (scriptedDiscoveryExecutor) ExecuteStream(context.Context, execution.Attemp
 }
 
 func TestExecuteModelDiscoveryFallsBackAcrossCredentialsInStableOrder(t *testing.T) {
+	t.Parallel()
 	var calls []string
 	recorder := &recordingDiscoveryExecutorTarget{
 		value: protocol.OpenAICompletions,
@@ -382,6 +384,7 @@ func TestExecuteModelDiscoveryFallsBackAcrossCredentialsInStableOrder(t *testing
 }
 
 func TestExecuteModelDiscoverySharesOneTotalTimeout(t *testing.T) {
+	t.Parallel()
 	var mu sync.Mutex
 	var deadlines []time.Time
 	recorder := &recordingDiscoveryExecutorTarget{
@@ -410,6 +413,7 @@ func TestExecuteModelDiscoverySharesOneTotalTimeout(t *testing.T) {
 }
 
 func TestExecuteModelDiscoveryReturnsParentCancellation(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	calls := 0
 	recorder := &recordingDiscoveryExecutorTarget{
@@ -431,6 +435,7 @@ func TestExecuteModelDiscoveryReturnsParentCancellation(t *testing.T) {
 }
 
 func TestExecuteModelDiscoveryRejectsInvalidTargetBeforeDispatch(t *testing.T) {
+	t.Parallel()
 	calls := 0
 	service := &Service{
 		executor: scriptedDiscoveryExecutor{execute: func(context.Context, execution.AttemptSpec) execution.AttemptResult {
@@ -464,6 +469,7 @@ func TestExecuteModelDiscoveryRejectsInvalidTargetBeforeDispatch(t *testing.T) {
 }
 
 func TestNormalizeDiscoveredModels(t *testing.T) {
+	t.Parallel()
 	got := normalizeDiscoveredModels([]string{" model-b ", "", "model-a", "model-b", "\t"})
 	if !reflect.DeepEqual(got, []string{"model-b", "model-a"}) {
 		t.Fatalf("normalizeDiscoveredModels() = %#v", got)

--- a/internal/control/discover_group_test.go
+++ b/internal/control/discover_group_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestDiscoveryUsesSingleReadSnapshot(t *testing.T) {
+	t.Parallel()
 	fixture, dsn := newFileServiceFixture(t)
 	group := seedPersistedDiscoveryGroup(t, fixture, true, models.JSON(`{}`))
 	group.Name = "discovery-snapshot-old"
@@ -174,6 +175,7 @@ func TestDiscoveryUsesSingleReadSnapshot(t *testing.T) {
 }
 
 func TestDiscoveryReleasesReadSnapshotBeforeDecrypt(t *testing.T) {
+	t.Parallel()
 	fixture, _ := newFileServiceFixture(t)
 	group := seedPersistedDiscoveryGroup(t, fixture, true, models.JSON(`{}`))
 	seedPersistedDiscoveryCredential(
@@ -235,6 +237,7 @@ func TestDiscoveryReleasesReadSnapshotBeforeDecrypt(t *testing.T) {
 }
 
 func TestDiscoverGroupModelsUsesDisabledGroupAndActiveCredentialsInIDOrder(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	group := seedPersistedDiscoveryGroup(t, fixture, false, models.JSON(
 		`{"header_rules":{"set":{"X-Group":"group"},"remove":["X-Remove"]}}`,
@@ -298,6 +301,7 @@ func TestDiscoverGroupModelsUsesDisabledGroupAndActiveCredentialsInIDOrder(t *te
 }
 
 func TestDiscoverGroupModelsReturnsNotFoundAndNoActiveUpstreamKey(t *testing.T) {
+	t.Parallel()
 	t.Run("missing Group", func(t *testing.T) {
 		fixture := newServiceFixture(t)
 		_, err := fixture.service.DiscoverGroupModels(t.Context(), 999)
@@ -344,6 +348,7 @@ func TestDiscoverGroupModelsUsesSubscriptionCredential(t *testing.T) {
 }
 
 func TestClaudeGroupDiscoversModelsAndBecomesAvailableAfterSelection(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	stage, err := fixture.service.ImportCredentialStage(t.Context(), channel.Claude, []byte(
 		`{"type":"claude","access_token":"claude-access","refresh_token":"claude-refresh","account_uuid":"claude-account","email":"claude@example.com","expired":"2030-01-01T00:00:00Z"}`,
@@ -398,6 +403,7 @@ func TestClaudeGroupDiscoversModelsAndBecomesAvailableAfterSelection(t *testing.
 }
 
 func TestDiscoverGroupModelsPreparesSubscriptionCredential(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	stage := mustImportSubscriptionStage(t, fixture, "account-prepared-models", "prepared@example.com")
 	created, err := fixture.service.CreateGroup(t.Context(), GroupCreateRequest{
@@ -432,6 +438,7 @@ func TestDiscoverGroupModelsPreparesSubscriptionCredential(t *testing.T) {
 }
 
 func TestDiscoverGroupModelsRefreshesSameCredentialOnceAfterUnauthorized(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	stage := mustImportSubscriptionStage(t, fixture, "account-model-refresh", "model-refresh@example.com")
 	created, err := fixture.service.CreateGroup(t.Context(), GroupCreateRequest{
@@ -479,6 +486,7 @@ func TestDiscoverGroupModelsRefreshesSameCredentialOnceAfterUnauthorized(t *test
 }
 
 func TestDiscoverGroupModelsSkipsSubscriptionCredentialRequiringAuthorization(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	stage := mustImportSubscriptionStage(t, fixture, "account-reauthorize-models", "reauthorize@example.com")
 	created, err := fixture.service.CreateGroup(t.Context(), GroupCreateRequest{
@@ -507,6 +515,7 @@ func TestDiscoverGroupModelsSkipsSubscriptionCredentialRequiringAuthorization(t 
 }
 
 func TestMapGroupDiscoveryTargetRejectsUnreadySubscriptionCredential(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	stage := mustImportSubscriptionStage(t, fixture, "account-route-owned", "route-owned@example.com")
 	created, err := fixture.service.CreateGroup(t.Context(), GroupCreateRequest{
@@ -534,6 +543,7 @@ func TestMapGroupDiscoveryTargetRejectsUnreadySubscriptionCredential(t *testing.
 }
 
 func TestMapGroupDiscoveryTargetPreparesSubscriptionCredential(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	stage := mustImportSubscriptionStage(t, fixture, "account-route-refresh", "route-refresh@example.com")
 	created, err := fixture.service.CreateGroup(t.Context(), GroupCreateRequest{
@@ -571,6 +581,7 @@ func TestMapGroupDiscoveryTargetPreparesSubscriptionCredential(t *testing.T) {
 }
 
 func TestDiscoverGroupModelsDoesNotMaskAttemptedSubscriptionFailure(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	first := mustImportSubscriptionStage(t, fixture, "account-reauthorize-first", "first@example.com")
 	created, err := fixture.service.CreateGroup(t.Context(), GroupCreateRequest{
@@ -604,6 +615,7 @@ func TestDiscoverGroupModelsDoesNotMaskAttemptedSubscriptionFailure(t *testing.T
 }
 
 func TestCodexPreparationAPIErrorTreatsStateCommitFailureAsUnknown(t *testing.T) {
+	t.Parallel()
 	err := subscriptionPreparationAPIError(&execution.ErrorEvidence{Code: "refresh_state_commit_failed"})
 	if !errors.Is(err, app_errors.ErrCredentialAuthOutcomeUnknown) {
 		t.Fatalf("subscriptionPreparationAPIError() = %v, want ErrCredentialAuthOutcomeUnknown", err)
@@ -611,6 +623,7 @@ func TestCodexPreparationAPIErrorTreatsStateCommitFailureAsUnknown(t *testing.T)
 }
 
 func TestDiscoverGroupModelsDecryptsEveryKeyBeforeHTTP(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	group := seedPersistedDiscoveryGroup(t, fixture, true, models.JSON(`{}`))
 	seedPersistedDiscoveryCredential(t, fixture, group.ID, 1, "key-1", models.CredentialStatusActive)
@@ -644,6 +657,7 @@ func TestDiscoverGroupModelsDecryptsEveryKeyBeforeHTTP(t *testing.T) {
 }
 
 func TestDiscoverGroupModelsDoesNotMutateDatabaseSnapshotOrRegistry(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		listFn  func(context.Context, context.CancelFunc) ([]string, error)
@@ -712,6 +726,7 @@ func TestDiscoverGroupModelsDoesNotMutateDatabaseSnapshotOrRegistry(t *testing.T
 }
 
 func TestDiscoverGroupModelsDoesNotAcquireWriteMuOrBlockWrites(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	created, err := fixture.service.CreateGroup(t.Context(), GroupCreateRequest{
 		ChannelID:   channel.OpenAICompatible,

--- a/internal/control/discover_test.go
+++ b/internal/control/discover_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestDiscoverModelsUsesSystemDefaultsAndNormalizesSuccessfulResult(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	if err := fixture.db.Create(&models.SystemSetting{
 		Key: "header_rules",
@@ -116,6 +117,7 @@ func TestDiscoverModelsUsesReadySubscriptionStage(t *testing.T) {
 }
 
 func TestDiscoverModelsAppliesRequestedProxyToReadySubscriptionStage(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	stageProxy := outboundproxy.Config{
 		Mode: outboundproxy.ModeCustom,
@@ -183,6 +185,7 @@ func TestDiscoverModelsAppliesRequestedProxyToReadySubscriptionStage(t *testing.
 }
 
 func TestDiscoverModelsRefreshesReadySubscriptionStageBeforeUse(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := time.Date(2026, time.August, 14, 8, 0, 0, 0, time.UTC)
 	fixture.service.now = func() time.Time { return now }
@@ -267,6 +270,7 @@ func TestDiscoverModelsRefreshesReadySubscriptionStageBeforeUse(t *testing.T) {
 }
 
 func TestDiscoverModelsRejectsReadyStageRefreshIdentityChange(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := time.Date(2026, time.August, 14, 8, 0, 0, 0, time.UTC)
 	fixture.service.now = func() time.Time { return now }
@@ -303,6 +307,7 @@ func TestDiscoverModelsRejectsReadyStageRefreshIdentityChange(t *testing.T) {
 }
 
 func TestDiscoverModelsRefreshesReadyStageOnceAfterUnauthorized(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	stage, err := fixture.service.ImportCredentialStage(t.Context(), channel.Codex, []byte(
 		`{"type":"codex","access_token":"stale-access","refresh_token":"refresh-token","account_id":"account-discovery-refresh","expired":"2030-01-01T00:00:00Z"}`,
@@ -340,6 +345,7 @@ func TestDiscoverModelsRefreshesReadyStageOnceAfterUnauthorized(t *testing.T) {
 }
 
 func TestDiscoverModelsMarksReadyStageOutcomeUnknownAfterAmbiguousRefresh(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := time.Date(2026, time.August, 14, 8, 0, 0, 0, time.UTC)
 	fixture.service.now = func() time.Time { return now }
@@ -368,6 +374,7 @@ func TestDiscoverModelsMarksReadyStageOutcomeUnknownAfterAmbiguousRefresh(t *tes
 }
 
 func TestReadyStageRefreshExcludesConcurrentConsume(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := time.Date(2026, time.August, 14, 8, 0, 0, 0, time.UTC)
 	fixture.service.now = func() time.Time { return now }
@@ -422,6 +429,7 @@ func TestReadyStageRefreshExcludesConcurrentConsume(t *testing.T) {
 }
 
 func TestReadyStageRefreshCancellationBoundary(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := time.Date(2026, time.August, 14, 8, 0, 0, 0, time.UTC)
 	fixture.service.now = func() time.Time { return now }
@@ -501,6 +509,7 @@ func TestReadyStageRefreshCancellationBoundary(t *testing.T) {
 }
 
 func TestDiscoverModelsRejectsInvalidDraftBeforeHTTP(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	var calls atomic.Int64
 	fixture.service.executor = newRecordingDiscoveryExecutor(&recordingDiscoveryExecutorTarget{
@@ -550,6 +559,7 @@ func TestDiscoverModelsRejectsInvalidDraftBeforeHTTP(t *testing.T) {
 }
 
 func TestDiscoverModelsUsesChannelNativeDiscoveryProtocol(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	calls := 0
 	fixture.service.executor = newRecordingDiscoveryExecutor(&recordingDiscoveryExecutorTarget{
@@ -588,6 +598,7 @@ func TestDiscoverModelsUsesChannelNativeDiscoveryProtocol(t *testing.T) {
 }
 
 func TestDiscoverModelsPassesStructuredCloudCredentialToExecutor(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	var observed execution.AttemptSpec
 	fixture.service.executor = scriptedDiscoveryExecutor{execute: func(
@@ -628,6 +639,7 @@ func TestDiscoverModelsPassesStructuredCloudCredentialToExecutor(t *testing.T) {
 }
 
 func TestDiscoverModelsDoesNotReadOrMutateRuntimeState(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	created, err := fixture.service.CreateGroup(context.Background(), GroupCreateRequest{
 		Name: stringPointer("discover-runtime-state"), ChannelID: channel.OpenAICompatible,
@@ -723,6 +735,7 @@ func TestDiscoverModelsDoesNotReadOrMutateRuntimeState(t *testing.T) {
 }
 
 func TestDiscoverModelsDoesNotAcquireWriteMu(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.executor = newRecordingDiscoveryExecutor(&recordingDiscoveryExecutorTarget{
 		value: protocol.OpenAICompletions,
@@ -755,6 +768,7 @@ func TestDiscoverModelsDoesNotAcquireWriteMu(t *testing.T) {
 }
 
 func TestDiscoverModelsDoesNotBlockMutation(t *testing.T) {
+	t.Parallel()
 	entered := make(chan struct{})
 	release := make(chan struct{})
 	fixture := newServiceFixture(t)

--- a/internal/control/external_database_integration_test.go
+++ b/internal/control/external_database_integration_test.go
@@ -16,6 +16,7 @@ import (
 // retained-rule two-phase period move obeys the real MySQL/PostgreSQL unique
 // index while preserving IDs and resetting each changed revision.
 func TestExternalDatabaseAccessKeyCostLimitPeriodPermutation(t *testing.T) {
+	// 不标记 t.Parallel()：依赖 GPT_LOAD_DATABASE_TEST_DSN 的共享外部数据库，并发执行有唯一索引冲突等正确性风险。
 	dsn := strings.TrimSpace(os.Getenv("GPT_LOAD_DATABASE_TEST_DSN"))
 	if dsn == "" {
 		t.Skip("GPT_LOAD_DATABASE_TEST_DSN is not set")
@@ -33,6 +34,7 @@ func TestExternalDatabaseAccessKeyCostLimitPeriodPermutation(t *testing.T) {
 // global model price, and removing the final reference cleans only the
 // automatic row.
 func TestExternalDatabaseGroupPriceReconciliation(t *testing.T) {
+	// 不标记 t.Parallel()：依赖 GPT_LOAD_DATABASE_TEST_DSN 的共享外部数据库，并发执行有唯一索引冲突等正确性风险。
 	dsn := strings.TrimSpace(os.Getenv("GPT_LOAD_DATABASE_TEST_DSN"))
 	if dsn == "" {
 		t.Skip("GPT_LOAD_DATABASE_TEST_DSN is not set")

--- a/internal/control/group_collection_http_test.go
+++ b/internal/control/group_collection_http_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestParseGroupCollectionQueryAcceptsStrictContract(t *testing.T) {
+	t.Parallel()
 	available := GroupCollectionStatusAvailable
 	unavailable := GroupCollectionStatusUnavailable
 	disabled := GroupCollectionStatusDisabled
@@ -162,6 +163,7 @@ func TestParseGroupCollectionQueryAcceptsStrictContract(t *testing.T) {
 }
 
 func TestParseGroupCollectionQueryDefaultsToRecentActivity(t *testing.T) {
+	t.Parallel()
 	got, apiErr := parseGroupCollectionQuery("", false)
 	if apiErr != nil {
 		t.Fatalf("parseGroupCollectionQuery() error = %v", apiErr)
@@ -172,6 +174,7 @@ func TestParseGroupCollectionQueryDefaultsToRecentActivity(t *testing.T) {
 }
 
 func TestParseGroupCollectionQueryRejectsEveryInvalidForm(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		rawQuery   string
@@ -223,6 +226,7 @@ func TestParseGroupCollectionQueryRejectsEveryInvalidForm(t *testing.T) {
 }
 
 func TestGroupCollectionQueryUsesCredentialSortAndRejectsProtocolFilter(t *testing.T) {
+	t.Parallel()
 	got, apiErr := parseGroupCollectionQuery("sort=credentials", false)
 	if apiErr != nil {
 		t.Fatalf("parseGroupCollectionQuery(sort=credentials) error = %v", apiErr)
@@ -258,6 +262,7 @@ func assertGroupCollectionQueryEqual(
 }
 
 func TestGroupCollectionHTTPReturnsExactCollectionAndOptionsContracts(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	createGroupOptionGroup(
@@ -363,6 +368,7 @@ func TestGroupCollectionHTTPReturnsExactCollectionAndOptionsContracts(t *testing
 }
 
 func TestGroupCollectionHTTPAllowsAvailableKeysInAnUnavailableStatus(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	group := createGroupCollectionGroup(t, fixture, "http-zero-model-completions", true, nil)
@@ -396,6 +402,7 @@ func TestGroupCollectionHTTPAllowsAvailableKeysInAnUnavailableStatus(t *testing.
 }
 
 func TestGroupOptionsHTTPRejectsAnyQueryIncludingBareQuestionMark(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	engine := gin.New()
 	NewServer(&config.Config{AuthKey: authTestKey}, nil).RegisterRoutes(engine)
@@ -422,6 +429,7 @@ func TestGroupOptionsHTTPRejectsAnyQueryIncludingBareQuestionMark(t *testing.T) 
 }
 
 func TestGroupCollectionHTTPRejectsInvalidQueryBeforeServiceAccess(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	engine := gin.New()
@@ -452,6 +460,7 @@ func TestGroupCollectionHTTPRejectsInvalidQueryBeforeServiceAccess(t *testing.T)
 }
 
 func TestGroupCollectionHTTPMapsServiceErrorsThroughStandardEnvelope(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	for _, target := range []string{"/api/groups", "/api/groups/options"} {
 		t.Run(target, func(t *testing.T) {

--- a/internal/control/group_collection_query_test.go
+++ b/internal/control/group_collection_query_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestListGroupCollectionCapturesThenQueries(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	observedAt := int64(1_700)
 	fixture.service.now = func() time.Time { return time.UnixMilli(observedAt) }
@@ -51,6 +52,7 @@ func TestListGroupCollectionCapturesThenQueries(t *testing.T) {
 }
 
 func TestListGroupCollectionSortsRecentActivityByHourThenRequestCount(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	older := createGroupCollectionGroup(t, fixture, "older", true, nil)
 	recentLow := createGroupCollectionGroup(t, fixture, "alpha recent", true, nil)
@@ -89,6 +91,7 @@ func TestListGroupCollectionSortsRecentActivityByHourThenRequestCount(t *testing
 }
 
 func TestGroupCollectionLatestActivityScopeQuotesGroupsForMySQL(t *testing.T) {
+	t.Parallel()
 	db, err := gorm.Open(gormmysql.New(gormmysql.Config{
 		DSN:                       "user:password@tcp(127.0.0.1:3306)/gpt_load",
 		SkipInitializeWithVersion: true,
@@ -116,6 +119,7 @@ func TestGroupCollectionLatestActivityScopeQuotesGroupsForMySQL(t *testing.T) {
 }
 
 func TestListGroupCollectionSkipsActivityReadForNonRecentSort(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	group := createGroupCollectionGroup(t, fixture, "name sort", true, nil)
 	entry := createGroupCollectionKey(t, fixture, group.ID, models.CredentialStatusActive, nil)
@@ -136,6 +140,7 @@ func TestListGroupCollectionSkipsActivityReadForNonRecentSort(t *testing.T) {
 }
 
 func TestListGroupCollectionQueryDoesNotSearchPersistedModelIDOrAlias(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	group := createGroupCollectionGroup(t, fixture, "not a model", true, nil)
 	group.Models = models.JSON(`[{"id":"private-upstream-model","alias":"public-model-alias"}]`)
@@ -161,6 +166,7 @@ func TestListGroupCollectionQueryDoesNotSearchPersistedModelIDOrAlias(t *testing
 }
 
 func TestGroupCollectionQueryFiltersUnicodeInsensitiveFieldsWithoutModels(t *testing.T) {
+	t.Parallel()
 	records := []groupCollectionRecord{
 		groupCollectionQueryRecord(1, "München", GroupCollectionStatusAvailable, "https://muenchen.example.net/v1", []protocol.Protocol{protocol.OpenAICompletions}, 7, 100),
 		groupCollectionQueryRecord(2, "URL only", GroupCollectionStatusUnavailable, "https://Api.Example.Net/v1", []protocol.Protocol{protocol.Gemini}, 3, 200),
@@ -190,6 +196,7 @@ func TestGroupCollectionQueryFiltersUnicodeInsensitiveFieldsWithoutModels(t *tes
 }
 
 func TestGroupCollectionQueryMatchesUnicodeSimpleFoldAndSortsWithIt(t *testing.T) {
+	t.Parallel()
 	records := []groupCollectionRecord{
 		groupCollectionQueryRecord(2, "ΟΣ", GroupCollectionStatusAvailable, "https://two.example/v1", nil, 1, 100),
 		groupCollectionQueryRecord(1, "ος", GroupCollectionStatusAvailable, "https://one.example/v1", nil, 1, 100),
@@ -204,6 +211,7 @@ func TestGroupCollectionQueryMatchesUnicodeSimpleFoldAndSortsWithIt(t *testing.T
 }
 
 func TestGroupCollectionQueryFiltersByConnectionType(t *testing.T) {
+	t.Parallel()
 	subscription := models.ConnectionTypeSubscription
 	records := []groupCollectionRecord{
 		groupCollectionQueryRecord(1, "API key", GroupCollectionStatusAvailable, "https://api-key.example", nil, 1, 100),
@@ -224,6 +232,7 @@ func TestGroupCollectionQueryFiltersByConnectionType(t *testing.T) {
 }
 
 func TestGroupCollectionQueryCombinesFiltersAndSummarizesCompleteCollection(t *testing.T) {
+	t.Parallel()
 	available := GroupCollectionStatusAvailable
 	records := []groupCollectionRecord{
 		groupCollectionQueryRecord(1, "Alpha", GroupCollectionStatusAvailable, "https://alpha.example/v1", []protocol.Protocol{protocol.OpenAICompletions}, 1, 100),
@@ -250,6 +259,7 @@ func TestGroupCollectionQueryCombinesFiltersAndSummarizesCompleteCollection(t *t
 }
 
 func TestGroupCollectionQueryUsesFixedSortsWithIDTieBreak(t *testing.T) {
+	t.Parallel()
 	records := []groupCollectionRecord{
 		groupCollectionQueryRecord(5, "Bravo", GroupCollectionStatusAvailable, "https://five.example/v1", nil, 3, 500),
 		groupCollectionQueryRecord(4, "bravo", GroupCollectionStatusAvailable, "https://four.example/v1", nil, 3, 400),
@@ -280,6 +290,7 @@ func TestGroupCollectionQueryUsesFixedSortsWithIDTieBreak(t *testing.T) {
 }
 
 func TestGroupCollectionQueryRecentActivityFallsBackToNameWithoutUsage(t *testing.T) {
+	t.Parallel()
 	records := []groupCollectionRecord{
 		groupCollectionQueryRecord(2, "Zulu", GroupCollectionStatusUnavailable, "https://zulu.example/v1", nil, 1, 200),
 		groupCollectionQueryRecord(1, "Alpha", GroupCollectionStatusDisabled, "https://alpha.example/v1", nil, 1, 100),
@@ -292,6 +303,7 @@ func TestGroupCollectionQueryRecentActivityFallsBackToNameWithoutUsage(t *testin
 }
 
 func TestGroupCollectionSortUsesActivityOnlyForRecentOrdering(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		sortBy GroupCollectionSort
@@ -315,6 +327,7 @@ func TestGroupCollectionSortUsesActivityOnlyForRecentOrdering(t *testing.T) {
 }
 
 func TestGroupCollectionQueryUsesIDTieBreakAfterEachSortPrimaryAndName(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		sort    GroupCollectionSort
@@ -371,6 +384,7 @@ func TestGroupCollectionQueryUsesIDTieBreakAfterEachSortPrimaryAndName(t *testin
 }
 
 func TestGroupCollectionQueryPaginatesWithoutLeakingCreatedAt(t *testing.T) {
+	t.Parallel()
 	records := []groupCollectionRecord{
 		groupCollectionQueryRecord(1, "one", GroupCollectionStatusAvailable, "https://one.example/v1", nil, 1, 10),
 		groupCollectionQueryRecord(2, "two", GroupCollectionStatusAvailable, "https://two.example/v1", nil, 1, 20),

--- a/internal/control/group_delete_test.go
+++ b/internal/control/group_delete_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestDeleteGroupRejectsActiveAndDisabledExplicitAccessKeyReferences(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	groupID := createGroupWithCredentials(t, fixture, "sk-in-use")
 	other := validControlGroup("other-reference")
@@ -88,6 +89,7 @@ func TestDeleteGroupRejectsActiveAndDisabledExplicitAccessKeyReferences(t *testi
 }
 
 func TestDeleteGroupCommitsCascadeThenRemovesRegistryThenPublishes(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	runtime := &recordingCredentialRuntimeExecutor{}
 	fixture.service.executor = runtime
@@ -128,6 +130,7 @@ func TestDeleteGroupCommitsCascadeThenRemovesRegistryThenPublishes(t *testing.T)
 }
 
 func TestDeleteGroupSerializesWithCredentialSecretMutation(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	groupID := createGroupWithCredentials(t, fixture, "sk-delete-serialized")
 	var credential models.Credential
@@ -169,6 +172,7 @@ func TestDeleteGroupSerializesWithCredentialSecretMutation(t *testing.T) {
 }
 
 func TestDeleteGroupCompileFailurePreservesDatabaseRegistryAndSnapshot(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	groupID := createGroupWithCredentials(t, fixture, "sk-delete-rollback")
 	corrupt := validControlGroup("delete-corrupt-other")
@@ -203,6 +207,7 @@ func TestDeleteGroupCompileFailurePreservesDatabaseRegistryAndSnapshot(t *testin
 }
 
 func TestDeleteGroupCommitFailurePreservesDatabaseRegistryAndSnapshot(t *testing.T) {
+	t.Parallel()
 	fixture, dsn := newFileServiceFixture(t)
 	groupID := createGroupWithCredentials(t, fixture, "sk-delete-commit-busy")
 	var row models.Credential
@@ -242,6 +247,7 @@ func TestDeleteGroupCommitFailurePreservesDatabaseRegistryAndSnapshot(t *testing
 }
 
 func TestDeleteGroupCorruptAccessKeyFiltersPreservesDatabaseRegistryAndSnapshot(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	groupID := createGroupWithCredentials(t, fixture, "sk-delete-corrupt-filter")
 	corrupt := models.AccessKey{
@@ -276,6 +282,7 @@ func TestDeleteGroupCorruptAccessKeyFiltersPreservesDatabaseRegistryAndSnapshot(
 }
 
 func TestDeleteGroupAcceptsRegistryAlreadyAtTargetStateAndRetainsHistory(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	groupID := createGroupWithCredentials(t, fixture, "sk-delete-target-state")
 	var key models.Credential
@@ -321,6 +328,7 @@ func TestDeleteGroupAcceptsRegistryAlreadyAtTargetStateAndRetainsHistory(t *test
 }
 
 func TestDeleteGroupEndpointAuthenticationValidationNotFoundConflictAndSuccess(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	groupID := createGroupWithCredentials(t, fixture, "sk-delete-http")

--- a/internal/control/group_detail_ledger_routes_test.go
+++ b/internal/control/group_detail_ledger_routes_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestGroupDetailLedgerRoutesReplaceLegacyContracts(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	mustEnsureInitialPrices(t, fixture)

--- a/internal/control/group_detail_test.go
+++ b/internal/control/group_detail_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestGetGroupSummaryUsesCollectionServiceStatusAndOnlyReturnsHeaderCounts(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	available := createGroupCollectionGroup(t, fixture, "summary-available", true, nil)
 	unavailable := createGroupCollectionGroup(t, fixture, "summary-unavailable", true, nil)
@@ -102,6 +103,7 @@ func TestGetGroupSummaryUsesCollectionServiceStatusAndOnlyReturnsHeaderCounts(t 
 }
 
 func TestGroupDetailStatusRequiresAHealthyKeyAndRouteCapability(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	group := createGroupCollectionGroup(t, fixture, "detail-zero-model-completions", true, nil)
 	setGroupCollectionChannel(t, fixture, group, channel.Anthropic, models.JSON(`{}`))
@@ -120,6 +122,7 @@ func TestGroupDetailStatusRequiresAHealthyKeyAndRouteCapability(t *testing.T) {
 }
 
 func TestGetGroupHTTPContractAndAuthentication(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	group := validControlGroup("detail-http")

--- a/internal/control/group_idempotency_phase1_test.go
+++ b/internal/control/group_idempotency_phase1_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestCreateGroupIdempotentReplaysOriginalCountsAndPreservesCredentialMultiplicity(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.operationRandom = bytes.NewReader(bytes.Repeat([]byte{0x71}, 16))
 	request := GroupCreateRequest{
@@ -55,6 +56,7 @@ func TestCreateGroupIdempotentReplaysOriginalCountsAndPreservesCredentialMultipl
 }
 
 func TestCreateGroupIdempotentCanonicalizesDisabledAliasesAndReplaysNarrowResult(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	request := GroupCreateRequest{
 		Name:      stringPointer("canonical-models"),

--- a/internal/control/group_models_test.go
+++ b/internal/control/group_models_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestGetGroupModelsReturnsClientNamesAndPricingStatus(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.catalogRuntime.Publish(&catalog.Snapshot{Providers: map[string]catalog.Provider{
 		"openai": {
@@ -64,6 +65,7 @@ func TestGetGroupModelsReturnsClientNamesAndPricingStatus(t *testing.T) {
 }
 
 func TestMapGroupModelsResponseTreatsContextTierOnlyPriceAsConfigured(t *testing.T) {
+	t.Parallel()
 	result, err := mapGroupModelsResponse(
 		string(channel.OpenAI),
 		[]GroupModel{{ID: "tiered-model"}},
@@ -90,6 +92,7 @@ func TestMapGroupModelsResponseTreatsContextTierOnlyPriceAsConfigured(t *testing
 }
 
 func TestNormalizeGroupModelsAppliesAliasSwitchAndReportsStableConflicts(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		values        []GroupModel
@@ -185,6 +188,7 @@ func TestNormalizeGroupModelsAppliesAliasSwitchAndReportsStableConflicts(t *test
 }
 
 func TestNormalizeGroupModelsRejectsDuplicateExternalNames(t *testing.T) {
+	t.Parallel()
 	for _, values := range [][]GroupModel{
 		{{ID: "provider-a", Alias: "public", AliasEnabled: true}, {ID: "provider-b", Alias: "public", AliasEnabled: true}},
 		{{ID: "public"}, {ID: "provider-b", Alias: "public", AliasEnabled: true}},
@@ -198,6 +202,7 @@ func TestNormalizeGroupModelsRejectsDuplicateExternalNames(t *testing.T) {
 }
 
 func TestUpdateGroupModelsRequiresNonNullModelsField(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	groupID := createGroupForCredentialImport(t, fixture, "sk-required-models")
 	for _, request := range []GroupModelsUpdateRequest{
@@ -217,6 +222,7 @@ func TestUpdateGroupModelsRequiresNonNullModelsField(t *testing.T) {
 }
 
 func TestUpdateGroupModelsReplacesAuthoritativeListAndPublishesOnce(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	mustEnsureInitialPrices(t, fixture)
 	created, err := fixture.service.CreateGroup(t.Context(), GroupCreateRequest{
@@ -356,6 +362,7 @@ func TestUpdateGroupModelsReplacesAuthoritativeListAndPublishesOnce(t *testing.T
 }
 
 func TestUpdateGroupModelsAllowsEmptyList(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	mustEnsureInitialPrices(t, fixture)
 	created, err := fixture.service.CreateGroup(t.Context(), GroupCreateRequest{
@@ -392,6 +399,7 @@ func TestUpdateGroupModelsAllowsEmptyList(t *testing.T) {
 }
 
 func TestUpdateGroupModelsNeverCallsDiscoveryOrChangesAccessKeyFilters(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	mustEnsureInitialPrices(t, fixture)
 	groupID := createGroupForCredentialImport(t, fixture, "sk-no-discovery")
@@ -443,6 +451,7 @@ func TestUpdateGroupModelsNeverCallsDiscoveryOrChangesAccessKeyFilters(t *testin
 }
 
 func TestUpdateGroupModelsFailuresDoNotPublish(t *testing.T) {
+	t.Parallel()
 	t.Run("external collision", func(t *testing.T) {
 		fixture := newServiceFixture(t)
 		groupID := createGroupForCredentialImport(t, fixture, "sk-invalid-models")

--- a/internal/control/group_options_test.go
+++ b/internal/control/group_options_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestListGroupOptionsReturnsAllGroupsByIDWithExternalModels(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	createGroupOptionGroup(t, fixture, 20, "later enabled", true,
 		channel.OpenAICompatible, `{"base_url":"https://later-enabled.example/v1"}`,
@@ -63,6 +64,7 @@ func TestListGroupOptionsReturnsAllGroupsByIDWithExternalModels(t *testing.T) {
 }
 
 func TestListGroupOptionsFailsClosedForInvalidDataDatabaseAndCancellation(t *testing.T) {
+	t.Parallel()
 	t.Run("invalid models JSON", func(t *testing.T) {
 		fixture := newServiceFixture(t)
 		createGroupOptionGroup(t, fixture, 1, "invalid", true, channel.OpenAI, `{}`, `{"not":"an array"}`)

--- a/internal/control/group_settings_test.go
+++ b/internal/control/group_settings_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestGetGroupSettingsReturnsPersistedDraftOverridesAndEffectiveConfig(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	group := validControlGroup("settings-read")
 	group.Overrides = models.JSON(`{
@@ -71,6 +72,7 @@ func TestGetGroupSettingsReturnsPersistedDraftOverridesAndEffectiveConfig(t *tes
 }
 
 func TestUpdateGroupSettingsPublishesOnceAndReturnsNewSettings(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	created, err := fixture.service.CreateGroup(t.Context(), GroupCreateRequest{
 		ChannelID: channel.OpenAICompatible,
@@ -114,6 +116,7 @@ func TestUpdateGroupSettingsPublishesOnceAndReturnsNewSettings(t *testing.T) {
 }
 
 func TestUpdateGroupSettingsOverridesAffinityParticipation(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	groupID := createGroupForCredentialImport(t, fixture, "sk-settings-affinity")
 
@@ -144,6 +147,7 @@ func TestUpdateGroupSettingsOverridesAffinityParticipation(t *testing.T) {
 }
 
 func TestUpdateGroupSettingsAllowsDuplicateUpstreamURLWithoutConfirmation(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	first, err := fixture.service.CreateGroup(t.Context(), GroupCreateRequest{
 		ChannelID:   channel.OpenAICompatible,
@@ -184,6 +188,7 @@ func TestUpdateGroupSettingsAllowsDuplicateUpstreamURLWithoutConfirmation(t *tes
 }
 
 func TestUpdateGroupTargetResetsCredentialHealthIdentity(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	created, err := fixture.service.CreateGroup(t.Context(), GroupCreateRequest{
 		ChannelID: channel.OpenAICompatible,
@@ -229,6 +234,7 @@ func TestUpdateGroupTargetResetsCredentialHealthIdentity(t *testing.T) {
 }
 
 func TestUpdateGroupTargetSerializesWithCredentialSecretMutation(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	created, err := fixture.service.CreateGroup(t.Context(), GroupCreateRequest{
 		ChannelID: channel.OpenAICompatible,
@@ -282,6 +288,7 @@ func TestUpdateGroupTargetSerializesWithCredentialSecretMutation(t *testing.T) {
 }
 
 func TestUpdateGroupSettingsValidatesWeightAndAllowsUsageObservationAcrossChannels(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	groupID := createGroupForCredentialImport(t, fixture, "sk-settings-validation")
 	beforeRevision := fixture.manager.Current().Revision
@@ -334,6 +341,7 @@ func TestUpdateGroupSettingsValidatesWeightAndAllowsUsageObservationAcrossChanne
 }
 
 func TestGroupSettingsHTTPRejectsStrictJSONAndUnauthorizedWithoutMutation(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	groupID := createGroupForCredentialImport(t, fixture, "sk-settings-http")
@@ -362,6 +370,7 @@ func TestGroupSettingsHTTPRejectsStrictJSONAndUnauthorizedWithoutMutation(t *tes
 }
 
 func TestGroupSettingsHTTPNotFoundAndDatabaseFailureDoNotMutate(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	groupID := createGroupForCredentialImport(t, fixture, "sk-settings-errors")

--- a/internal/control/group_update_test.go
+++ b/internal/control/group_update_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestMapGroupRowToStateCarriesDeepClonedParams(t *testing.T) {
+	t.Parallel()
 	group := models.Group{
 		ID: 1, Name: "channel-group", ChannelID: string(channel.OpenAICompatible),
 		Params: models.JSON(`{"base_url":"https://api.example.com/v1"}`),
@@ -28,6 +29,7 @@ func TestMapGroupRowToStateCarriesDeepClonedParams(t *testing.T) {
 }
 
 func TestSubscriptionGroupSettingsAndModelsRemainUpdatable(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	stage := mustImportSubscriptionStage(t, fixture, "account-group-update", "group-update@example.com")
 	created, err := fixture.service.CreateGroup(t.Context(), GroupCreateRequest{
@@ -66,6 +68,7 @@ func TestSubscriptionGroupSettingsAndModelsRemainUpdatable(t *testing.T) {
 }
 
 func TestGroupCatalogSyncTriggerOnlyTracksProviderAndModelIDChanges(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	created, err := fixture.service.CreateGroup(t.Context(), GroupCreateRequest{
 		ChannelID: channel.OpenAI,

--- a/internal/control/health_quota_test.go
+++ b/internal/control/health_quota_test.go
@@ -12,6 +12,7 @@ import (
 
 // 额度观测只服务于管理面展示，不影响调度可用性；首页仍需单独暴露额度快用完的凭据。
 func TestRuntimeHealthReportsLowQuotaCredentials(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := healthNow()
 	fixture.service.now = func() time.Time { return now }
@@ -79,6 +80,7 @@ func TestRuntimeHealthReportsLowQuotaCredentials(t *testing.T) {
 }
 
 func TestRuntimeHealthReportsResetCreditsExpiringWithinFortyEightHours(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := healthNow()
 	fixture.service.now = func() time.Time { return now }
@@ -132,6 +134,7 @@ func TestRuntimeHealthReportsResetCreditsExpiringWithinFortyEightHours(t *testin
 }
 
 func TestRuntimeHealthHonorsRecordedResetCreditAvailability(t *testing.T) {
+	t.Parallel()
 	for _, test := range []struct {
 		name      string
 		available int64

--- a/internal/control/health_test.go
+++ b/internal/control/health_test.go
@@ -44,6 +44,7 @@ func encryptHealthKey(t *testing.T, fixture serviceFixture, plaintext string) st
 }
 
 func TestRuntimeHealthReturnsMutuallyExclusiveCurrentState(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := healthNow()
 	fixture.service.now = func() time.Time { return now }
@@ -175,6 +176,7 @@ func TestRuntimeHealthReturnsMutuallyExclusiveCurrentState(t *testing.T) {
 }
 
 func TestRuntimeHealthAdvertisesExecutorValidationForChannelCredential(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := healthNow()
 	fixture.service.now = func() time.Time { return now }
@@ -208,6 +210,7 @@ func TestRuntimeHealthAdvertisesExecutorValidationForChannelCredential(t *testin
 }
 
 func TestRuntimeHealthExposesProblemCountsInsteadOfFailureAliases(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := healthNow()
 	fixture.service.now = func() time.Time { return now }
@@ -266,6 +269,7 @@ func TestRuntimeHealthExposesProblemCountsInsteadOfFailureAliases(t *testing.T) 
 }
 
 func TestRuntimeHealthSortsProblemKeysByGroupAndKey(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := healthNow()
 	fixture.service.now = func() time.Time { return now }
@@ -335,6 +339,7 @@ func TestRuntimeHealthSortsProblemKeysByGroupAndKey(t *testing.T) {
 }
 
 func TestRuntimeHealthCapsProblemCredentialDetails(t *testing.T) {
+	t.Parallel()
 	const detailLimit = 100
 
 	fixture := newServiceFixture(t)
@@ -405,6 +410,7 @@ func TestRuntimeHealthCapsProblemCredentialDetails(t *testing.T) {
 }
 
 func TestRuntimeHealthJSONOmitsScoresCredentialsAndZeroTimes(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.now = healthNow
 	plaintext := "provider-secret-credential-tail"
@@ -490,6 +496,7 @@ func TestRuntimeHealthJSONOmitsScoresCredentialsAndZeroTimes(t *testing.T) {
 }
 
 func TestRuntimeHealthFailsClosedWhenProblemKeyCannotBeDecrypted(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.now = healthNow
 	if _, err := fixture.manager.Publish(state.CompileInput{ChannelRegistry: fixture.channelRegistry, Groups: []state.GroupConfig{{ConnectionType: "api_key", ID: 1, Name: "safe", ChannelID: channel.OpenAI, Params: json.RawMessage(`{}`),
@@ -513,6 +520,7 @@ func TestRuntimeHealthFailsClosedWhenProblemKeyCannotBeDecrypted(t *testing.T) {
 }
 
 func TestHealthProblemMaskFailsClosedWhenCiphertextIsMissing(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	if _, err := fixture.service.healthProblemMask(nil, 1, "", "api_key"); !errors.Is(
 		err,
@@ -523,6 +531,7 @@ func TestHealthProblemMaskFailsClosedWhenCiphertextIsMissing(t *testing.T) {
 }
 
 func TestHealthProblemMaskExtractsTypedCredentialSecret(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	ciphertext := encryptHealthKey(
 		t,
@@ -544,6 +553,7 @@ func TestHealthProblemMaskExtractsTypedCredentialSecret(t *testing.T) {
 }
 
 func TestHealthProblemMaskUsesSafeSubscriptionAccountIdentity(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	ciphertext := encryptHealthKey(t, fixture,
 		`{"type":"codex","access_token":"access-secret","refresh_token":"refresh-secret","account_id":"account-one","email":"owner@example.com"}`)
@@ -557,6 +567,7 @@ func TestHealthProblemMaskUsesSafeSubscriptionAccountIdentity(t *testing.T) {
 }
 
 func TestRuntimeHealthDTOHasNoCredentialOrScoreFields(t *testing.T) {
+	t.Parallel()
 	forbidden := map[string]struct{}{
 		"EncryptedValue": {}, "KeyHash": {}, "AccessKey": {},
 		"HeaderRules": {}, "Percentage": {}, "SuccessRate": {}, "Score": {},
@@ -580,6 +591,7 @@ func TestRuntimeHealthDTOHasNoCredentialOrScoreFields(t *testing.T) {
 }
 
 func TestRuntimeHealthFailsLoudForRegistryCatalogMismatch(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	if err := fixture.registry.ReplaceCredentials([]state.CredentialEntry{{
 		ID: 1, GroupID: 999, Version: 1, IdentityGeneration: 1, Fingerprint: "test-1", Status: state.CredentialStatusActive,
@@ -596,6 +608,7 @@ func TestRuntimeHealthFailsLoudForRegistryCatalogMismatch(t *testing.T) {
 }
 
 func TestRuntimeHealthFailsWhenSnapshotIsUninitialized(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.manager = state.NewManager()
 	if _, err := fixture.service.RuntimeHealth(); !errors.Is(
@@ -607,6 +620,7 @@ func TestRuntimeHealthFailsWhenSnapshotIsUninitialized(t *testing.T) {
 }
 
 func TestRuntimeHealthEndpointRequiresManagementAuthentication(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	fixture.service.now = healthNow

--- a/internal/control/home_available_credentials_test.go
+++ b/internal/control/home_available_credentials_test.go
@@ -14,6 +14,7 @@ import (
 // 只看 status/拉黑/冷却会把「待重新授权」和「权重手动置 0」的凭据算成可用，
 // 而调度器根本不会选中它们，两页并排就会自相矛盾。
 func TestReadHomeBaseAvailableCredentialsMatchHealthClassification(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := time.Date(2026, time.August, 16, 9, 0, 0, 0, time.UTC)
 	zeroWeight := 0

--- a/internal/control/home_statistics_test.go
+++ b/internal/control/home_statistics_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestHomeBaseHTTPUsesAuthenticationEnvelopeAndServerClock(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	server := NewServer(
@@ -89,6 +90,7 @@ func TestHomeBaseHTTPUsesAuthenticationEnvelopeAndServerClock(t *testing.T) {
 }
 
 func TestHomeBaseHTTPScopesAccessKeyAndIncludesCurrentProfile(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	current, err := fixture.service.CreateAccessKey(t.Context(), AccessKeyCreateRequest{
@@ -134,6 +136,7 @@ func TestHomeBaseHTTPScopesAccessKeyAndIncludesCurrentProfile(t *testing.T) {
 }
 
 func TestHomeBaseHTTPRejectsEveryQueryBeforeReading(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	fixture.service.db = nil
@@ -155,6 +158,7 @@ func TestHomeBaseHTTPRejectsEveryQueryBeforeReading(t *testing.T) {
 }
 
 func TestParseHomeStatisticsQueryIsStrictAndDefaultsTo24Hours(t *testing.T) {
+	t.Parallel()
 	const observedAtMS = int64(1_785_412_345_678)
 	tests := []struct {
 		rawQuery string
@@ -209,6 +213,7 @@ func TestParseHomeStatisticsQueryIsStrictAndDefaultsTo24Hours(t *testing.T) {
 }
 
 func TestHomeStatisticsHTTPDefaultsToDense24HoursAndMapsExactWire(t *testing.T) {
+	t.Parallel()
 	now := time.Date(2026, time.July, 30, 12, 34, 56, 789, time.UTC)
 	currentAccessKeyName := "current-access"
 	reader := &recordingHomeStatisticsReader{
@@ -429,6 +434,7 @@ func TestHomeStatisticsHTTPDefaultsToDense24HoursAndMapsExactWire(t *testing.T) 
 }
 
 func TestHomeStatisticsHTTPBindsAccessKeyAndRemovesOtherRankingDimensions(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	created, err := fixture.service.CreateAccessKey(t.Context(), AccessKeyCreateRequest{
@@ -486,6 +492,7 @@ func TestHomeStatisticsHTTPBindsAccessKeyAndRemovesOtherRankingDimensions(t *tes
 }
 
 func TestHomeStatisticsHTTPAcceptsOnlyOneSupportedRange(t *testing.T) {
+	t.Parallel()
 	now := time.Date(2026, time.July, 30, 12, 0, 0, 0, time.UTC)
 	reader := &recordingHomeStatisticsReader{}
 	engine := newHomeStatisticsTestEngine(t, now, reader)
@@ -543,6 +550,7 @@ func TestHomeStatisticsHTTPAcceptsOnlyOneSupportedRange(t *testing.T) {
 }
 
 func TestHomeStatisticsHTTPFailsClosedOnUnsafeDataAndReadError(t *testing.T) {
+	t.Parallel()
 	now := time.Date(2026, time.July, 30, 12, 0, 0, 0, time.UTC)
 	t.Run("unsafe aggregate", func(t *testing.T) {
 		reader := &recordingHomeStatisticsReader{

--- a/internal/control/home_test.go
+++ b/internal/control/home_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestReadHomeBaseUsesPersistedAndRuntimeSnapshots(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := time.Date(2026, time.July, 30, 12, 0, 0, 0, time.UTC)
 	nowMS := now.UnixMilli()
@@ -177,6 +178,7 @@ func TestReadHomeBaseUsesPersistedAndRuntimeSnapshots(t *testing.T) {
 }
 
 func TestHomeInventoryWireUsesCredentialTerms(t *testing.T) {
+	t.Parallel()
 	encoded, err := json.Marshal(HomeInventory{
 		GroupCount: 1, CredentialCount: 2, AvailableCredentialCount: 1, ModelCount: 3,
 	})
@@ -197,6 +199,7 @@ func TestHomeInventoryWireUsesCredentialTerms(t *testing.T) {
 }
 
 func TestReadAccessKeyHomeBaseScopesInventoryToRoutableModels(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	allowed := createPriceTestGroup(t, fixture.db, models.Group{
 		Name: "allowed", ChannelID: string(channel.OpenAI), Params: models.JSON(`{}`),
@@ -239,6 +242,7 @@ func TestReadAccessKeyHomeBaseScopesInventoryToRoutableModels(t *testing.T) {
 }
 
 func TestReadHomeBaseFailsClosed(t *testing.T) {
+	t.Parallel()
 	t.Run("invalid time", func(t *testing.T) {
 		fixture := newServiceFixture(t)
 		for _, nowMS := range []int64{-1, maxSafeInteger + 1} {
@@ -290,6 +294,7 @@ func TestReadHomeBaseFailsClosed(t *testing.T) {
 }
 
 func TestReadHomeBaseKeepsDatabaseRowsInOneReadSnapshot(t *testing.T) {
+	t.Parallel()
 	fixture, dsn := newFileServiceFixture(t)
 	group := validControlGroup("home-snapshot")
 	if err := fixture.db.Create(group).Error; err != nil {

--- a/internal/control/idempotency_digest_test.go
+++ b/internal/control/idempotency_digest_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestIdempotencyDigestFixtures(t *testing.T) {
+	t.Parallel()
 	type fixture struct {
 		Name            string        `json:"name"`
 		OperationKind   operationKind `json:"operation_kind"`
@@ -78,6 +79,7 @@ func TestIdempotencyDigestFixtures(t *testing.T) {
 }
 
 func TestIdempotencyDigestV1MatchesAccessKeyCreateFixture(t *testing.T) {
+	t.Parallel()
 	body := []byte(
 		`{"filters":{"groups":[],"models":[],"protocols":[]},"name":"CI client","rpm_limit":0}`,
 	)
@@ -116,6 +118,7 @@ func TestIdempotencyDigestV1MatchesAccessKeyCreateFixture(t *testing.T) {
 }
 
 func TestNormalizeIdempotencyKeyLinesPreservesSortedMultiplicity(t *testing.T) {
+	t.Parallel()
 	one, err := normalizeIdempotencyKeyLines(" K \r\n")
 	if err != nil {
 		t.Fatalf("normalizeIdempotencyKeyLines(K) error = %v", err)
@@ -161,6 +164,7 @@ func TestNormalizeIdempotencyKeyLinesPreservesSortedMultiplicity(t *testing.T) {
 }
 
 func TestIdempotencyDigestRejectsUnsupportedVersionAndInvalidFields(t *testing.T) {
+	t.Parallel()
 	valid := idempotencyDigestInput{
 		Version: 1, Method: "POST", OperationKind: operationKindAccessKeyCreate,
 		PathTemplate: "/api/access-keys", ResourceLocator: "new",

--- a/internal/control/idempotency_operation_test.go
+++ b/internal/control/idempotency_operation_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestOperationRequiredStagesAreKindSpecificAndDetached(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		kind operationKind
 		want []operationStage
@@ -70,6 +71,7 @@ func TestOperationRequiredStagesAreKindSpecificAndDetached(t *testing.T) {
 }
 
 func TestValidateIdempotencyKeyRequiresCanonicalLowercaseUUIDV4(t *testing.T) {
+	t.Parallel()
 	const valid = "018f47a2-9c35-4d6e-8b1a-1234567890ab"
 	if err := validateIdempotencyKey(valid); err != nil {
 		t.Fatalf("validateIdempotencyKey(valid) error = %v", err)
@@ -91,6 +93,7 @@ func TestValidateIdempotencyKeyRequiresCanonicalLowercaseUUIDV4(t *testing.T) {
 }
 
 func TestNewOperationIDUsesCanonicalUUIDV4WithoutSharingCredentialRandom(t *testing.T) {
+	t.Parallel()
 	random := bytes.NewReader([]byte{
 		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
 		0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
@@ -108,6 +111,7 @@ func TestNewOperationIDUsesCanonicalUUIDV4WithoutSharingCredentialRandom(t *test
 }
 
 func TestExecuteIdempotentOperationCommitsResultAndReplaysWithoutMutation(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.operationRandom = bytes.NewReader(bytes.Repeat([]byte{0x42}, 16))
 	const key = "018f47a2-9c35-4d6e-8b1a-1234567890ab"
@@ -177,6 +181,7 @@ func TestExecuteIdempotentOperationCommitsResultAndReplaysWithoutMutation(t *tes
 }
 
 func TestExecuteIdempotentOperationRejectsKeyReuseWithDifferentDigest(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.operationRandom = bytes.NewReader(bytes.Repeat([]byte{0x24}, 16))
 	const key = "018f47a2-9c35-4d6e-8b1a-1234567890ab"

--- a/internal/control/model_price_sync_http_test.go
+++ b/internal/control/model_price_sync_http_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestModelPriceSyncRouteSanitizesFailure(t *testing.T) {
+	// 不标记 t.Parallel()：本测试劫持了全局 logrus 输出/格式，与其他并行测试同时运行会互相覆盖断言。
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	const rawFailure = "secret upstream response body"

--- a/internal/control/model_price_test.go
+++ b/internal/control/model_price_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestChannelModelPriceIsSharedAcrossGroupsAndAliases(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	createPriceTestGroup(t, fixture.db, models.Group{
 		Name: "first", ChannelID: string(channel.OpenAICompatible),
@@ -61,6 +62,7 @@ func TestChannelModelPriceIsSharedAcrossGroupsAndAliases(t *testing.T) {
 }
 
 func TestProjectModelPriceRowDoesNotExposeSlotCompleteness(t *testing.T) {
+	t.Parallel()
 	value := int64(1)
 	record, err := projectModelPriceRow(models.ModelPrice{
 		ID: 1, ChannelID: string(channel.OpenAICompatible), ModelID: "tiered", InputPriceNanoUSDPerMillionTokens: &value,
@@ -83,6 +85,7 @@ func TestProjectModelPriceRowDoesNotExposeSlotCompleteness(t *testing.T) {
 }
 
 func TestProjectModelPriceRowExposesPersistedFastSchedule(t *testing.T) {
+	t.Parallel()
 	standardInput := int64(3)
 	record, err := projectModelPriceRow(models.ModelPrice{
 		ID: 1, ChannelID: string(channel.OpenAI), ModelID: "gpt-fast",
@@ -139,6 +142,7 @@ func TestProjectModelPriceRowExposesPersistedFastSchedule(t *testing.T) {
 }
 
 func TestResetModelPriceChangesOnlySelectedChannelIdentity(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	manual := int64(99)
 	rows := []models.ModelPrice{
@@ -199,6 +203,7 @@ func TestResetModelPriceChangesOnlySelectedChannelIdentity(t *testing.T) {
 }
 
 func TestDeleteModelPriceIgnoresSameModelReferenceFromDifferentChannel(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	manual := int64(1)
 	row := models.ModelPrice{

--- a/internal/control/model_prices_api_test.go
+++ b/internal/control/model_prices_api_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestParseModelPriceListQueryAcceptsFinalContract(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		rawQuery   string
@@ -70,6 +71,7 @@ func TestParseModelPriceListQueryAcceptsFinalContract(t *testing.T) {
 }
 
 func TestParseModelPriceListQueryRejectsAmbiguousOrUnsafeInput(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		rawQuery   string
@@ -104,6 +106,7 @@ func TestParseModelPriceListQueryRejectsAmbiguousOrUnsafeInput(t *testing.T) {
 }
 
 func TestParseModelPriceRowIDRequiresCanonicalPositiveSafeUint(t *testing.T) {
+	t.Parallel()
 	for _, value := range []string{"1", "9007199254740991"} {
 		got, err := parseModelPriceRowID(value)
 		if err != nil {
@@ -122,6 +125,7 @@ func TestParseModelPriceRowIDRequiresCanonicalPositiveSafeUint(t *testing.T) {
 }
 
 func TestNullableDecimalAcceptsOnlyExactUSDStringOrNull(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		body string
 		want *int64
@@ -143,6 +147,7 @@ func TestNullableDecimalAcceptsOnlyExactUSDStringOrNull(t *testing.T) {
 }
 
 func TestNullableDecimalClassifiesInvalidDecimalStringsAsValidation(t *testing.T) {
+	t.Parallel()
 	for _, body := range []string{
 		`""`, `" "`, `"1e3"`, `"+1"`, `"-1"`, `".5"`, `"1."`,
 		`"1.0000000000"`, `"9223372036.854775808"`,
@@ -156,6 +161,7 @@ func TestNullableDecimalClassifiesInvalidDecimalStringsAsValidation(t *testing.T
 }
 
 func TestNullableDecimalRejectsJSONNumbersAndContainers(t *testing.T) {
+	t.Parallel()
 	for _, body := range []string{`0`, `1.5`, `1e3`, `{}`, `[]`, `true`} {
 		var got nullableDecimal
 		if err := json.Unmarshal([]byte(body), &got); err == nil {
@@ -165,6 +171,7 @@ func TestNullableDecimalRejectsJSONNumbersAndContainers(t *testing.T) {
 }
 
 func TestModelPriceUpdateRequestRequiresFullReplacementSlots(t *testing.T) {
+	t.Parallel()
 	request, apiErr := decodeModelPriceUpdateRequestForTest(
 		`{"input":"2.5","output":null,"cache_read":"0","cache_write":null,"context_tiers":[],"mode_schedules":{}}`,
 	)
@@ -208,6 +215,7 @@ func TestModelPriceUpdateRequestRequiresFullReplacementSlots(t *testing.T) {
 }
 
 func TestModelPriceUpdateRequestDecodesContextTiers(t *testing.T) {
+	t.Parallel()
 	request, apiErr := decodeModelPriceUpdateRequestForTest(
 		`{"input":"2.5","output":null,"cache_read":"0","cache_write":null,"context_tiers":[` +
 			`{"threshold_tokens":1000,"input":"3","output":null,"cache_read":null,"cache_write":null},` +
@@ -241,6 +249,7 @@ func TestModelPriceUpdateRequestDecodesContextTiers(t *testing.T) {
 }
 
 func TestModelPriceUpdateRequestDecodesModeSchedules(t *testing.T) {
+	t.Parallel()
 	request, apiErr := decodeModelPriceUpdateRequestForTest(
 		`{"input":"2","output":null,"cache_read":null,"cache_write":null,"context_tiers":[],` +
 			`"mode_schedules":{"fast":{"prices":{"input":"7","output":null,"cache_read":null,"cache_write":null},` +
@@ -268,6 +277,7 @@ func TestModelPriceUpdateRequestDecodesModeSchedules(t *testing.T) {
 }
 
 func TestModelPriceUpdateRequestClassifiesTypeAndDecimalErrors(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string

--- a/internal/control/model_prices_audit_test.go
+++ b/internal/control/model_prices_audit_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestModelPriceMutationAuditSuccessRejectionAndFailure(t *testing.T) {
+	t.Parallel()
 	t.Run("success", func(t *testing.T) {
 		for _, test := range []struct {
 			operation string
@@ -173,6 +174,7 @@ func TestModelPriceMutationAuditSuccessRejectionAndFailure(t *testing.T) {
 }
 
 func TestModelPriceMutationAuditExcludesAuthFailureAndWrongMethod(t *testing.T) {
+	t.Parallel()
 	fixture, row := newModelPriceAuditFixture(t)
 	var logs bytes.Buffer
 	_, engine := newMutationAuditRouteServer(t, fixture, &logs)
@@ -193,6 +195,7 @@ func TestModelPriceMutationAuditExcludesAuthFailureAndWrongMethod(t *testing.T) 
 }
 
 func TestModelPriceSyncStaticPathOwnsDynamicMutationMethodsBeforeAuthAndAudit(t *testing.T) {
+	t.Parallel()
 	for _, test := range []struct {
 		method        string
 		body          string

--- a/internal/control/model_prices_http_test.go
+++ b/internal/control/model_prices_http_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestModelPriceFinalRoutesRequireManagementAuthentication(t *testing.T) {
+	t.Parallel()
 	fixture, engine, row := newModelPriceHTTPFixture(t, true)
 	_ = fixture
 	for _, request := range []struct {
@@ -43,6 +44,7 @@ func TestModelPriceFinalRoutesRequireManagementAuthentication(t *testing.T) {
 }
 
 func TestModelPriceHTTPListAndUpdateUseFinalWireContract(t *testing.T) {
+	t.Parallel()
 	fixture, engine, row := newModelPriceHTTPFixture(t, true)
 	fixture.catalogRuntime.Publish(&catalog.Snapshot{Providers: map[string]catalog.Provider{
 		"openai": {ID: "openai", Models: map[string]catalog.Model{
@@ -145,6 +147,7 @@ func TestModelPriceHTTPListAndUpdateUseFinalWireContract(t *testing.T) {
 }
 
 func TestModelPriceHTTPUpdateAcceptsAndPersistsContextTiers(t *testing.T) {
+	t.Parallel()
 	_, engine, row := newModelPriceHTTPFixture(t, true)
 
 	tieredBody := `{"input":"1","output":null,"cache_read":null,"cache_write":null,"confirm_unpriced":false,` +
@@ -237,6 +240,7 @@ func TestModelPriceHTTPUpdateAcceptsAndPersistsContextTiers(t *testing.T) {
 }
 
 func TestModelPriceHTTPUpdateEditsPersistedModeScheduleAsManualRuntimeFact(t *testing.T) {
+	t.Parallel()
 	fixture, engine, row := newModelPriceHTTPFixture(t, true)
 	if err := fixture.db.Model(&models.ModelPrice{}).Where("id = ?", row.ID).Update(
 		"mode_price_schedules",
@@ -278,6 +282,7 @@ func TestModelPriceHTTPUpdateEditsPersistedModeScheduleAsManualRuntimeFact(t *te
 }
 
 func TestModelPriceHTTPUpdateRejectsModeScheduleKeyChanges(t *testing.T) {
+	t.Parallel()
 	t.Run("add unsynchronized Fast schedule", func(t *testing.T) {
 		fixture, engine, row := newModelPriceHTTPFixture(t, true)
 		body := `{"input":"2","output":null,"cache_read":null,"cache_write":null,"context_tiers":[],` +
@@ -332,6 +337,7 @@ func TestModelPriceHTTPUpdateRejectsModeScheduleKeyChanges(t *testing.T) {
 }
 
 func TestModelPriceHTTPUpdateIgnoresIfMatch(t *testing.T) {
+	t.Parallel()
 	_, engine, row := newModelPriceHTTPFixture(t, true)
 	recorder := httptest.NewRecorder()
 	request := httptest.NewRequest(
@@ -354,6 +360,7 @@ func TestModelPriceHTTPUpdateIgnoresIfMatch(t *testing.T) {
 }
 
 func TestModelPriceHTTPResetDeleteAndStableErrorData(t *testing.T) {
+	t.Parallel()
 	t.Run("reset returns the complete pending row", func(t *testing.T) {
 		_, engine, row := newModelPriceHTTPFixture(t, true)
 		response := serveModelPriceHTTPRequest(
@@ -456,6 +463,7 @@ func TestModelPriceHTTPResetDeleteAndStableErrorData(t *testing.T) {
 }
 
 func TestModelPriceHTTPRejectsLegacyAndAmbiguousContracts(t *testing.T) {
+	t.Parallel()
 	_, engine, row := newModelPriceHTTPFixture(t, true)
 	for _, request := range []struct {
 		name     string
@@ -502,6 +510,7 @@ func TestModelPriceHTTPRejectsLegacyAndAmbiguousContracts(t *testing.T) {
 }
 
 func TestModelPriceHTTPErrorsUseThreeLocaleMessageIDs(t *testing.T) {
+	t.Parallel()
 	for _, test := range []struct {
 		language string
 		message  string

--- a/internal/control/mutation_audit_routes_test.go
+++ b/internal/control/mutation_audit_routes_test.go
@@ -39,6 +39,7 @@ type groupMutationAuditCase struct {
 }
 
 func TestModelPriceSyncMutationAudit(t *testing.T) {
+	t.Parallel()
 	t.Run("success", func(t *testing.T) {
 		fixture := newServiceFixture(t)
 		fixture.catalogRuntime.Publish(&catalog.Snapshot{Providers: map[string]catalog.Provider{}})
@@ -117,6 +118,7 @@ func TestModelPriceSyncMutationAudit(t *testing.T) {
 }
 
 func TestGroupMutationAuditRoutes(t *testing.T) {
+	t.Parallel()
 	for _, test := range groupMutationAuditCases() {
 		t.Run(test.operation+"/success", func(t *testing.T) {
 			fixture := newServiceFixture(t)
@@ -186,6 +188,7 @@ func TestGroupMutationAuditRoutes(t *testing.T) {
 }
 
 func TestGroupMutationAuditIncompleteAndBlocked(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.reconcileRegistryGroup = func(
 		uint,
@@ -250,6 +253,7 @@ func TestGroupMutationAuditIncompleteAndBlocked(t *testing.T) {
 }
 
 func TestGroupMutationAuditExcludesInternalCalls(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	groupID := createGroupWithCredentials(
 		t,
@@ -289,6 +293,7 @@ func TestGroupMutationAuditExcludesInternalCalls(t *testing.T) {
 }
 
 func TestSettingsMutationAudit(t *testing.T) {
+	t.Parallel()
 	t.Run("success", func(t *testing.T) {
 		fixture := newServiceFixture(t)
 		var logs bytes.Buffer
@@ -412,6 +417,7 @@ func TestSettingsMutationAudit(t *testing.T) {
 }
 
 func TestAccessKeyMutationAudit(t *testing.T) {
+	t.Parallel()
 	t.Run("create and replay", func(t *testing.T) {
 		fixture := newServiceFixture(t)
 		fixture.service.random = bytes.NewReader(
@@ -710,6 +716,7 @@ func TestAccessKeyMutationAudit(t *testing.T) {
 }
 
 func TestAccessKeyRevealAudit(t *testing.T) {
+	t.Parallel()
 	t.Run("success excludes credential", func(t *testing.T) {
 		fixture := newServiceFixture(t)
 		created := seedAuditAccessKey(t, fixture)
@@ -812,6 +819,7 @@ func TestAccessKeyRevealAudit(t *testing.T) {
 }
 
 func TestControlSecurityEventFormatterSecretMatrix(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	const (
 		authKey             = "gl-control-auth-secret-0001"

--- a/internal/control/mutation_audit_test.go
+++ b/internal/control/mutation_audit_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestClassifyMutationOutcome(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		statusCode int
@@ -72,6 +73,7 @@ func TestClassifyMutationOutcome(t *testing.T) {
 }
 
 func TestMutationLocatorsOnlyExposeValidatedIDs(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		params gin.Params
@@ -149,6 +151,7 @@ func TestMutationLocatorsOnlyExposeValidatedIDs(t *testing.T) {
 }
 
 func TestAuditMutationRecordsExactlyOneOutcome(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	tests := []struct {
 		name          string
@@ -281,6 +284,7 @@ func TestAuditMutationRecordsExactlyOneOutcome(t *testing.T) {
 }
 
 func TestAuditMutationUsesSuccessfulLocatorOverride(t *testing.T) {
+	t.Parallel()
 	var logs bytes.Buffer
 	server := NewServer(&config.Config{AuthKey: authTestKey}, nil)
 	server.logger = newControlJSONLogger(&logs)
@@ -317,6 +321,7 @@ func TestAuditMutationUsesSuccessfulLocatorOverride(t *testing.T) {
 }
 
 func TestAuditMutationLogsPanicThenRethrowsToRecovery(t *testing.T) {
+	t.Parallel()
 	const panicSecret = "sk-panic-audit-secret"
 	var logs bytes.Buffer
 	server := NewServer(&config.Config{AuthKey: authTestKey}, nil)
@@ -378,6 +383,7 @@ func TestAuditMutationLogsPanicThenRethrowsToRecovery(t *testing.T) {
 }
 
 func TestAuditMutationLoggerPanicDoesNotChangeResponse(t *testing.T) {
+	t.Parallel()
 	server := NewServer(&config.Config{AuthKey: authTestKey}, nil)
 	server.logger = logrus.New()
 	server.logger.AddHook(controlPanicLogHook{})
@@ -409,6 +415,7 @@ func TestAuditMutationLoggerPanicDoesNotChangeResponse(t *testing.T) {
 }
 
 func TestMutationAuditExcludesReadAndDiscoveryRoutes(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	var logs bytes.Buffer

--- a/internal/control/operation_error_test.go
+++ b/internal/control/operation_error_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestControlOperationErrorCarriesOnlyFixedContext(t *testing.T) {
+	t.Parallel()
 	err := withControlOperationContext(
 		newControlOperationError(stageApplyCommittedRegistryMutation),
 		12,
@@ -33,6 +34,7 @@ func TestControlOperationErrorCarriesOnlyFixedContext(t *testing.T) {
 }
 
 func TestServiceErrorMessageIDUsesTypedResourceNotFound(t *testing.T) {
+	t.Parallel()
 	for _, test := range []struct {
 		name      string
 		operation string
@@ -77,6 +79,7 @@ func TestServiceErrorMessageIDUsesTypedResourceNotFound(t *testing.T) {
 }
 
 func TestServiceErrorMessageIDUsesGroupNameExistsForGroupSettingsUpdate(t *testing.T) {
+	t.Parallel()
 	if got := serviceErrorMessageID(
 		"update_group_settings",
 		app_errors.ErrDuplicateResource,
@@ -87,6 +90,7 @@ func TestServiceErrorMessageIDUsesGroupNameExistsForGroupSettingsUpdate(t *testi
 }
 
 func TestLogServiceErrorUsesOnlyFixedOperationContext(t *testing.T) {
+	// 不标记 t.Parallel()：本测试劫持了全局 logrus 输出/格式，与其他并行测试同时运行会互相覆盖断言。
 	const secretCause = "known-operation-secret-cause"
 	err := fmt.Errorf(
 		"%s: %w",

--- a/internal/control/operation_recovery_test.go
+++ b/internal/control/operation_recovery_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestOperationReplayRepairsPostCommitRegistryFailureWithoutRerunningMutation(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.operationRandom = bytes.NewReader(bytes.Repeat([]byte{0x31}, 16))
 	reconcileCalls := 0
@@ -74,6 +75,7 @@ func TestOperationReplayRepairsPostCommitRegistryFailureWithoutRerunningMutation
 }
 
 func TestOperationReplayOnlyRecordsStageWhenRegistrySideEffectAlreadySatisfied(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.operationRandom = bytes.NewReader(bytes.Repeat([]byte{0x32}, 16))
 	reconcileCalls := 0
@@ -127,6 +129,7 @@ func TestOperationReplayOnlyRecordsStageWhenRegistrySideEffectAlreadySatisfied(t
 }
 
 func TestOperationRegistryRecoverySerializesWithCredentialSecretMutation(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	mutations := 0
 	input := newDurableGroupOperationInput(
@@ -180,6 +183,7 @@ func TestOperationRegistryRecoverySerializesWithCredentialSecretMutation(t *test
 }
 
 func TestOperationBarrierBlocksNewMutationBehindOlderRecovery(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.operationRandom = bytes.NewReader(bytes.Repeat([]byte{0x33}, 32))
 	fixture.service.reconcileRegistryGroup = func(uint, []state.CredentialEntry) (bool, error) {
@@ -257,6 +261,7 @@ func TestOperationBarrierBlocksNewMutationBehindOlderRecovery(t *testing.T) {
 }
 
 func TestOperationBarrierReturnsDatabaseErrorWhenRecoveryQueryFails(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
@@ -293,6 +298,7 @@ func TestOperationBarrierReturnsDatabaseErrorWhenRecoveryQueryFails(t *testing.T
 }
 
 func TestDrainCommittedOperationsFailsClosedOnUnsupportedDigestVersion(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	stages, err := json.Marshal([]operationStage{
 		operationStageDBCommitted,
@@ -334,6 +340,7 @@ func TestDrainCommittedOperationsFailsClosedOnUnsupportedDigestVersion(t *testin
 }
 
 func TestOperationRecoveryBackoffIsExponentialAndBounded(t *testing.T) {
+	t.Parallel()
 	backoff := operationRecoveryInitialBackoff
 	want := []time.Duration{
 		500 * time.Millisecond,
@@ -354,6 +361,7 @@ func TestOperationRecoveryBackoffIsExponentialAndBounded(t *testing.T) {
 }
 
 func TestCompactCompletedOperationsKeepsPermanentComparatorTombstone(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.operationRandom = bytes.NewReader(bytes.Repeat([]byte{0x34}, 16))
 	fixture.service.now = func() time.Time {

--- a/internal/control/price_reconcile_test.go
+++ b/internal/control/price_reconcile_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestReconcileReferencedPricesUsesChannelModelIdentity(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	createPriceTestGroup(t, fixture.db, models.Group{
 		Name: "openai", ChannelID: string(channel.OpenAI), Params: models.JSON(`{}`),
@@ -66,6 +67,7 @@ func TestReconcileReferencedPricesUsesChannelModelIdentity(t *testing.T) {
 }
 
 func TestLoadPriceTableDoesNotMergeModelsDevModePricesIntoManualRule(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	standard := int64(2)
 	if err := fixture.db.Create(&models.ModelPrice{

--- a/internal/control/price_reference_test.go
+++ b/internal/control/price_reference_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestPriceIdentityForChannelModelRequiresRegisteredChannel(t *testing.T) {
+	t.Parallel()
 	identity, err := PriceIdentityForChannelModel(string(channel.OpenAICompatible), "shared")
 	if err != nil || identity != (pricing.Identity{
 		ChannelID: string(channel.OpenAICompatible), ModelID: "shared",
@@ -22,6 +23,7 @@ func TestPriceIdentityForChannelModelRequiresRegisteredChannel(t *testing.T) {
 }
 
 func TestResolveAutomaticPriceForIdentityUsesOfficialChannelCatalogProvider(t *testing.T) {
+	t.Parallel()
 	openAICost := &catalog.ModelCost{Prices: pricing.Prices{Input: priceTestValue(1)}}
 	anthropicCost := &catalog.ModelCost{Prices: pricing.Prices{Input: priceTestValue(2)}}
 	snapshot := &catalog.Snapshot{Providers: map[string]catalog.Provider{
@@ -43,6 +45,7 @@ func TestResolveAutomaticPriceForIdentityUsesOfficialChannelCatalogProvider(t *t
 }
 
 func TestResolveAutomaticPriceForIdentityUsesVolcengineOfficialSupplement(t *testing.T) {
+	t.Parallel()
 	snapshot, err := catalog.MergeOfficial(&catalog.Snapshot{})
 	if err != nil {
 		t.Fatalf("MergeOfficial() error = %v", err)
@@ -59,6 +62,7 @@ func TestResolveAutomaticPriceForIdentityUsesVolcengineOfficialSupplement(t *tes
 }
 
 func TestResolveAutomaticPriceForIdentityFallsBackWhenChannelCatalogProviderMisses(t *testing.T) {
+	t.Parallel()
 	openAICost := &catalog.ModelCost{Prices: pricing.Prices{Input: priceTestValue(1)}}
 	snapshot := &catalog.Snapshot{Providers: map[string]catalog.Provider{
 		"openai": {ID: "openai", Models: map[string]catalog.Model{
@@ -76,6 +80,7 @@ func TestResolveAutomaticPriceForIdentityFallsBackWhenChannelCatalogProviderMiss
 }
 
 func TestResolveAutomaticPriceForIdentityFallsBackForCompatibleChannel(t *testing.T) {
+	t.Parallel()
 	openAICost := &catalog.ModelCost{Prices: pricing.Prices{Input: priceTestValue(1)}}
 	snapshot := &catalog.Snapshot{Providers: map[string]catalog.Provider{
 		"openai": {ID: "openai", Models: map[string]catalog.Model{
@@ -93,6 +98,7 @@ func TestResolveAutomaticPriceForIdentityFallsBackForCompatibleChannel(t *testin
 }
 
 func TestResolveAutomaticPriceForIdentityTreatsCodexOpenAIPriceAsReference(t *testing.T) {
+	t.Parallel()
 	openAICost := &catalog.ModelCost{Prices: pricing.Prices{Input: priceTestValue(1)}}
 	snapshot := &catalog.Snapshot{Providers: map[string]catalog.Provider{
 		"openai": {ID: "openai", Models: map[string]catalog.Model{
@@ -110,6 +116,7 @@ func TestResolveAutomaticPriceForIdentityTreatsCodexOpenAIPriceAsReference(t *te
 }
 
 func TestResolveAutomaticPriceForIdentityTreatsClaudeAnthropicPriceAsReference(t *testing.T) {
+	t.Parallel()
 	anthropicCost := &catalog.ModelCost{Prices: pricing.Prices{Input: priceTestValue(1)}}
 	snapshot := &catalog.Snapshot{Providers: map[string]catalog.Provider{
 		"anthropic": {ID: "anthropic", Models: map[string]catalog.Model{
@@ -127,6 +134,7 @@ func TestResolveAutomaticPriceForIdentityTreatsClaudeAnthropicPriceAsReference(t
 }
 
 func TestResolveAutomaticPriceForIdentityTreatsAntigravityGooglePriceAsReference(t *testing.T) {
+	t.Parallel()
 	googleCost := &catalog.ModelCost{Prices: pricing.Prices{Input: priceTestValue(1)}}
 	snapshot := &catalog.Snapshot{Providers: map[string]catalog.Provider{
 		"google": {ID: "google", Models: map[string]catalog.Model{
@@ -144,6 +152,7 @@ func TestResolveAutomaticPriceForIdentityTreatsAntigravityGooglePriceAsReference
 }
 
 func TestResolveAutomaticPriceForIdentityTreatsGrokXAIPriceAsReference(t *testing.T) {
+	t.Parallel()
 	xaiCost := &catalog.ModelCost{Prices: pricing.Prices{Input: priceTestValue(1)}}
 	snapshot := &catalog.Snapshot{Providers: map[string]catalog.Provider{
 		"xai": {ID: "xai", Models: map[string]catalog.Model{
@@ -161,6 +170,7 @@ func TestResolveAutomaticPriceForIdentityTreatsGrokXAIPriceAsReference(t *testin
 }
 
 func TestCompatibleAutomaticPriceUsesGlobalPriority(t *testing.T) {
+	t.Parallel()
 	openAICost := &catalog.ModelCost{Prices: pricing.Prices{Input: priceTestValue(1)}}
 	alphaCost := &catalog.ModelCost{Prices: pricing.Prices{Input: priceTestValue(2)}}
 	snapshot := &catalog.Snapshot{Providers: map[string]catalog.Provider{
@@ -185,6 +195,7 @@ func TestCompatibleAutomaticPriceUsesGlobalPriority(t *testing.T) {
 }
 
 func TestCompatibleAutomaticPriceFallsBackToStableProviderID(t *testing.T) {
+	t.Parallel()
 	alphaCost := &catalog.ModelCost{Prices: pricing.Prices{Input: priceTestValue(1)}}
 	snapshot := &catalog.Snapshot{Providers: map[string]catalog.Provider{
 		"zeta":  {ID: "zeta", Models: map[string]catalog.Model{"shared": {ID: "shared", Cost: &catalog.ModelCost{}}}},

--- a/internal/control/pricing_status_test.go
+++ b/internal/control/pricing_status_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestResolveCandidatePricingUsesCurrentAutomaticPriceMatch(t *testing.T) {
+	t.Parallel()
 	price := int64(0)
 	snapshot := &catalog.Snapshot{Providers: map[string]catalog.Provider{
 		"openai": {
@@ -39,6 +40,7 @@ func TestResolveCandidatePricingUsesCurrentAutomaticPriceMatch(t *testing.T) {
 }
 
 func TestResolveCandidatePricingHidesManuallyUnpricedSource(t *testing.T) {
+	t.Parallel()
 	status, source := resolveCandidatePricing(
 		&models.ModelPrice{ChannelID: string(channel.OpenAI), ModelID: "gpt-4o", IsManual: true},
 		nil,

--- a/internal/control/project_model_collection_test.go
+++ b/internal/control/project_model_collection_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestProjectModelsSeparateSameUpstreamModelByChannelAndDetail(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	createPriceTestGroup(t, fixture.db, models.Group{
 		Name: "enabled", ChannelID: string(channel.OpenAICompatible), Params: models.JSON(`{"base_url":"https://enabled.example/v1"}`),
@@ -95,6 +96,7 @@ func TestProjectModelsSeparateSameUpstreamModelByChannelAndDetail(t *testing.T) 
 }
 
 func TestProjectModelsHTTPScopesAccessKeyFiltersAndRelationships(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	allowedOpenAI := createPriceTestGroup(t, fixture.db, models.Group{
@@ -207,6 +209,7 @@ func TestProjectModelsHTTPScopesAccessKeyFiltersAndRelationships(t *testing.T) {
 }
 
 func TestProjectModelCatalogReferenceUsesTheRecordedPriceProviderAndSource(t *testing.T) {
+	t.Parallel()
 	snapshot := &catalog.Snapshot{Providers: map[string]catalog.Provider{
 		"openai": {ID: "openai", Models: map[string]catalog.Model{
 			"shared": {

--- a/internal/control/proxy_config_test.go
+++ b/internal/control/proxy_config_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestGroupAndCredentialProxyUseFinalPrecedenceAndEncryptedStorage(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	runtime := &recordingCredentialRuntimeExecutor{}
 	fixture.service.executor = runtime
@@ -113,6 +114,7 @@ func TestGroupAndCredentialProxyUseFinalPrecedenceAndEncryptedStorage(t *testing
 }
 
 func TestCredentialProxyUpdateRetiresRuntimeAfterCommittedRegistryRecovery(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	runtime := &recordingCredentialRuntimeExecutor{}
 	fixture.service.executor = runtime
@@ -172,6 +174,7 @@ func TestCredentialProxyUpdateRetiresRuntimeAfterCommittedRegistryRecovery(t *te
 }
 
 func TestGroupAndCredentialProxyRejectInvalidConfigWithoutMutation(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	groupID := createGroupWithCredentials(t, fixture, "sk-invalid-proxy-test")
 	credentials, err := fixture.service.ListGroupCredentials(t.Context(), groupID, CredentialCollectionQuery{Page: 1, PageSize: 20})
@@ -205,6 +208,7 @@ func TestGroupAndCredentialProxyRejectInvalidConfigWithoutMutation(t *testing.T)
 }
 
 func TestUnsupportedChannelRejectsManagedGroupAndCredentialProxy(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	name := "azure-without-managed-proxy"
 	created, err := fixture.service.CreateGroup(t.Context(), GroupCreateRequest{

--- a/internal/control/request_logs_test.go
+++ b/internal/control/request_logs_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestRequestLogReadsPreserveRequestCancellation(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	reader := &recordingRequestLogReader{err: context.Canceled, getErr: context.Canceled}
 	fixture.service.requestLogs = reader
@@ -45,6 +46,7 @@ func TestRequestLogReadsPreserveRequestCancellation(t *testing.T) {
 }
 
 func TestListRequestLogsSuppressesOnlyCanceledHTTPRequestErrors(t *testing.T) {
+	// 不标记 t.Parallel()：本测试劫持了全局 logrus 输出/格式，与其他并行测试同时运行会互相覆盖断言。
 	initControlI18n(t)
 	tests := []struct {
 		name       string
@@ -119,6 +121,7 @@ func TestListRequestLogsSuppressesOnlyCanceledHTTPRequestErrors(t *testing.T) {
 }
 
 func TestRequestLogEndpointRejectsUnknownDuplicateAndMalformedQueries(t *testing.T) {
+	t.Parallel()
 	validCursor := encodeTestCursorPayload(
 		`{"v":2,"completed_at_ms":1784894400000,"request_id":"00000000-0000-4000-8000-000000000001"}`,
 	)
@@ -184,6 +187,7 @@ func TestRequestLogEndpointRejectsUnknownDuplicateAndMalformedQueries(t *testing
 }
 
 func TestRequestLogEndpointRejectsInvalidDomainValues(t *testing.T) {
+	t.Parallel()
 	equalTime := "1784894400000"
 	tests := []struct {
 		name  string
@@ -219,6 +223,7 @@ func TestRequestLogEndpointRejectsInvalidDomainValues(t *testing.T) {
 }
 
 func TestRequestLogEndpointAcceptsCanonicalNumericBoundaries(t *testing.T) {
+	t.Parallel()
 	if strconv.IntSize != 64 {
 		t.Skip("maximum JavaScript safe integer does not fit uint on this architecture")
 	}
@@ -242,6 +247,7 @@ func TestRequestLogEndpointAcceptsCanonicalNumericBoundaries(t *testing.T) {
 }
 
 func TestRequestLogEndpointParsesAdvancedFilters(t *testing.T) {
+	t.Parallel()
 	reader := &recordingRequestLogReader{}
 	engine := newRequestLogTestEngine(t, reader)
 	query := strings.Join([]string{
@@ -306,6 +312,7 @@ func TestRequestLogEndpointParsesAdvancedFilters(t *testing.T) {
 }
 
 func TestRequestLogEndpointRejectsInvalidAdvancedFilters(t *testing.T) {
+	t.Parallel()
 	tests := []string{
 		"protocol=openai",
 		"stream=1",
@@ -346,6 +353,7 @@ func TestRequestLogEndpointRejectsInvalidAdvancedFilters(t *testing.T) {
 }
 
 func TestRequestLogEndpointReturnsOpaqueCursorAndSafeDTO(t *testing.T) {
+	t.Parallel()
 	completedAt := time.Date(2026, time.July, 24, 12, 0, 0, 123456789, time.UTC)
 	completedAtMS := completedAt.UnixMilli()
 	contextThreshold := int64(272_000)
@@ -499,6 +507,7 @@ func TestRequestLogEndpointReturnsOpaqueCursorAndSafeDTO(t *testing.T) {
 }
 
 func TestRequestLogDetailEndpointReturnsAttemptsAndFrozenPricingReceipt(t *testing.T) {
+	t.Parallel()
 	requestID := "00000000-0000-4000-8000-000000000611"
 	reasoningBudget := int64(4096)
 	rate := int64(1_000_000_000)
@@ -656,6 +665,7 @@ func TestRequestLogDetailEndpointReturnsAttemptsAndFrozenPricingReceipt(t *testi
 }
 
 func TestRequestLogPricingReceiptKeepsHistoricalSchemasReadable(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		receipt       pricing.Receipt
@@ -726,6 +736,7 @@ func TestRequestLogPricingReceiptKeepsHistoricalSchemasReadable(t *testing.T) {
 }
 
 func TestRequestLogEndpointProjectsUsageCostAndNullGroupZero(t *testing.T) {
+	t.Parallel()
 	reasoningBudget := int64(-1)
 	reader := &recordingRequestLogReader{pages: []requestlog.Page{{Items: []requestlog.Record{
 		{
@@ -804,6 +815,7 @@ func TestRequestLogEndpointProjectsUsageCostAndNullGroupZero(t *testing.T) {
 }
 
 func TestRequestLogResponseUsesNullModelsForProtocolOnlyResponsesResources(t *testing.T) {
+	t.Parallel()
 	result, err := mapRequestLogListResponse(requestlog.Page{
 		Items: []requestlog.Record{{
 			RequestID:           "00000000-0000-4000-8000-000000000503",
@@ -843,6 +855,7 @@ func TestRequestLogResponseUsesNullModelsForProtocolOnlyResponsesResources(t *te
 }
 
 func TestRequestLogDetailProjectsEmptyAttemptReasoningAsNull(t *testing.T) {
+	t.Parallel()
 	result, err := mapRequestLogDetailResponse(requestlog.Record{
 		RequestID:           "00000000-0000-4000-8000-000000000504",
 		Protocol:            protocol.OpenAIResponses,
@@ -875,6 +888,7 @@ func TestRequestLogDetailProjectsEmptyAttemptReasoningAsNull(t *testing.T) {
 }
 
 func TestRequestLogUsageCostProjectionRejectsUnsafeValues(t *testing.T) {
+	t.Parallel()
 	base := requestlog.Record{
 		UsageState: usage.StateComplete, CostState: pricing.CostStatePriced,
 	}
@@ -931,6 +945,7 @@ func TestRequestLogUsageCostProjectionRejectsUnsafeValues(t *testing.T) {
 }
 
 func TestRequestLogUsageCostProjectionAcceptsMaximumSafeFinalGroupID(t *testing.T) {
+	t.Parallel()
 	if strconv.IntSize != 64 {
 		t.Skip("maximum JavaScript safe integer does not fit uint on this architecture")
 	}
@@ -950,6 +965,7 @@ func TestRequestLogUsageCostProjectionAcceptsMaximumSafeFinalGroupID(t *testing.
 }
 
 func TestRequestLogEndpointFailsClosedOnCorruptReaderUsageCost(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		mutate func(*requestlog.Record)
@@ -1008,6 +1024,7 @@ func TestRequestLogEndpointFailsClosedOnCorruptReaderUsageCost(t *testing.T) {
 }
 
 func TestRequestLogEndpointRequiresManagementAuthentication(t *testing.T) {
+	t.Parallel()
 	reader := &recordingRequestLogReader{}
 	engine := newRequestLogTestEngine(t, reader)
 	recorder := performRequestLogRequest(engine, "", "")
@@ -1021,6 +1038,7 @@ func TestRequestLogEndpointRequiresManagementAuthentication(t *testing.T) {
 }
 
 func TestRequestLogEndpointsBindAccessKeyScopeAndRedactRoutingInternals(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	current, err := fixture.service.CreateAccessKey(t.Context(), AccessKeyCreateRequest{
@@ -1267,6 +1285,7 @@ func encodeTestCursorPayload(payload string) string {
 }
 
 func TestRequestLogAttemptActionUsesCredentialTerms(t *testing.T) {
+	t.Parallel()
 	for input, want := range map[telemetry.Action]string{
 		telemetry.Action("cooldown_credential"): "cooldown_credential",
 		telemetry.Action("fail_credential"):     "fail_credential",

--- a/internal/control/route_inspect_test.go
+++ b/internal/control/route_inspect_test.go
@@ -84,6 +84,7 @@ func routeModelValue(value *string) string {
 }
 
 func TestRouteInspectEndpointRejectsMalformedAndInvalidRequests(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	engine := gin.New()
@@ -205,6 +206,7 @@ func TestRouteInspectEndpointRejectsMalformedAndInvalidRequests(t *testing.T) {
 }
 
 func TestRouteInspectDerivesStandardRequestMetadataFromProtocol(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	if _, err := fixture.manager.Publish(state.CompileInput{
@@ -258,6 +260,7 @@ func TestRouteInspectDerivesStandardRequestMetadataFromProtocol(t *testing.T) {
 }
 
 func TestRouteInspectRejectsLegacyDerivedFields(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	engine := gin.New()
@@ -324,6 +327,7 @@ func TestRouteInspectStandardRequestIncludesNativeAndConvertedTargets(t *testing
 }
 
 func TestRouteInspectEndpointReturnsCurrentSafeExplanation(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	now := healthNow()
@@ -450,6 +454,7 @@ func TestRouteInspectEndpointReturnsCurrentSafeExplanation(t *testing.T) {
 }
 
 func TestRouteInspectEndpointReturnsFilterExplanations(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	tests := []struct {
 		name        string
@@ -557,6 +562,7 @@ func TestRouteInspectEndpointReturnsFilterExplanations(t *testing.T) {
 }
 
 func TestRouteInspectEndpointReturnsNoRouteTargetExplanation(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	now := healthNow()
@@ -593,6 +599,7 @@ func TestRouteInspectEndpointReturnsNoRouteTargetExplanation(t *testing.T) {
 }
 
 func TestRouteInspectEndpointReturnsNoAvailableKeyExplanation(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	now := healthNow()
@@ -710,6 +717,7 @@ func TestRouteInspectEndpointReturnsNoAvailableKeyExplanation(t *testing.T) {
 }
 
 func TestRouteInspectReturnsDisabledAccessKeyAsExplanation(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	if _, err := fixture.manager.Publish(state.CompileInput{
@@ -746,6 +754,7 @@ func TestRouteInspectReturnsDisabledAccessKeyAsExplanation(t *testing.T) {
 }
 
 func TestRouteInspectMissingAccessKeyReturnsNotFound(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	_, err := fixture.service.InspectRoute(routeInspectRequest{
@@ -793,6 +802,7 @@ func (spy *routeInspectEncryptionSpy) Hash(string) string {
 }
 
 func TestRouteInspectNeverCallsUpstreamOrMutatesRuntime(t *testing.T) {
+	t.Parallel()
 	var upstreamCalls atomic.Int64
 	fixture := newServiceFixture(t)
 	encryptionSpy := &routeInspectEncryptionSpy{}
@@ -861,6 +871,7 @@ func TestRouteInspectNeverCallsUpstreamOrMutatesRuntime(t *testing.T) {
 }
 
 func TestRouteInspectEndpointRequiresManagementAuthentication(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	beforeSnapshot := fixture.manager.Current()
@@ -882,6 +893,7 @@ func TestRouteInspectEndpointRequiresManagementAuthentication(t *testing.T) {
 }
 
 func TestRouteInspectCatalogMismatchReturnsInternalServerError(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	if _, err := fixture.manager.Publish(state.CompileInput{

--- a/internal/control/runtime_observation_test.go
+++ b/internal/control/runtime_observation_test.go
@@ -27,6 +27,7 @@ func (probe healthDecryptLockProbe) Decrypt(ciphertext string) (string, error) {
 }
 
 func TestCaptureRuntimeObservationWaitsForPublishedConfigPair(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	group := validControlGroup("runtime-observation")
 	var key models.Credential
@@ -113,6 +114,7 @@ func TestCaptureRuntimeObservationWaitsForPublishedConfigPair(t *testing.T) {
 }
 
 func TestCaptureRuntimeHealthObservationWaitsForPublishedConfigPair(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	group := validControlGroup("runtime-health-observation")
 	var key models.Credential
@@ -205,6 +207,7 @@ func TestCaptureRuntimeHealthObservationWaitsForPublishedConfigPair(t *testing.T
 }
 
 func TestRuntimeHealthReleasesReadLockBeforeRequestLogMapping(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.requestLogStats.fn = func() requestlog.Stats {
 		if !fixture.service.writeMu.TryLock() {
@@ -219,6 +222,7 @@ func TestRuntimeHealthReleasesReadLockBeforeRequestLogMapping(t *testing.T) {
 }
 
 func TestRuntimeHealthReleasesReadLockBeforeDecryptingProblemKeys(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := healthNow()
 	fixture.service.now = func() time.Time { return now }
@@ -250,6 +254,7 @@ func TestRuntimeHealthReleasesReadLockBeforeDecryptingProblemKeys(t *testing.T) 
 }
 
 func TestRuntimeHealthKeepsAccessQuotaViewWithCapturedConfig(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := healthNow()
 	fixture.service.now = func() time.Time { return now }

--- a/internal/control/runtime_test.go
+++ b/internal/control/runtime_test.go
@@ -195,6 +195,7 @@ func (recovery *controlledOperationRecovery) RunOperationRecovery(ctx context.Co
 }
 
 func TestRuntimeRunsOperationRecoveryUntilCancellation(t *testing.T) {
+	t.Parallel()
 	recovery := &controlledOperationRecovery{
 		started:  make(chan struct{}),
 		returned: make(chan struct{}),
@@ -216,6 +217,7 @@ func TestRuntimeRunsOperationRecoveryUntilCancellation(t *testing.T) {
 }
 
 func TestRuntimeSweepsRequestLogsImmediatelyAndHourlyWithoutOverlap(t *testing.T) {
+	t.Parallel()
 	base := time.Date(2026, time.July, 24, 12, 0, 0, 0, time.UTC)
 	clock := &fakeRuntimeClock{now: base}
 	cleaner := newControlledRequestLogCleaner(false)
@@ -287,6 +289,7 @@ func TestRuntimeSweepsRequestLogsImmediatelyAndHourlyWithoutOverlap(t *testing.T
 }
 
 func TestRuntimeSweepsCredentialStagesWithoutRequestLogCleaner(t *testing.T) {
+	t.Parallel()
 	base := time.Date(2026, time.August, 13, 8, 0, 0, 0, time.UTC)
 	autoTicker := newFakeRuntimeTicker()
 	validationTicker := newFakeRuntimeTicker()
@@ -322,6 +325,7 @@ func TestRuntimeSweepsCredentialStagesWithoutRequestLogCleaner(t *testing.T) {
 }
 
 func TestRuntimeCancellationWaitsForRetentionSweep(t *testing.T) {
+	t.Parallel()
 	cleaner := newControlledRequestLogCleaner(true)
 	autoTicker := newFakeRuntimeTicker()
 	validationTicker := newFakeRuntimeTicker()
@@ -371,6 +375,7 @@ func TestRuntimeCancellationWaitsForRetentionSweep(t *testing.T) {
 }
 
 func TestRuntimeCreatesAutoWeightAndJitteredValidationTickers(t *testing.T) {
+	t.Parallel()
 	registry := newFakeAutoWeightRegistry(1)
 	autoTicker := newFakeRuntimeTicker()
 	validationTicker := newFakeRuntimeTicker()
@@ -391,6 +396,7 @@ func TestRuntimeCreatesAutoWeightAndJitteredValidationTickers(t *testing.T) {
 }
 
 func TestRuntimeValidationJitterDoesNotOverflow(t *testing.T) {
+	t.Parallel()
 	autoTicker := newFakeRuntimeTicker()
 	validationTicker := newFakeRuntimeTicker()
 	created := make(chan time.Duration, 2)
@@ -426,6 +432,7 @@ func TestRuntimeValidationJitterDoesNotOverflow(t *testing.T) {
 }
 
 func TestRuntimeReschedulesValidationWhenPublishedIntervalChanges(t *testing.T) {
+	t.Parallel()
 	manager := state.NewManager()
 	if _, err := manager.Publish(state.CompileInput{}); err != nil {
 		t.Fatal(err)
@@ -482,6 +489,7 @@ func TestRuntimeReschedulesValidationWhenPublishedIntervalChanges(t *testing.T) 
 }
 
 func TestRuntimeWaitsForTickBeforeRecompute(t *testing.T) {
+	t.Parallel()
 	registry := newFakeAutoWeightRegistry(1)
 	runtime, autoTicker, _, created := newRuntimeHarness(registry, health.NewStatsStore(), newFakeValidationSweep(false), time.Now)
 
@@ -495,6 +503,7 @@ func TestRuntimeWaitsForTickBeforeRecompute(t *testing.T) {
 }
 
 func TestRuntimeRecomputesEveryActiveKey(t *testing.T) {
+	t.Parallel()
 	registry := newFakeAutoWeightRegistry(3, 7, 9)
 	runtime, autoTicker, _, created := newRuntimeHarness(registry, health.NewStatsStore(), newFakeValidationSweep(false), time.Now)
 
@@ -520,6 +529,7 @@ func TestRuntimeRecomputesEveryActiveKey(t *testing.T) {
 }
 
 func TestRuntimeResetsExpiredStatsToDefaultWeight(t *testing.T) {
+	t.Parallel()
 	base := time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)
 	stats := health.NewStatsStore()
 	for sample := 0; sample < 10; sample++ {
@@ -545,6 +555,7 @@ func TestRuntimeResetsExpiredStatsToDefaultWeight(t *testing.T) {
 }
 
 func TestRuntimeContinuesWhenKeyDisappears(t *testing.T) {
+	t.Parallel()
 	registry := newFakeAutoWeightRegistry(1, 2, 3)
 	registry.reject[2] = true
 	runtime, autoTicker, _, created := newRuntimeHarness(registry, health.NewStatsStore(), newFakeValidationSweep(false), time.Now)
@@ -561,6 +572,7 @@ func TestRuntimeContinuesWhenKeyDisappears(t *testing.T) {
 }
 
 func TestRuntimeCooldownProblemDoesNotAffectAutoWeightSeenByCandidateCollection(t *testing.T) {
+	t.Parallel()
 	base := time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)
 	registry := state.NewCredentialRegistry()
 	if err := registry.ReplaceCredentials([]state.CredentialEntry{{
@@ -585,6 +597,7 @@ func TestRuntimeCooldownProblemDoesNotAffectAutoWeightSeenByCandidateCollection(
 }
 
 func TestRuntimeCoordinatesStatsSnapshotAndAutoWeightWrite(t *testing.T) {
+	t.Parallel()
 	now := time.Date(2026, time.July, 27, 12, 0, 0, 0, time.UTC)
 	registry := newFakeAutoWeightRegistry(1)
 	stats := health.NewStatsStore()
@@ -627,6 +640,7 @@ func TestRuntimeCoordinatesStatsSnapshotAndAutoWeightWrite(t *testing.T) {
 }
 
 func TestRuntimeCoordinatesAutoWeightWithValidationRecovery(t *testing.T) {
+	t.Parallel()
 	base := time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)
 	stats := health.NewStatsStore()
 	for range 10 {
@@ -678,6 +692,7 @@ func TestRuntimeCoordinatesAutoWeightWithValidationRecovery(t *testing.T) {
 }
 
 func TestRuntimeWaitsForValidationTick(t *testing.T) {
+	t.Parallel()
 	registry := newFakeAutoWeightRegistry(1)
 	validator := newFakeValidationSweep(false)
 	runtime, _, validationTicker, created := newRuntimeHarness(registry, health.NewStatsStore(), validator, time.Now)
@@ -696,6 +711,7 @@ func TestRuntimeWaitsForValidationTick(t *testing.T) {
 }
 
 func TestRuntimeKeepsRecomputingWhileValidationIsBlocked(t *testing.T) {
+	t.Parallel()
 	registry := newFakeAutoWeightRegistry(1)
 	validator := newFakeValidationSweep(true)
 	runtime, autoTicker, validationTicker, created := newRuntimeHarness(registry, health.NewStatsStore(), validator, time.Now)
@@ -713,6 +729,7 @@ func TestRuntimeKeepsRecomputingWhileValidationIsBlocked(t *testing.T) {
 }
 
 func TestRuntimeCancellationStopsBothTickersAndWaitsForValidation(t *testing.T) {
+	t.Parallel()
 	registry := newFakeAutoWeightRegistry(1)
 	validator := newFakeValidationSweep(true)
 	runtime, autoTicker, validationTicker, created := newRuntimeHarness(registry, health.NewStatsStore(), validator, time.Now)
@@ -729,6 +746,7 @@ func TestRuntimeCancellationStopsBothTickersAndWaitsForValidation(t *testing.T) 
 }
 
 func TestRuntimeStopsOnContextCancellation(t *testing.T) {
+	t.Parallel()
 	registry := newFakeAutoWeightRegistry(1)
 	runtime, autoTicker, validationTicker, created := newRuntimeHarness(registry, health.NewStatsStore(), newFakeValidationSweep(false), time.Now)
 

--- a/internal/control/server_auth_test.go
+++ b/internal/control/server_auth_test.go
@@ -23,6 +23,7 @@ import (
 const authTestKey = "test-auth-key"
 
 func TestAuthenticateFailsClosedForInvalidPeerWithoutComparison(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	for _, remote := range []string{
 		"",
@@ -63,6 +64,7 @@ func TestAuthenticateFailsClosedForInvalidPeerWithoutComparison(t *testing.T) {
 }
 
 func TestAuthenticateLockedRequestsIgnoreForwardingHeaders(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	_, engine := newAuthProbeServer(t)
 	const peer = "192.0.2.10:1234"
@@ -87,6 +89,7 @@ func TestAuthenticateLockedRequestsIgnoreForwardingHeaders(t *testing.T) {
 }
 
 func TestAuthenticateSeparatesDifferentRemotePeers(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	_, engine := newAuthProbeServer(t)
 
@@ -110,6 +113,7 @@ func TestAuthenticateSeparatesDifferentRemotePeers(t *testing.T) {
 }
 
 func TestAuthenticateComparesEveryUnlockedCredentialShapeOnce(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	server, engine := newAuthProbeServer(t)
 
@@ -146,6 +150,7 @@ func TestAuthenticateComparesEveryUnlockedCredentialShapeOnce(t *testing.T) {
 }
 
 func TestAuthenticateComparesEveryLockedAuthorizationShapeOnce(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	for index, test := range []struct {
 		name          string
@@ -202,6 +207,7 @@ func TestAuthenticateComparesEveryLockedAuthorizationShapeOnce(t *testing.T) {
 }
 
 func TestAuthenticateLockedCorrectKeyClearsPeerAndNextFailureReturns401(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	_, engine := newAuthProbeServer(t)
 	const peer = "192.0.2.30:1234"
@@ -212,6 +218,7 @@ func TestAuthenticateLockedCorrectKeyClearsPeerAndNextFailureReturns401(t *testi
 }
 
 func TestAuthenticateLockedWrongTokensPreserve429ShapeAndRetryAfter(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	server, engine := newAuthProbeServer(t)
 	server.authFailures.now = func() time.Time {
@@ -255,6 +262,7 @@ func TestAuthenticateLockedWrongTokensPreserve429ShapeAndRetryAfter(t *testing.T
 }
 
 func TestAuthenticateSuccessBeforeThresholdClearsPeerFailures(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	_, engine := newAuthProbeServer(t)
 	const peer = "192.0.2.21:1234"
@@ -270,6 +278,7 @@ func TestAuthenticateSuccessBeforeThresholdClearsPeerFailures(t *testing.T) {
 }
 
 func TestAuthenticateLockExpiresAfterThirtyMinutes(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	server, engine := newAuthProbeServer(t)
 	current := time.Date(2026, 7, 23, 0, 0, 0, 0, time.UTC)
@@ -284,6 +293,7 @@ func TestAuthenticateLockExpiresAfterThirtyMinutes(t *testing.T) {
 }
 
 func TestAuthenticateRetryAfterMatchesResponseData(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	_, engine := newAuthProbeServer(t)
 	const peer = "192.0.2.23:1234"
@@ -314,6 +324,7 @@ func TestAuthenticateRetryAfterMatchesResponseData(t *testing.T) {
 }
 
 func TestAuthenticateMessagesAreLocalized(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	for index, test := range []struct {
 		language     string
@@ -365,6 +376,7 @@ func TestAuthenticateMessagesAreLocalized(t *testing.T) {
 }
 
 func TestAuthSessionEndpointReturnsAuthenticatedWithoutDatabaseAccess(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	engine := gin.New()
 	NewServer(&config.Config{AuthKey: authTestKey}, nil).RegisterRoutes(engine)
@@ -400,6 +412,7 @@ func TestAuthSessionEndpointReturnsAuthenticatedWithoutDatabaseAccess(t *testing
 }
 
 func TestAuthSessionEndpointAcceptsActiveAccessKeyAndRejectsAdminRoutes(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	created, err := fixture.service.CreateAccessKey(t.Context(), AccessKeyCreateRequest{
@@ -508,6 +521,7 @@ func TestAuthSessionEndpointAcceptsActiveAccessKeyAndRejectsAdminRoutes(t *testi
 }
 
 func TestAccessKeyAuthenticationDoesNotClearPeerFailuresOrLock(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	created, err := fixture.service.CreateAccessKey(t.Context(), AccessKeyCreateRequest{
@@ -553,6 +567,7 @@ func TestAccessKeyAuthenticationDoesNotClearPeerFailuresOrLock(t *testing.T) {
 }
 
 func TestAuthSessionEndpointRejectsDisabledAccessKey(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	status := state.AccessKeyStatusDisabled
@@ -579,6 +594,7 @@ func TestAuthSessionEndpointRejectsDisabledAccessKey(t *testing.T) {
 }
 
 func TestAuthSessionEndpointRejectsCredentialMatchingAdminAndAccessKey(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	created, err := fixture.service.CreateAccessKey(t.Context(), AccessKeyCreateRequest{
@@ -603,6 +619,7 @@ func TestAuthSessionEndpointRejectsCredentialMatchingAdminAndAccessKey(t *testin
 }
 
 func TestAuthSessionEndpointRequiresAuthentication(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	engine := gin.New()
 	NewServer(&config.Config{AuthKey: authTestKey}, nil).RegisterRoutes(engine)
@@ -615,6 +632,7 @@ func TestAuthSessionEndpointRequiresAuthentication(t *testing.T) {
 }
 
 func TestCollectionEndpointsRequireBearerAuthentication(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	engine := gin.New()
 	NewServer(&config.Config{AuthKey: authTestKey}, nil).RegisterRoutes(engine)
@@ -657,6 +675,7 @@ func TestCollectionEndpointsRequireBearerAuthentication(t *testing.T) {
 }
 
 func TestAuthSessionEndpointUsesLimiter(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	engine := gin.New()
 	NewServer(&config.Config{AuthKey: authTestKey}, nil).RegisterRoutes(engine)

--- a/internal/control/server_phase1_test.go
+++ b/internal/control/server_phase1_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestControlRoutesRequireAuthenticationForGroupCreateAndModelDiscovery(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	fixture.service.executor = newRecordingDiscoveryExecutor(&recordingDiscoveryExecutorTarget{
@@ -79,6 +80,7 @@ func TestControlRoutesRequireAuthenticationForGroupCreateAndModelDiscovery(t *te
 }
 
 func TestCreateAndImportEndpointsRequireCanonicalIdempotencyKeyBeforeMutation(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	groupID := createGroupWithCredentials(t, fixture, "seed-idempotency-header")
@@ -151,6 +153,7 @@ func TestCreateAndImportEndpointsRequireCanonicalIdempotencyKeyBeforeMutation(t 
 }
 
 func TestAccessKeyCreateReplayOptionsAndRevealWireContracts(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	fixture.service.random = bytes.NewReader(make([]byte, 16))

--- a/internal/control/server_test.go
+++ b/internal/control/server_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestServerHomeAndSystemUpdateRoutesUseExactManagementContracts(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	module := NewServer(
 		&config.Config{AuthKey: "test-auth-key"},
@@ -74,6 +75,7 @@ func TestServerHomeAndSystemUpdateRoutesUseExactManagementContracts(t *testing.T
 }
 
 func TestGroupCollectionHTTPRoutesDeclareStaticOptionsBeforeDynamicDetail(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	module := NewServer(
 		&config.Config{AuthKey: authTestKey},
@@ -107,6 +109,7 @@ func TestGroupCollectionHTTPRoutesDeclareStaticOptionsBeforeDynamicDetail(t *tes
 }
 
 func TestSystemInfoHTTPContract(t *testing.T) {
+	// 不标记 t.Parallel()：本测试劫持了全局 logrus 输出/格式，与其他并行测试同时运行会互相覆盖断言。
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	cfg := &config.Config{
@@ -207,6 +210,7 @@ func TestSystemInfoHTTPContract(t *testing.T) {
 }
 
 func TestControlJSONBodyLimitBoundary(t *testing.T) {
+	t.Parallel()
 	if maxControlJSONBodyBytes != 32<<20 {
 		t.Fatalf("maxControlJSONBodyBytes = %d, want %d", maxControlJSONBodyBytes, 32<<20)
 	}
@@ -256,6 +260,7 @@ func TestControlJSONBodyLimitBoundary(t *testing.T) {
 }
 
 func TestControlMutationRejectsDuplicateJSONWithoutSideEffects(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 
 	for _, endpoint := range []struct {
@@ -476,6 +481,7 @@ func assertControlJSONBodyLimitStateUnchanged(
 }
 
 func TestControlJSONBodyLimitAppliesToEveryJSONEndpoint(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 
 	for _, endpoint := range []struct {
@@ -618,6 +624,7 @@ func TestControlJSONBodyLimitAppliesToEveryJSONEndpoint(t *testing.T) {
 }
 
 func TestControlJSONBodyLimitContentLengthFastPathPreservesAuthenticationPriority(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	engine := gin.New()
@@ -661,6 +668,7 @@ func TestControlJSONBodyLimitContentLengthFastPathPreservesAuthenticationPriorit
 }
 
 func TestControlJSONBodyLimitLocalizes413(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	engine := gin.New()
@@ -704,6 +712,7 @@ func TestControlJSONBodyLimitLocalizes413(t *testing.T) {
 }
 
 func TestManagementAuthRequiresConstantShapeBearerToken(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	engine := gin.New()
@@ -746,6 +755,7 @@ func TestManagementAuthRequiresConstantShapeBearerToken(t *testing.T) {
 }
 
 func TestManagementAuthLocalizesUnauthorized(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	engine := gin.New()
@@ -769,6 +779,7 @@ func TestManagementAuthLocalizesUnauthorized(t *testing.T) {
 }
 
 func TestManagementAuthDoesNotLogSecretOrDigest(t *testing.T) {
+	// 不标记 t.Parallel()：本测试劫持了全局 logrus 输出/格式，与其他并行测试同时运行会互相覆盖断言。
 	initControlI18n(t)
 	const authKey = "distinctive-control-auth-key"
 	fixture := newServiceFixture(t)
@@ -794,6 +805,7 @@ func TestManagementAuthDoesNotLogSecretOrDigest(t *testing.T) {
 }
 
 func TestGroupCreateHTTPReturnsNarrowSuccessAndConflictEnvelopes(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	engine := gin.New()
@@ -868,6 +880,7 @@ func TestGroupCreateHTTPReturnsNarrowSuccessAndConflictEnvelopes(t *testing.T) {
 }
 
 func TestGroupCreateHTTPRejectsLegacyMissingAndMalformedContractsWithoutMutation(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	tests := []struct {
 		name string
@@ -932,6 +945,7 @@ func TestGroupCreateHTTPRejectsLegacyMissingAndMalformedContractsWithoutMutation
 }
 
 func TestImportGroupCredentialsEndpointReturnsSuccessEnvelope(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	groupID := createGroupForCredentialImport(t, fixture, "sk-existing")
@@ -983,6 +997,7 @@ func TestImportGroupCredentialsEndpointReturnsSuccessEnvelope(t *testing.T) {
 }
 
 func TestImportGroupCredentialsEndpointRejectsUnknownFieldsAndInvalidGroupID(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	groupID := createGroupForCredentialImport(t, fixture, "sk-existing")
@@ -1022,6 +1037,7 @@ func TestImportGroupCredentialsEndpointRejectsUnknownFieldsAndInvalidGroupID(t *
 }
 
 func TestImportGroupCredentialsEndpointReturnsGroupNotFound(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	engine := gin.New()
@@ -1080,6 +1096,7 @@ func assertImportedCredentialState(t *testing.T, fixture serviceFixture, groupID
 }
 
 func TestLegacyImportRouteIsNotRegistered(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	engine := gin.New()
 	NewServer(&config.Config{AuthKey: "test-auth-key"}, fixture.service).RegisterRoutes(engine)
@@ -1092,6 +1109,7 @@ func TestLegacyImportRouteIsNotRegistered(t *testing.T) {
 }
 
 func TestManagementWritesRejectUnknownFieldsAndMultipleJSONValues(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 
 	t.Run("group create rejects unknown top-level field", func(t *testing.T) {
@@ -1183,6 +1201,7 @@ func TestManagementWritesRejectUnknownFieldsAndMultipleJSONValues(t *testing.T) 
 }
 
 func TestUpdateGroupSettingsEndpointRejectsStrictInvalidBodies(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	groupID := createGroupForCredentialImport(t, fixture, "sk-update-http")
@@ -1232,6 +1251,7 @@ func TestUpdateGroupSettingsEndpointRejectsStrictInvalidBodies(t *testing.T) {
 }
 
 func TestUpdateGroupSettingsEndpointRejectsTopLevelNullWithoutMutation(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	groupID := createGroupForCredentialImport(t, fixture, "sk-update-null")
@@ -1283,6 +1303,7 @@ func TestUpdateGroupSettingsEndpointRejectsTopLevelNullWithoutMutation(t *testin
 }
 
 func TestUpdateGroupSettingsEndpointAllowsURLReuseAndPreservesI18nAndAuth(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	first, err := fixture.service.CreateGroup(t.Context(), GroupCreateRequest{
@@ -1384,6 +1405,7 @@ func TestUpdateGroupSettingsEndpointAllowsURLReuseAndPreservesI18nAndAuth(t *tes
 }
 
 func TestUpdateGroupSettingsEndpointRejectsOversizedJSON(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	groupID := createGroupForCredentialImport(t, fixture, "sk-update-limit")
@@ -1408,6 +1430,7 @@ func TestUpdateGroupSettingsEndpointRejectsOversizedJSON(t *testing.T) {
 }
 
 func TestUpdateGroupModelsEndpointRejectsStrictInvalidBodiesWithoutMutation(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	created, err := fixture.service.CreateGroup(t.Context(), GroupCreateRequest{
@@ -1470,6 +1493,7 @@ func TestUpdateGroupModelsEndpointRejectsStrictInvalidBodiesWithoutMutation(t *t
 }
 
 func TestGroupModelsHTTPReturnsStructuredConflictWithoutMutation(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	groupID := createGroupForCredentialImport(t, fixture, "sk-model-conflict-http")
@@ -1507,6 +1531,7 @@ func TestGroupModelsHTTPReturnsStructuredConflictWithoutMutation(t *testing.T) {
 }
 
 func TestGroupModelsHTTPRejectsMissingAliasEnabledWithoutMutation(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	mustEnsureInitialPrices(t, fixture)
@@ -1537,6 +1562,7 @@ func TestGroupModelsHTTPRejectsMissingAliasEnabledWithoutMutation(t *testing.T) 
 }
 
 func TestUpdateGroupModelsEndpointIDsAuthNotFoundAndSuccessDTO(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	mustEnsureInitialPrices(t, fixture)
@@ -1682,6 +1708,7 @@ func assertUpdateGroupErrorResponse(
 }
 
 func TestUpdateAccessKeyRoutesParseIDsAndPreservePointerSemantics(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	fixture.service.random = bytes.NewReader(make([]byte, 16))
@@ -1750,6 +1777,7 @@ func TestUpdateAccessKeyRoutesParseIDsAndPreservePointerSemantics(t *testing.T) 
 }
 
 func TestModelDiscoveryHTTPContract(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	const authKey = "test-auth-key"
 
@@ -1967,6 +1995,7 @@ func TestModelDiscoveryHTTPContract(t *testing.T) {
 }
 
 func TestServerDraftModelDiscoveryLogsOnlyMetadata(t *testing.T) {
+	// 不标记 t.Parallel()：本测试劫持了全局 logrus 输出/格式，与其他并行测试同时运行会互相覆盖断言。
 	initControlI18n(t)
 	const (
 		authSecret = "distinctive-auth-secret"
@@ -2012,6 +2041,7 @@ func TestServerDraftModelDiscoveryLogsOnlyMetadata(t *testing.T) {
 }
 
 func TestServerGroupModelDiscoveryBodyContract(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	const authKey = "test-auth-key"
 
@@ -2202,6 +2232,7 @@ func serveDiscoveryRequestWithLanguage(
 }
 
 func TestSettingsHTTPContract(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	engine := gin.New()
@@ -2281,6 +2312,7 @@ func TestSettingsHTTPContract(t *testing.T) {
 }
 
 func TestSettingsHTTPStableSuccessEnvelopeUpdateAndReset(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	engine := gin.New()
@@ -2306,6 +2338,7 @@ func TestSettingsHTTPStableSuccessEnvelopeUpdateAndReset(t *testing.T) {
 }
 
 func TestSettingsHTTPBodyLimitRejectsBeforeMutation(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	engine := gin.New()
@@ -2341,6 +2374,7 @@ func TestSettingsHTTPBodyLimitRejectsBeforeMutation(t *testing.T) {
 }
 
 func TestSettingsHTTPFiltersPrivateRowsAndDoesNotLogValues(t *testing.T) {
+	// 不标记 t.Parallel()：本测试劫持了全局 logrus 输出/格式，与其他并行测试同时运行会互相覆盖断言。
 	initControlI18n(t)
 	const (
 		authKey          = "settings-auth-key"

--- a/internal/control/service_integration_test.go
+++ b/internal/control/service_integration_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestControlWriteLockDoesNotBlockDataPlane(t *testing.T) {
+	t.Parallel()
 	requestReached := make(chan bool, 2)
 	upstream := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		body, _ := io.ReadAll(request.Body)

--- a/internal/control/service_test.go
+++ b/internal/control/service_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 func TestReadSnapshotKeepsOneVersionWhileWALWriterCommits(t *testing.T) {
+	t.Parallel()
 	fixture, dsn := newFileServiceFixture(t)
 	group := validControlGroup("read-snapshot-old")
 	if err := fixture.db.Create(group).Error; err != nil {
@@ -106,6 +107,7 @@ func TestReadSnapshotKeepsOneVersionWhileWALWriterCommits(t *testing.T) {
 }
 
 func TestReadSnapshotCancellationTakesPrecedenceAndReleasesConnection(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	ctx, cancel := context.WithCancel(t.Context())
 	const callbackCause = "callback detail must not win over cancellation"
@@ -132,6 +134,7 @@ func TestReadSnapshotCancellationTakesPrecedenceAndReleasesConnection(t *testing
 }
 
 func TestWriteConfigDiscardsConnectionAfterCommitBusy(t *testing.T) {
+	t.Parallel()
 	fixture, dsn := newFileServiceFixture(t)
 	beforeRevision := fixture.manager.Current().Revision
 	releaseReader := holdRollbackJournalReadLock(t, fixture.db, dsn)
@@ -179,6 +182,7 @@ func TestWriteConfigDiscardsConnectionAfterCommitBusy(t *testing.T) {
 }
 
 func TestWriteConfigRollsBackWhenCompileRejectsCandidate(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	before := fixture.manager.Current().Revision
 
@@ -198,6 +202,7 @@ func TestWriteConfigRollsBackWhenCompileRejectsCandidate(t *testing.T) {
 }
 
 func TestWriteConfigAppliesRuntimeBeforePublishingSnapshot(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	beforeSnapshot := fixture.manager.Current()
 	group := validControlGroup("registry-before-snapshot")
@@ -243,6 +248,7 @@ func TestWriteConfigAppliesRuntimeBeforePublishingSnapshot(t *testing.T) {
 }
 
 func TestWriteConfigMakesCreatedGroupAndFirstKeyAtomicallyVisibleToDataPlane(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.random = strings.NewReader(strings.Repeat("\x01", 16))
 	accessKey, err := fixture.service.CreateAccessKey(t.Context(), AccessKeyCreateRequest{Name: "client"})
@@ -383,6 +389,7 @@ func TestWriteConfigMakesCreatedGroupAndFirstKeyAtomicallyVisibleToDataPlane(t *
 }
 
 func TestWriteConfigRuntimeFailureReloadsCommittedDatabaseTruth(t *testing.T) {
+	// 不标记 t.Parallel()：本测试劫持了全局 logrus 输出/格式，与其他并行测试同时运行会互相覆盖断言。
 	fixture := newServiceFixture(t)
 	beforeSnapshot := fixture.manager.Current()
 	const secretCause = "forced Registry publication failure"
@@ -448,6 +455,7 @@ func TestWriteConfigRuntimeFailureReloadsCommittedDatabaseTruth(t *testing.T) {
 }
 
 func TestWriteConfigSnapshotFailureReloadsCommittedDatabaseTruth(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	beforeRevision := fixture.manager.Current().Revision
 	fixture.service.publishSnapshot = func(state.CompileInput) (*state.ConfigSnapshot, error) {
@@ -471,6 +479,7 @@ func TestWriteConfigSnapshotFailureReloadsCommittedDatabaseTruth(t *testing.T) {
 }
 
 func TestWriteConfigRecoveryPreservesCredentialRuntimeState(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	group := validControlGroup("runtime-health-preserved")
 	if err := fixture.db.Create(group).Error; err != nil {
@@ -510,6 +519,7 @@ func TestWriteConfigRecoveryPreservesCredentialRuntimeState(t *testing.T) {
 }
 
 func TestWriteConfigSerializesConcurrentDatabaseAndSnapshotPublication(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	before := fixture.manager.Current().Revision
 	start := make(chan struct{})
@@ -547,6 +557,7 @@ func TestWriteConfigSerializesConcurrentDatabaseAndSnapshotPublication(t *testin
 }
 
 func TestConcurrentCreateGroupsPublishDatabaseTruth(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	before := fixture.manager.Current().Revision
 	requests := []GroupCreateRequest{

--- a/internal/control/settings_etag_test.go
+++ b/internal/control/settings_etag_test.go
@@ -20,6 +20,7 @@ type settingsETagFixture struct {
 }
 
 func TestSettingsWireETagMatchesCheckedInFixture(t *testing.T) {
+	t.Parallel()
 	raw, err := os.ReadFile("testdata/settings-etag-v1.json")
 	if err != nil {
 		t.Fatal(err)
@@ -96,6 +97,7 @@ func TestSettingsWireETagMatchesCheckedInFixture(t *testing.T) {
 }
 
 func TestSettingsDTOCanonicalizesHeaderRulesAndOverrides(t *testing.T) {
+	t.Parallel()
 	dto := canonicalizeSettingsDTO(SettingsDTO{
 		Values: SettingsValuesResponse{
 			HeaderRules: HeaderRulesResponse{

--- a/internal/control/settings_occ_test.go
+++ b/internal/control/settings_occ_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestSettingsHTTPUsesCanonicalLocalizedStrongRepresentation(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	engine := gin.New()
@@ -50,6 +51,7 @@ func TestSettingsHTTPUsesCanonicalLocalizedStrongRepresentation(t *testing.T) {
 }
 
 func TestSettingsHTTPRequiresStrongIfMatchAndReturnsLatestConflict(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	engine := gin.New()
@@ -124,6 +126,7 @@ func TestSettingsHTTPRequiresStrongIfMatchAndReturnsLatestConflict(t *testing.T)
 }
 
 func TestSettingsHTTPMatchingWriteReturnsCurrentGETAndAllowsABA(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	engine := gin.New()
@@ -177,6 +180,7 @@ func TestSettingsHTTPMatchingWriteReturnsCurrentGETAndAllowsABA(t *testing.T) {
 }
 
 func TestSettingsETagIgnoresOtherResourcesAndSurvivesRuntimeReload(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	engine := gin.New()

--- a/internal/control/settings_test.go
+++ b/internal/control/settings_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestSettingsProxyConfigIsEncryptedMaskedAndResettable(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	const endpoint = "http://proxy-user:proxy-password@proxy.example.com:8080"
 
@@ -77,6 +78,7 @@ func TestSettingsProxyConfigIsEncryptedMaskedAndResettable(t *testing.T) {
 }
 
 func TestSettingsProxyPasswordChangesETagWithoutExposingPassword(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	current, err := fixture.service.GetSettings(t.Context())
 	if err != nil {
@@ -111,6 +113,7 @@ func TestSettingsProxyPasswordChangesETagWithoutExposingPassword(t *testing.T) {
 }
 
 func TestSettingsProxyRejectsInvalidConfigWithoutMutation(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	_, err := fixture.service.UpdateSettings(t.Context(), SettingsUpdateRequest{
 		Settings: map[string]json.RawMessage{outboundproxy.SystemSettingKey: json.RawMessage(
@@ -130,6 +133,7 @@ func TestSettingsProxyRejectsInvalidConfigWithoutMutation(t *testing.T) {
 }
 
 func TestGetSettingsReturnsSnapshotDefaultsAndNoOverrides(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	got, err := fixture.service.GetSettings(t.Context())
 	if err != nil {
@@ -163,6 +167,7 @@ func TestGetSettingsReturnsSnapshotDefaultsAndNoOverrides(t *testing.T) {
 }
 
 func TestUpdateSettingsChangesAndResetsValidationInterval(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	updated, err := fixture.service.UpdateSettings(t.Context(), SettingsUpdateRequest{
 		Settings: map[string]json.RawMessage{
@@ -192,6 +197,7 @@ func TestUpdateSettingsChangesAndResetsValidationInterval(t *testing.T) {
 }
 
 func TestUpdateSettingsChangesAndResetsAffinityDefaults(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	updated, err := fixture.service.UpdateSettings(t.Context(), SettingsUpdateRequest{
 		Settings: map[string]json.RawMessage{
@@ -230,6 +236,7 @@ func TestUpdateSettingsChangesAndResetsAffinityDefaults(t *testing.T) {
 }
 
 func TestModelsDevEnvironmentOverrideWinsAndIsReadOnlyWithoutPersistence(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	disabled := false
 	fixture.service.modelsDevAutoSyncOverride = &disabled
@@ -262,6 +269,7 @@ func TestModelsDevEnvironmentOverrideWinsAndIsReadOnlyWithoutPersistence(t *test
 }
 
 func TestUpdateSettingsInjectUsageOptionsBooleanAndNullReset(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	updated, err := fixture.service.UpdateSettings(t.Context(), SettingsUpdateRequest{
 		Settings: map[string]json.RawMessage{state.SettingInjectUsageOptions: json.RawMessage("false")},
@@ -281,6 +289,7 @@ func TestUpdateSettingsInjectUsageOptionsBooleanAndNullReset(t *testing.T) {
 }
 
 func TestUpdateSettingsEnablingModelsDevRequestsImmediateSyncOnce(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	if _, err := fixture.service.UpdateSettings(t.Context(), SettingsUpdateRequest{
 		Settings: map[string]json.RawMessage{
@@ -325,6 +334,7 @@ func TestUpdateSettingsEnablingModelsDevRequestsImmediateSyncOnce(t *testing.T) 
 }
 
 func TestUpdateSettingsIfMatchEnablingModelsDevRequestsImmediateSync(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	if _, err := fixture.service.UpdateSettings(t.Context(), SettingsUpdateRequest{
 		Settings: map[string]json.RawMessage{
@@ -366,6 +376,7 @@ func TestUpdateSettingsIfMatchEnablingModelsDevRequestsImmediateSync(t *testing.
 }
 
 func TestUpdateSettingsRejectsNonBooleanInjectUsageWithoutMutation(t *testing.T) {
+	t.Parallel()
 	for _, raw := range []json.RawMessage{json.RawMessage("0"), json.RawMessage("1"), json.RawMessage(`"true"`), json.RawMessage("[]"), json.RawMessage("{}")} {
 		fixture := newServiceFixture(t)
 		before := fixture.manager.Current().Revision
@@ -383,6 +394,7 @@ func TestUpdateSettingsRejectsNonBooleanInjectUsageWithoutMutation(t *testing.T)
 }
 
 func TestGetSettingsFiltersAndSortsPublicRuntimeOverrides(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	_, err := fixture.service.UpdateSettings(t.Context(), SettingsUpdateRequest{
 		Settings: map[string]json.RawMessage{
@@ -422,6 +434,7 @@ func TestGetSettingsFiltersAndSortsPublicRuntimeOverrides(t *testing.T) {
 }
 
 func TestGetSettingsRejectsMissingSnapshot(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.manager = state.NewManager()
 
@@ -432,6 +445,7 @@ func TestGetSettingsRejectsMissingSnapshot(t *testing.T) {
 }
 
 func TestGetSettingsWaitsForConfigurationWriteLock(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.writeMu.Lock()
 	locked := true
@@ -472,6 +486,7 @@ func TestGetSettingsWaitsForConfigurationWriteLock(t *testing.T) {
 }
 
 func TestUpdateSettingsPersistsPublishesAndResetsOverrides(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	before := fixture.manager.Current().Revision
 	got, err := fixture.service.UpdateSettings(t.Context(), SettingsUpdateRequest{
@@ -517,6 +532,7 @@ func TestUpdateSettingsPersistsPublishesAndResetsOverrides(t *testing.T) {
 }
 
 func TestUpdateSettingsCanonicalizesValuesAndReturnsEffectiveHeaderRules(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	fixture.service.now = func() time.Time {
 		return time.Date(2026, time.July, 24, 12, 30, 0, 0, time.FixedZone("offset", 8*60*60))
@@ -557,6 +573,7 @@ func TestUpdateSettingsCanonicalizesValuesAndReturnsEffectiveHeaderRules(t *test
 }
 
 func TestUpdateSettingsRejectsSDKOwnedCredentialHeaders(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	const (
 		authKey       = "settings-template-test-auth"
@@ -603,6 +620,7 @@ func TestUpdateSettingsRejectsSDKOwnedCredentialHeaders(t *testing.T) {
 }
 
 func TestUpdateSettingsRejectsInvalidChangesWithoutPublishing(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		updates map[string]json.RawMessage
@@ -642,6 +660,7 @@ func TestUpdateSettingsRejectsInvalidChangesWithoutPublishing(t *testing.T) {
 }
 
 func TestUpdateSettingsRollsBackAllRowsWithoutPublishing(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	if err := fixture.db.Exec(`
 		CREATE TRIGGER reject_request_timeout
@@ -680,6 +699,7 @@ func TestUpdateSettingsRollsBackAllRowsWithoutPublishing(t *testing.T) {
 }
 
 func TestSettingsUpdateRequestRejectsDuplicateUnknownAndWrongShapeJSON(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		body string
@@ -709,6 +729,7 @@ func TestSettingsUpdateRequestRejectsDuplicateUnknownAndWrongShapeJSON(t *testin
 }
 
 func TestSettingsUpdateRequestPreservesRawNullAndNumbers(t *testing.T) {
+	t.Parallel()
 	var request SettingsUpdateRequest
 	if err := json.Unmarshal([]byte(
 		`{"settings":{"request_timeout":9e2,"header_rules":null}}`,
@@ -723,6 +744,7 @@ func TestSettingsUpdateRequestPreservesRawNullAndNumbers(t *testing.T) {
 }
 
 func TestRejectDuplicateJSONFieldsWalksArraysScalarsAndTrailingValues(t *testing.T) {
+	t.Parallel()
 	for _, valid := range []string{
 		`1`,
 		`[true,null,"value",{"one":[{"two":2}]}]`,
@@ -744,6 +766,7 @@ func TestRejectDuplicateJSONFieldsWalksArraysScalarsAndTrailingValues(t *testing
 }
 
 func TestConcurrentSettingsUpdatesPublishDatabaseTruth(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	before := fixture.manager.Current().Revision
 	updates := []SettingsUpdateRequest{

--- a/internal/control/strict_json_test.go
+++ b/internal/control/strict_json_test.go
@@ -23,6 +23,7 @@ type strictJSONTestTarget struct {
 }
 
 func TestBindStrictJSONRejectsDuplicateKeysAtEveryObjectDepth(t *testing.T) {
+	t.Parallel()
 	for _, test := range []struct {
 		name string
 		body string
@@ -70,6 +71,7 @@ func TestBindStrictJSONRejectsDuplicateKeysAtEveryObjectDepth(t *testing.T) {
 }
 
 func TestBindStrictJSONPreservesJSONNumber(t *testing.T) {
+	t.Parallel()
 	const largeInteger = "900719925474099312345678901234567890"
 	var target strictJSONTestTarget
 	if err := bindStrictJSONForTest(`{"count":`+largeInteger+`}`, &target); err != nil {

--- a/internal/control/system_info_test.go
+++ b/internal/control/system_info_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestSystemInfoResponseContainsOnlySafeMetadata(t *testing.T) {
+	t.Parallel()
 	cfg := &config.Config{
 		DataDir:     "./safe-data",
 		DatabaseDSN: "file:distinctive-secret-dsn",
@@ -71,6 +72,7 @@ func TestSystemInfoResponseContainsOnlySafeMetadata(t *testing.T) {
 }
 
 func TestSystemInfoResponseUsesNullPathsForEnvironmentSources(t *testing.T) {
+	t.Parallel()
 	encoded, err := json.Marshal(newSystemInfoResponse(&config.Config{
 		AuthKeyMetadata: config.SecretMetadata{
 			Source: config.SecretSourceEnvironment,
@@ -100,6 +102,7 @@ func TestSystemInfoResponseUsesNullPathsForEnvironmentSources(t *testing.T) {
 }
 
 func TestSystemInfoResponseReportsSelectedDatabaseDriver(t *testing.T) {
+	t.Parallel()
 	for _, test := range []struct {
 		name   string
 		driver config.DatabaseDriver

--- a/internal/control/system_update_test.go
+++ b/internal/control/system_update_test.go
@@ -34,6 +34,7 @@ func (checker *recordingReleaseUpdateChecker) Check(_ context.Context, force boo
 }
 
 func TestSystemUpdateHTTPChecksOnDemandWithoutAffectingHome(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	checker := &recordingReleaseUpdateChecker{update: &releasecheck.Update{
@@ -94,6 +95,7 @@ func TestSystemUpdateHTTPChecksOnDemandWithoutAffectingHome(t *testing.T) {
 }
 
 func TestSystemUpdateHTTPReturnsNullForSuccessfulNoUpdate(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	checker := &recordingReleaseUpdateChecker{}
@@ -121,6 +123,7 @@ func TestSystemUpdateHTTPReturnsNullForSuccessfulNoUpdate(t *testing.T) {
 }
 
 func TestSystemUpdateHTTPHidesUpstreamFailureBehindBadGateway(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	checker := &recordingReleaseUpdateChecker{err: errors.New("private upstream detail")}
@@ -141,6 +144,7 @@ func TestSystemUpdateHTTPHidesUpstreamFailureBehindBadGateway(t *testing.T) {
 }
 
 func TestSystemUpdateHTTPRejectsAccessKeyAndInvalidQueryBeforeCheck(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	accessKey, err := fixture.service.CreateAccessKey(t.Context(), AccessKeyCreateRequest{Name: "read only"})

--- a/internal/control/test_helpers_test.go
+++ b/internal/control/test_helpers_test.go
@@ -31,6 +31,7 @@ import (
 	"gpt-load/internal/subscription"
 	subscriptionproviders "gpt-load/internal/subscription/providers"
 	subscriptionruntime "gpt-load/internal/subscription/runtime"
+	"gpt-load/internal/testutil/encryptiontest"
 	"gpt-load/internal/testutil/sqlitetest"
 )
 
@@ -193,10 +194,7 @@ func newServiceFixtureWithDatabase(t *testing.T, db *gorm.DB) serviceFixture {
 	manager.SetSnapshotReconciler(controlAccessQuotaReconciler{runtime: accessQuota})
 	registry := state.NewCredentialRegistry()
 	channelRegistry := channel.NewRegistry()
-	keyService, err := encryption.NewService("control-test-master-key-material-2026")
-	if err != nil {
-		t.Fatalf("encryption.NewService() error = %v", err)
-	}
+	keyService := encryptiontest.Service(t, "control-test-master-key-material-2026")
 	if _, err := manager.Publish(state.CompileInput{}); err != nil {
 		t.Fatalf("manager.Publish(empty) error = %v", err)
 	}

--- a/internal/control/usage_test.go
+++ b/internal/control/usage_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestUsageAPIRouteUsesManagementAuthentication(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	fixture.service.now = func() time.Time {
@@ -40,6 +41,7 @@ func TestUsageAPIRouteUsesManagementAuthentication(t *testing.T) {
 }
 
 func TestParseUsageQueryUsesFixedUTCAlignedWindows(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		rawQuery    string
@@ -150,6 +152,7 @@ func TestParseUsageQueryUsesFixedUTCAlignedWindows(t *testing.T) {
 }
 
 func TestUsageAPIReturnsExactPresetRange(t *testing.T) {
+	t.Parallel()
 	now := time.Date(2026, time.July, 27, 12, 34, 56, 789, time.UTC)
 	tests := []struct {
 		rangeValue    string
@@ -187,6 +190,7 @@ func TestUsageAPIReturnsExactPresetRange(t *testing.T) {
 }
 
 func TestUsageAPIReturnsDistributionWithoutCredentialIdentity(t *testing.T) {
+	t.Parallel()
 	now := time.Date(2026, time.August, 12, 8, 0, 0, 0, time.UTC)
 	other := requestlog.UsageDistributionAggregate{
 		RequestCount:         3,
@@ -271,6 +275,7 @@ func TestUsageAPIReturnsDistributionWithoutCredentialIdentity(t *testing.T) {
 }
 
 func TestUsageAPIDefaultsToFixedUTCAligned24HoursAndReturnsZeroArrays(t *testing.T) {
+	t.Parallel()
 	now := time.Date(2026, time.July, 27, 12, 34, 56, 789, time.FixedZone("UTC+8", 8*60*60))
 	reader := &recordingUsageStatReader{}
 	engine, fixture := newUsageTestEngine(t, now, reader)
@@ -355,6 +360,7 @@ func TestUsageAPIDefaultsToFixedUTCAligned24HoursAndReturnsZeroArrays(t *testing
 }
 
 func TestUsageAPIReturnsAllDistributionViewsInOneResponse(t *testing.T) {
+	t.Parallel()
 	now := time.Date(2026, time.August, 12, 8, 0, 0, 0, time.UTC)
 	reader := &recordingUsageStatReader{}
 	engine, _ := newUsageTestEngine(t, now, reader)
@@ -407,6 +413,7 @@ func TestUsageAPIReturnsAllDistributionViewsInOneResponse(t *testing.T) {
 }
 
 func TestUsageAPISelectsThirtyUTCDaysAndAppliesFilters(t *testing.T) {
+	t.Parallel()
 	now := time.Date(2026, time.July, 27, 12, 0, 0, 0, time.UTC)
 	reader := &recordingUsageStatReader{report: requestlog.UsageReport{
 		Summary: requestlog.UsageAggregate{
@@ -532,6 +539,7 @@ func TestUsageAPISelectsThirtyUTCDaysAndAppliesFilters(t *testing.T) {
 }
 
 func TestUsageAPIValidatesModelAsUTF8BytesWithoutBoundaryWhitespaceOrControls(t *testing.T) {
+	t.Parallel()
 	reader := &recordingUsageStatReader{}
 	engine, _ := newUsageTestEngine(
 		t,
@@ -577,6 +585,7 @@ func TestUsageAPIValidatesModelAsUTF8BytesWithoutBoundaryWhitespaceOrControls(t 
 }
 
 func TestUsageAPIRejectsStrictInvalidQueriesWithoutCallingReader(t *testing.T) {
+	t.Parallel()
 	reader := &recordingUsageStatReader{}
 	engine, _ := newUsageTestEngine(t, time.Date(2026, time.July, 27, 0, 0, 0, 0, time.UTC), reader)
 	tests := []struct {
@@ -633,6 +642,7 @@ func TestUsageAPIRejectsStrictInvalidQueriesWithoutCallingReader(t *testing.T) {
 }
 
 func TestMapUsageRejectsUnsafeOrMismatchedDistribution(t *testing.T) {
+	t.Parallel()
 	fixture := newServiceFixture(t)
 	query := requestlog.UsageQuery{
 		FromMS:      time.Date(2026, time.July, 27, 0, 0, 0, 0, time.UTC).UnixMilli(),
@@ -740,6 +750,7 @@ func TestMapUsageRejectsUnsafeOrMismatchedDistribution(t *testing.T) {
 }
 
 func TestUsageAPIRejectsUnsafeAggregateAndKeepsErrorsSecret(t *testing.T) {
+	t.Parallel()
 	reader := &recordingUsageStatReader{report: requestlog.UsageReport{
 		Summary: requestlog.UsageAggregate{RequestCount: 9_007_199_254_740_992},
 	}}
@@ -760,6 +771,7 @@ func TestUsageAPIRejectsUnsafeAggregateAndKeepsErrorsSecret(t *testing.T) {
 }
 
 func TestUsageAPIRejectsUnsafeProcessStatsWithoutLeakingCause(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		mutate func(*requestlog.Stats)
@@ -787,6 +799,7 @@ func TestUsageAPIRejectsUnsafeProcessStatsWithoutLeakingCause(t *testing.T) {
 }
 
 func TestUsageAPIExcludesLegacyZeroAttemptAggregateFromSQLite(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	now := time.Date(2026, time.July, 27, 12, 0, 0, 0, time.UTC)
 	fixture := newServiceFixture(t)
@@ -836,6 +849,7 @@ func TestUsageAPIExcludesLegacyZeroAttemptAggregateFromSQLite(t *testing.T) {
 }
 
 func TestUsageAPIAcceptsMaximumSafeCanonicalGroupID(t *testing.T) {
+	t.Parallel()
 	if strconv.IntSize != 64 {
 		t.Skip("maximum JavaScript safe integer does not fit uint on this architecture")
 	}
@@ -856,6 +870,7 @@ func TestUsageAPIAcceptsMaximumSafeCanonicalGroupID(t *testing.T) {
 }
 
 func TestUsageAPIRequiresManagementAuthentication(t *testing.T) {
+	t.Parallel()
 	engine, _ := newUsageTestEngine(t, time.Now(), &recordingUsageStatReader{})
 	recorder := performUsageRequest(engine, "", "")
 	if recorder.Code != http.StatusUnauthorized {
@@ -864,6 +879,7 @@ func TestUsageAPIRequiresManagementAuthentication(t *testing.T) {
 }
 
 func TestUsageAPIBindsAccessKeyScopeAndRedactsProcessHealth(t *testing.T) {
+	t.Parallel()
 	initControlI18n(t)
 	fixture := newServiceFixture(t)
 	created, err := fixture.service.CreateAccessKey(t.Context(), AccessKeyCreateRequest{

--- a/internal/control/validation_test.go
+++ b/internal/control/validation_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestValidationWorkerUsesExplicitModelAndCanonicalRepresentativeProtocol(t *testing.T) {
+	t.Parallel()
 	probes := &validationProbeRecorder{}
 	worker := newValidationWorkerForTest(
 		validationSnapshot(map[uint]state.GroupView{
@@ -101,6 +102,7 @@ func TestValidationProtocolUsesFirstNativePresetProtocolThenConfiguredFallback(t
 }
 
 func TestValidationWorkerFallsBackToFirstRealModelID(t *testing.T) {
+	t.Parallel()
 	probes := &validationProbeRecorder{}
 	worker := newValidationWorkerForTest(
 		validationSnapshot(map[uint]state.GroupView{
@@ -146,6 +148,7 @@ func TestValidationWorkerUsesResponsesProbeForResponsesOnlyGroup(t *testing.T) {
 }
 
 func TestValidationWorkerProbesStructuredCloudCredential(t *testing.T) {
+	t.Parallel()
 	group := validationGroup(nil, "anthropic.claude-test", nil)
 	setValidationChannel(&group, channel.AWSBedrock, json.RawMessage(`{"region":"us-east-1"}`))
 	worker := newValidationWorkerForTest(
@@ -197,6 +200,7 @@ func TestValidationWorkerProbesStructuredCloudCredential(t *testing.T) {
 }
 
 func TestValidationWorkerUsesNativeGeminiProbeForVertexModel(t *testing.T) {
+	t.Parallel()
 	group := validationGroup(nil, "gemini-2.5-pro", nil)
 	setValidationChannel(&group, channel.GoogleVertex, json.RawMessage(`{}`))
 	worker := newValidationWorkerForTest(
@@ -234,6 +238,7 @@ func TestValidationWorkerUsesNativeGeminiProbeForVertexModel(t *testing.T) {
 }
 
 func TestValidationSignatureUsesCanonicalLengthPrefixedEncoding(t *testing.T) {
+	t.Parallel()
 	group := validationGroup(
 		[]protocol.Protocol{protocol.OpenAICompletions}, " model-a ", nil,
 	)
@@ -260,6 +265,7 @@ func TestValidationSignatureUsesCanonicalLengthPrefixedEncoding(t *testing.T) {
 }
 
 func TestValidationSignatureChangesForEveryCoveredInput(t *testing.T) {
+	t.Parallel()
 	base := validationSignatureGroup()
 	tests := []struct {
 		name   string
@@ -317,6 +323,7 @@ func TestValidationSignatureChangesForEveryCoveredInput(t *testing.T) {
 }
 
 func TestValidationSignatureIsStableAcrossNormalizedHeaderOrder(t *testing.T) {
+	t.Parallel()
 	first := validationSignatureGroup()
 	first.HeaderRules.Set = map[string]string{
 		"X-Alpha": "first",
@@ -346,6 +353,7 @@ func TestValidationSignatureIsStableAcrossNormalizedHeaderOrder(t *testing.T) {
 }
 
 func TestValidationWorkerSkipsMissingGroupProtocolModelAndDialect(t *testing.T) {
+	t.Parallel()
 	probes := &validationProbeRecorder{}
 	snapshot := validationSnapshot(map[uint]state.GroupView{
 		1: validationGroup(nil, "", nil),
@@ -371,6 +379,7 @@ func TestValidationWorkerSkipsMissingGroupProtocolModelAndDialect(t *testing.T) 
 }
 
 func TestValidationWorkerKeepsKeyBlacklistedOnDecryptOrProbeFailure(t *testing.T) {
+	t.Parallel()
 	probes := &validationProbeRecorder{errByKey: map[string]error{"plain-key-2": errors.New("probe failed")}}
 	worker := newValidationWorkerForTest(
 		validationSnapshot(map[uint]state.GroupView{1: validationGroup([]protocol.Protocol{protocol.OpenAICompletions}, "model", nil)}),
@@ -393,6 +402,7 @@ func TestValidationWorkerKeepsKeyBlacklistedOnDecryptOrProbeFailure(t *testing.T
 }
 
 func TestValidationWorkerCoordinatesConditionalRecoveryAndStatsReset(t *testing.T) {
+	t.Parallel()
 	probes := &validationProbeRecorder{}
 	worker := newValidationWorkerForTest(
 		validationSnapshot(map[uint]state.GroupView{1: validationGroup([]protocol.Protocol{protocol.OpenAICompletions}, "model", nil)}),
@@ -436,6 +446,7 @@ func TestValidationWorkerCoordinatesConditionalRecoveryAndStatsReset(t *testing.
 }
 
 func TestValidationWorkerLogsSuccessfulRecovery(t *testing.T) {
+	// 不标记 t.Parallel()：本测试劫持了全局 logrus 输出/格式，与其他并行测试同时运行会互相覆盖断言。
 	var logs bytes.Buffer
 	logger := logrus.StandardLogger()
 	previousOutput, previousFormatter, previousLevel := logger.Out, logger.Formatter, logger.GetLevel()
@@ -477,6 +488,7 @@ func TestValidationWorkerLogsSuccessfulRecovery(t *testing.T) {
 }
 
 func TestValidationWorkerRecoverIfMatchFailsDoesNotResetStats(t *testing.T) {
+	t.Parallel()
 	probes := &validationProbeRecorder{}
 	worker := newValidationWorkerForTest(
 		validationSnapshot(map[uint]state.GroupView{1: validationGroup([]protocol.Protocol{protocol.OpenAICompletions}, "model", nil)}),
@@ -493,6 +505,7 @@ func TestValidationWorkerRecoverIfMatchFailsDoesNotResetStats(t *testing.T) {
 }
 
 func TestValidationWorkerFailureGenerationChangesDuringProbeRejectsRecovery(t *testing.T) {
+	t.Parallel()
 	now := time.Date(2026, time.July, 27, 12, 0, 0, 0, time.UTC)
 	registry := state.NewCredentialRegistry()
 	if err := registry.ReplaceCredentials([]state.CredentialEntry{{
@@ -549,6 +562,7 @@ func TestValidationWorkerFailureGenerationChangesDuringProbeRejectsRecovery(t *t
 }
 
 func TestValidationSignatureChangesDuringProbeRejectRecovery(t *testing.T) {
+	t.Parallel()
 	oldGroup := validationSignatureGroup()
 	tests := []struct {
 		name    string
@@ -609,6 +623,7 @@ func TestValidationSignatureChangesDuringProbeRejectRecovery(t *testing.T) {
 }
 
 func TestValidationWorkerUnrelatedSnapshotRevisionAllowsRecovery(t *testing.T) {
+	t.Parallel()
 	oldGroup := validationSignatureGroup()
 	worker := newValidationWorkerForTest(
 		&state.ConfigSnapshot{
@@ -643,6 +658,7 @@ func TestValidationWorkerUnrelatedSnapshotRevisionAllowsRecovery(t *testing.T) {
 }
 
 func TestValidationSignatureRemovedOrDisabledGroupRejectsRecovery(t *testing.T) {
+	t.Parallel()
 	for _, name := range []string{"removed", "disabled"} {
 		t.Run(name, func(t *testing.T) {
 			worker := newValidationWorkerForTest(
@@ -727,6 +743,7 @@ func (stats *publicationValidationStats) Reset(keyID uint) {
 }
 
 func TestValidationWorkerPublicationBoundaryBlocksPublishThroughRecoverAndReset(t *testing.T) {
+	t.Parallel()
 	manager := state.NewManager()
 	if _, err := manager.Publish(validationManagerCompileInput("https://upstream.example.com")); err != nil {
 		t.Fatalf("initial Publish() error = %v", err)
@@ -817,6 +834,7 @@ func TestValidationWorkerPublicationBoundaryBlocksPublishThroughRecoverAndReset(
 }
 
 func TestValidationSignatureMismatchLogDoesNotLeakSensitiveInputs(t *testing.T) {
+	// 不标记 t.Parallel()：本测试劫持了全局 logrus 输出/格式，与其他并行测试同时运行会互相覆盖断言。
 	var logs bytes.Buffer
 	logger := logrus.StandardLogger()
 	previousOutput, previousFormatter, previousLevel := logger.Out, logger.Formatter, logger.GetLevel()
@@ -903,6 +921,7 @@ func (coordinator *barrierValidationMutationCoordinator) Do(_ uint, fn func()) {
 }
 
 func TestValidationWorkerConditionalRecoveryFailureCompletesCoordinatorInterval(t *testing.T) {
+	t.Parallel()
 	worker := newValidationWorkerForTest(
 		validationSnapshot(map[uint]state.GroupView{1: validationGroup([]protocol.Protocol{protocol.OpenAICompletions}, "model", nil)}),
 		[]state.CredentialRef{{ID: 7, GroupID: 1, EncryptedValue: "key-7"}},
@@ -934,6 +953,7 @@ func TestValidationWorkerConditionalRecoveryFailureCompletesCoordinatorInterval(
 }
 
 func TestValidationWorkerDoesNotRecoverDisabledOrReplacedKeyRef(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name            string
 		mutate          func(t *testing.T, registry *state.CredentialRegistry)
@@ -1015,6 +1035,7 @@ func TestValidationWorkerDoesNotRecoverDisabledOrReplacedKeyRef(t *testing.T) {
 }
 
 func TestValidationWorkerFailureLogUsesSafeStructuredFields(t *testing.T) {
+	// 不标记 t.Parallel()：本测试劫持了全局 logrus 输出/格式，与其他并行测试同时运行会互相覆盖断言。
 	var logs bytes.Buffer
 	logger := logrus.StandardLogger()
 	previousOutput, previousFormatter, previousLevel := logger.Out, logger.Formatter, logger.GetLevel()
@@ -1050,6 +1071,7 @@ func TestValidationWorkerFailureLogUsesSafeStructuredFields(t *testing.T) {
 }
 
 func TestValidationWorkerLimitsGlobalConcurrencyToEight(t *testing.T) {
+	t.Parallel()
 	started := make(chan uint, 9)
 	release := make(chan struct{})
 	probes := &validationProbeRecorder{
@@ -1095,6 +1117,7 @@ func TestValidationWorkerLimitsGlobalConcurrencyToEight(t *testing.T) {
 }
 
 func TestValidationWorkerCancellationStopsDispatchAndInFlightProbes(t *testing.T) {
+	t.Parallel()
 	started := make(chan uint, 9)
 	probes := &validationProbeRecorder{
 		probe: func(ctx context.Context, _ protocol.Protocol, _ string, apiKey string) error {
@@ -1131,6 +1154,7 @@ func TestValidationWorkerCancellationStopsDispatchAndInFlightProbes(t *testing.T
 }
 
 func TestValidationWorkerDoesNotProbeQueuedJobAfterCancellation(t *testing.T) {
+	t.Parallel()
 	probes := &validationProbeRecorder{}
 	worker := newValidationWorkerForTest(
 		validationSnapshot(map[uint]state.GroupView{1: validationGroup([]protocol.Protocol{protocol.OpenAICompletions}, "model", nil)}),

--- a/internal/control/wire_v3_contract_test.go
+++ b/internal/control/wire_v3_contract_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccessKeyMillisWireOmitsLegacyTimestampKeys(t *testing.T) {
+	t.Parallel()
 	encoded, err := json.Marshal(AccessKeyMetadata{
 		ID:          7,
 		CreatedAtMS: 1_784_894_400_000,
@@ -27,6 +28,7 @@ func TestAccessKeyMillisWireOmitsLegacyTimestampKeys(t *testing.T) {
 }
 
 func TestRevealMillisWireOmitsLegacyTimestampKey(t *testing.T) {
+	t.Parallel()
 	assertManagementWireObject(
 		t,
 		AccessKeyRevealResult{ID: 7, Key: "secret", RevealedAtMS: 1_784_894_400_000},
@@ -35,6 +37,7 @@ func TestRevealMillisWireOmitsLegacyTimestampKey(t *testing.T) {
 }
 
 func TestHealthMillisWireUsesNullableEpochMilliseconds(t *testing.T) {
+	t.Parallel()
 	cooldownUntilMS := int64(1_784_894_460_000)
 	assertManagementWireObject(
 		t,
@@ -61,6 +64,7 @@ func TestHealthMillisWireUsesNullableEpochMilliseconds(t *testing.T) {
 }
 
 func TestInspectMillisWireUsesEpochMilliseconds(t *testing.T) {
+	t.Parallel()
 	cooldownUntilMS := int64(1_784_894_460_000)
 	assertManagementWireObject(
 		t,
@@ -77,6 +81,7 @@ func TestInspectMillisWireUsesEpochMilliseconds(t *testing.T) {
 }
 
 func TestHealthAndRouteInspectionUseCredentialWireNames(t *testing.T) {
+	t.Parallel()
 	healthBody, err := json.Marshal(runtimeHealthResponse{
 		Counts:                 healthCountsResponse{Credentials: 1, Available: 1},
 		CooldownCredentials:    []healthProblemCredentialResponse{{CredentialID: 7}},
@@ -129,6 +134,7 @@ func TestHealthAndRouteInspectionUseCredentialWireNames(t *testing.T) {
 }
 
 func TestRequestLogMillisCostWireUsesCursorV2Fields(t *testing.T) {
+	t.Parallel()
 	assertManagementWireObject(
 		t,
 		requestLogCursorPayload{
@@ -149,6 +155,7 @@ func TestRequestLogMillisCostWireUsesCursorV2Fields(t *testing.T) {
 }
 
 func TestUsageMillisCostWireUsesIntegerBucketsAndStringCost(t *testing.T) {
+	t.Parallel()
 	assertManagementWireObject(
 		t,
 		usageResponse{
@@ -168,6 +175,7 @@ func TestUsageMillisCostWireUsesIntegerBucketsAndStringCost(t *testing.T) {
 }
 
 func TestIdempotencyOperationMillisWireOmitsLegacyTimestampKey(t *testing.T) {
+	t.Parallel()
 	assertManagementWireObject(
 		t,
 		operationExpiredData{

--- a/internal/execution/cpa/adapter_test.go
+++ b/internal/execution/cpa/adapter_test.go
@@ -30,6 +30,7 @@ import (
 	"gpt-load/internal/subscription/providers/antigravity"
 	"gpt-load/internal/subscription/providers/codex"
 	subscriptionruntime "gpt-load/internal/subscription/runtime"
+	"gpt-load/internal/testutil/encryptiontest"
 )
 
 type fakeExecutor struct {
@@ -981,10 +982,7 @@ func newSubscriptionAdapterFixture(
 	if err := db.AutoMigrate(&models.Group{}, &models.Credential{}); err != nil {
 		t.Fatal(err)
 	}
-	keyService, err := encryption.NewService("cpa-adapter-test-encryption-key-material")
-	if err != nil {
-		t.Fatal(err)
-	}
+	keyService := encryptiontest.Service(t, "cpa-adapter-test-encryption-key-material")
 	ciphertext, err := keyService.Encrypt(string(canonical))
 	if err != nil {
 		t.Fatal(err)

--- a/internal/gateway/dialects_integration_test.go
+++ b/internal/gateway/dialects_integration_test.go
@@ -23,9 +23,9 @@ import (
 	"gpt-load/internal/execution"
 	"gpt-load/internal/health"
 	"gpt-load/internal/platform/contentcoding"
-	"gpt-load/internal/platform/encryption"
 	"gpt-load/internal/protocol"
 	"gpt-load/internal/state"
+	"gpt-load/internal/testutil/encryptiontest"
 	"gpt-load/internal/testutil/fakeupstream"
 )
 
@@ -88,10 +88,7 @@ func newDialectGatewayEngineWithForwarder(
 ) (*gin.Engine, *state.CredentialRegistry) {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
-	keyService, err := encryption.NewService("dialect-gateway-test-master-key")
-	if err != nil {
-		t.Fatalf("NewService() error = %v", err)
-	}
+	keyService := encryptiontest.Service(t, "dialect-gateway-test-master-key")
 
 	configs := make([]state.GroupConfig, 0, len(groups))
 	entries := make([]state.CredentialEntry, 0)

--- a/internal/gateway/handler_test.go
+++ b/internal/gateway/handler_test.go
@@ -32,6 +32,7 @@ import (
 	"gpt-load/internal/protocol"
 	"gpt-load/internal/ratelimit"
 	"gpt-load/internal/state"
+	"gpt-load/internal/testutil/encryptiontest"
 	"gpt-load/internal/testutil/fakeupstream"
 	"gpt-load/internal/usage"
 )
@@ -1480,10 +1481,7 @@ func TestHandlerModelEndpointsRequireValidAccessKey(t *testing.T) {
 }
 
 func TestHandlerModelEndpointHasNoDataPlaneSideEffects(t *testing.T) {
-	keyService, err := encryption.NewService("model-handler-test-master-key")
-	if err != nil {
-		t.Fatalf("NewService() error = %v", err)
-	}
+	keyService := encryptiontest.Service(t, "model-handler-test-master-key")
 	manager := state.NewManager()
 	if _, err := manager.Publish(state.CompileInput{
 		ChannelRegistry: channel.NewRegistry(),
@@ -1546,10 +1544,7 @@ func newModelListHandlerEngineWithLimit(
 	limit int64,
 ) *gin.Engine {
 	t.Helper()
-	keyService, err := encryption.NewService("model-handler-test-master-key")
-	if err != nil {
-		t.Fatalf("NewService() error = %v", err)
-	}
+	keyService := encryptiontest.Service(t, "model-handler-test-master-key")
 	manager := state.NewManager()
 	if _, err := manager.Publish(state.CompileInput{
 		ChannelRegistry: channel.NewRegistry(),
@@ -3852,10 +3847,7 @@ func TestHandlerReturnsStableTerminalReasons(t *testing.T) {
 func TestHandlerReturnsModelRequiredByFilterForProtocolOnlyRequest(t *testing.T) {
 	forwarder := &scriptedForwarder{}
 	handler, manager, _ := newHandlerForTest(t, forwarder, "sk-responses")
-	keyService, err := encryption.NewService("handler-test-master-key")
-	if err != nil {
-		t.Fatalf("NewService() error = %v", err)
-	}
+	keyService := encryptiontest.Service(t, "handler-test-master-key")
 	if _, err := manager.Publish(state.CompileInput{
 		ChannelRegistry: channel.NewRegistry(),
 		Groups: []state.GroupConfig{{ConnectionType: "api_key", ID: 1,
@@ -4050,10 +4042,7 @@ func TestHandlerKeepsFrozenSnapshotAndInjectUsageSettingAcrossRetry(t *testing.T
 		{StatusCode: http.StatusOK, Header: make(http.Header), Body: []byte(`{"ok":true}`), RequestWritten: true},
 	}}
 	engine, manager, _ := newHandlerTestRuntime(t, forwarder, "sk-one", "sk-two")
-	keyService, err := encryption.NewService("handler-test-master-key")
-	if err != nil {
-		t.Fatalf("NewService() error = %v", err)
-	}
+	keyService := encryptiontest.Service(t, "handler-test-master-key")
 	forwarder.onCall = func(index int) {
 		if index != 0 {
 			return
@@ -4135,10 +4124,7 @@ func TestHandlerSkipsCandidateChangedAfterCollection(t *testing.T) {
 				StatusCode: http.StatusOK, Header: make(http.Header), Body: []byte(`{"ok":true}`), RequestWritten: true,
 			}}}
 			_, manager, registry := newHandlerTestRuntime(t, forwarder, "sk-group-one")
-			keyService, err := encryption.NewService("handler-test-master-key")
-			if err != nil {
-				t.Fatalf("NewService() error = %v", err)
-			}
+			keyService := encryptiontest.Service(t, "handler-test-master-key")
 			runtimeRegistry := &mutatingRuntimeRegistry{
 				CredentialRegistry: registry,
 				mutate:             func() { tt.mutate(t, registry, keyService) },
@@ -4224,10 +4210,7 @@ func TestHandlerFreezesKeyIdentityAfterInspectingBody(t *testing.T) {
 				},
 			}}
 			handler, _, registry := newHandlerForTest(t, forwarder)
-			keyService, err := encryption.NewService("handler-test-master-key")
-			if err != nil {
-				t.Fatalf("NewService() error = %v", err)
-			}
+			keyService := encryptiontest.Service(t, "handler-test-master-key")
 			recordingEncryption := &recordingDecryptEncryption{Service: keyService}
 			handler.encryption = recordingEncryption
 			engine := gin.New()
@@ -4381,10 +4364,7 @@ func TestHandlerAllowsCapturedUnavailableIdentityAfterRecovery(t *testing.T) {
 			handler.newRandom = func() *rand.Rand { return rand.New(zeroSource{}) }
 			engine := gin.New()
 			bindGatewayRoutesForTest(t, engine, handler)
-			keyService, err := encryption.NewService("handler-test-master-key")
-			if err != nil {
-				t.Fatalf("NewService() error = %v", err)
-			}
+			keyService := encryptiontest.Service(t, "handler-test-master-key")
 			encrypt := func(plaintext string) string {
 				t.Helper()
 				return encryptTestCredentialValue(t, keyService, plaintext)
@@ -4450,10 +4430,7 @@ func TestHandlerAllowsCapturedUnavailableIdentityAfterRecovery(t *testing.T) {
 func newRealGatewayEngine(t *testing.T, upstreamURL string, upstreamKeys ...string) *gin.Engine {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
-	keyService, err := encryption.NewService("handler-test-master-key")
-	if err != nil {
-		t.Fatalf("NewService() error = %v", err)
-	}
+	keyService := encryptiontest.Service(t, "handler-test-master-key")
 	manager := state.NewManager()
 	baseURL := testUpstreamBaseURL(upstreamURL, protocol.OpenAICompletions)
 	channelID, params := testChannelConfig(t, protocol.OpenAICompletions, baseURL)
@@ -4552,10 +4529,7 @@ func newHandlerForTestWithStats(
 ) (*Handler, *state.Manager, *state.CredentialRegistry) {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
-	keyService, err := encryption.NewService("handler-test-master-key")
-	if err != nil {
-		t.Fatalf("NewService() error = %v", err)
-	}
+	keyService := encryptiontest.Service(t, "handler-test-master-key")
 	manager := state.NewManager()
 	credentialConfigs := make([]state.CredentialConfig, 0, len(upstreamKeys))
 	for index := range upstreamKeys {
@@ -4620,10 +4594,7 @@ func newConvertedFallbackHandlerTestRuntime(
 ) (*gin.Engine, *state.CredentialRegistry) {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
-	keyService, err := encryption.NewService("handler-conversion-fallback-test-key")
-	if err != nil {
-		t.Fatalf("NewService() error = %v", err)
-	}
+	keyService := encryptiontest.Service(t, "handler-conversion-fallback-test-key")
 	channelRegistry := channel.NewRegistry()
 	manager := state.NewManager()
 	groups := []state.GroupConfig{

--- a/internal/gateway/proxy_test.go
+++ b/internal/gateway/proxy_test.go
@@ -4,17 +4,14 @@ import (
 	"testing"
 
 	"gpt-load/internal/outboundproxy"
-	"gpt-load/internal/platform/encryption"
 	"gpt-load/internal/state"
+	"gpt-load/internal/testutil/encryptiontest"
 )
 
 func TestResolveAttemptProxyUsesCredentialOverrideAndVerifiesFingerprint(t *testing.T) {
 	t.Parallel()
 
-	crypto, err := encryption.NewService("gateway-proxy-test-key-material-2026")
-	if err != nil {
-		t.Fatal(err)
-	}
+	crypto := encryptiontest.Service(t, "gateway-proxy-test-key-material-2026")
 	config := outboundproxy.Config{Mode: outboundproxy.ModeCustom, URL: "socks5://user:password@proxy.example.com:1080"}
 	encoded, err := outboundproxy.Encode(config)
 	if err != nil {

--- a/internal/gateway/request_log_test.go
+++ b/internal/gateway/request_log_test.go
@@ -25,7 +25,6 @@ import (
 	"gpt-load/internal/execution"
 	"gpt-load/internal/health"
 	"gpt-load/internal/httplifecycle"
-	"gpt-load/internal/platform/encryption"
 	"gpt-load/internal/platform/redact"
 	"gpt-load/internal/pricing"
 	"gpt-load/internal/protocol"
@@ -34,6 +33,7 @@ import (
 	"gpt-load/internal/scheduler"
 	"gpt-load/internal/state"
 	"gpt-load/internal/telemetry"
+	"gpt-load/internal/testutil/encryptiontest"
 	"gpt-load/internal/usage"
 )
 
@@ -1635,10 +1635,7 @@ func TestHandlerRPMAdmissionOrderingAndSingleCharge(t *testing.T) {
 }
 
 func TestHandlerUsesFrozenRPMLimitAcrossSnapshotPublish(t *testing.T) {
-	keyService, err := encryption.NewService("frozen-rpm-test-master-key")
-	if err != nil {
-		t.Fatalf("NewService() error = %v", err)
-	}
+	keyService := encryptiontest.Service(t, "frozen-rpm-test-master-key")
 	manager := state.NewManager()
 	publish := func(limit int64) {
 		t.Helper()

--- a/internal/gateway/stream_integration_test.go
+++ b/internal/gateway/stream_integration_test.go
@@ -28,9 +28,9 @@ import (
 	"gpt-load/internal/dialect"
 	"gpt-load/internal/health"
 	"gpt-load/internal/platform/config"
-	"gpt-load/internal/platform/encryption"
 	"gpt-load/internal/protocol"
 	"gpt-load/internal/state"
+	"gpt-load/internal/testutil/encryptiontest"
 	"gpt-load/internal/testutil/fakeupstream"
 )
 
@@ -855,10 +855,7 @@ type streamGatewayGroup struct {
 func newStreamingGatewayEngine(t *testing.T, groups ...streamGatewayGroup) (*gin.Engine, *state.CredentialRegistry) {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
-	keyService, err := encryption.NewService("stream-handler-test-master-key")
-	if err != nil {
-		t.Fatalf("NewService() error = %v", err)
-	}
+	keyService := encryptiontest.Service(t, "stream-handler-test-master-key")
 
 	groupConfigs := make([]state.GroupConfig, 0, len(groups))
 	entries := make([]state.CredentialEntry, 0, len(groups))

--- a/internal/state/loader/loader_test.go
+++ b/internal/state/loader/loader_test.go
@@ -21,8 +21,8 @@ import (
 	"gpt-load/internal/protocol"
 	"gpt-load/internal/state"
 	"gpt-load/internal/state/loader"
-	"gpt-load/internal/storage"
 	"gpt-load/internal/storage/models"
+	"gpt-load/internal/testutil/sqlitetest"
 )
 
 func TestBuildCompileInputWithProxyDecryptsGlobalAndGroupPolicies(t *testing.T) {
@@ -959,24 +959,7 @@ func TestLoaderRejectsInvalidCredentialRowsWithoutPublishing(t *testing.T) {
 
 func openMigratedDatabase(t *testing.T) *gorm.DB {
 	t.Helper()
-
-	db, err := storage.Open(":memory:")
-	if err != nil {
-		t.Fatalf("storage.Open(:memory:) error = %v", err)
-	}
-	sqlDB, err := db.DB()
-	if err != nil {
-		t.Fatalf("db.DB() error = %v", err)
-	}
-	t.Cleanup(func() {
-		if err := sqlDB.Close(); err != nil {
-			t.Errorf("close database: %v", err)
-		}
-	})
-	if err := storage.AutoMigrate(db); err != nil {
-		t.Fatalf("storage.AutoMigrate() error = %v", err)
-	}
-	return db
+	return sqlitetest.OpenMigrated(t)
 }
 
 func mustCreate(t *testing.T, db *gorm.DB, value any) {

--- a/internal/subscription/credential_manager_test.go
+++ b/internal/subscription/credential_manager_test.go
@@ -23,6 +23,7 @@ import (
 	subscriptionproviders "gpt-load/internal/subscription/providers"
 	"gpt-load/internal/subscription/providers/codex"
 	subscriptionruntime "gpt-load/internal/subscription/runtime"
+	"gpt-load/internal/testutil/encryptiontest"
 )
 
 type failingEncryptService struct {
@@ -304,10 +305,7 @@ func newCredentialManagerFixture(
 	if err := db.AutoMigrate(&models.Group{}, &models.Credential{}); err != nil {
 		t.Fatal(err)
 	}
-	keyService, err := encryption.NewService("subscription-manager-test-encryption-key-material")
-	if err != nil {
-		t.Fatal(err)
-	}
+	keyService := encryptiontest.Service(t, "subscription-manager-test-encryption-key-material")
 	ciphertext, err := keyService.Encrypt(string(canonical))
 	if err != nil {
 		t.Fatal(err)

--- a/internal/testutil/encryptiontest/encryptiontest.go
+++ b/internal/testutil/encryptiontest/encryptiontest.go
@@ -1,0 +1,33 @@
+package encryptiontest
+
+import (
+	"sync"
+	"testing"
+
+	"gpt-load/internal/platform/encryption"
+)
+
+var (
+	mu       sync.Mutex
+	services = map[string]encryption.Service{}
+)
+
+// Service returns an encryption.Service derived from keyMaterial, reusing a
+// previously derived instance for the same keyMaterial within this test
+// binary. PBKDF2 key derivation dominates fixture construction cost across
+// packages; aesService is stateless after construction, so sharing an
+// instance across fixtures (including parallel tests) is safe.
+func Service(t *testing.T, keyMaterial string) encryption.Service {
+	t.Helper()
+	mu.Lock()
+	defer mu.Unlock()
+	if svc, ok := services[keyMaterial]; ok {
+		return svc
+	}
+	svc, err := encryption.NewService(keyMaterial)
+	if err != nil {
+		t.Fatalf("encryption.NewService(%q) error = %v", keyMaterial, err)
+	}
+	services[keyMaterial] = svc
+	return svc
+}

--- a/internal/testutil/encryptiontest/encryptiontest.go
+++ b/internal/testutil/encryptiontest/encryptiontest.go
@@ -14,9 +14,11 @@ var (
 
 // Service returns an encryption.Service derived from keyMaterial, reusing a
 // previously derived instance for the same keyMaterial within this test
-// binary. PBKDF2 key derivation dominates fixture construction cost across
-// packages; aesService is stateless after construction, so sharing an
-// instance across fixtures (including parallel tests) is safe.
+// binary (each package's go test run is a separate process, so this cache
+// does not span packages). PBKDF2 key derivation dominates fixture
+// construction cost in several packages; aesService is stateless after
+// construction, so sharing an instance across fixtures (including parallel
+// tests) within one package is safe.
 func Service(t *testing.T, keyMaterial string) encryption.Service {
 	t.Helper()
 	mu.Lock()

--- a/internal/webui/workflow_test.go
+++ b/internal/webui/workflow_test.go
@@ -1430,7 +1430,8 @@ func TestReleaseWorkflowVerifiesDownloadedNativeChecksumsAndGeneratedKeys(t *tes
 	nativePowerShellImplementation := readRepositoryFile(t, ".github/scripts/release-native-smoke.ps1")
 	nativeImplementation := nativeJob + nativeShellImplementation + nativePowerShellImplementation
 	for _, required := range []string{
-		"name: release-assets",
+		"name: binary-${{ matrix.filename }}",
+		"name: release-checksums",
 		"SHA256SUMS",
 		"sha256sum",
 		"shasum -a 256",


### PR DESCRIPTION
### 关联 Issue / Related Issue
N/A

### 变更内容 / Change Content
- [ ] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [x] 其他改动 / Other changes

CI 全绿约 9 分钟、Release 全绿约 13 分钟，排查后按根因横向修复测试性能问题，并优化 workflow 结构。

**测试性能（按根因横向修复，而非逐包修复）**：
- 消除 388+ 次重复的 PBKDF2（10 万轮 SHA256）密钥派生：`internal/control` 测试 fixture 改为共享单例；新增 `internal/testutil/encryptiontest` 提供按 key material 值 memoize 的共享 `encryption.Service`，横向覆盖 `gateway`、`subscription`、`execution/cpa` 中同样存在的重复派生。
- `internal/state/loader` 的 21 次 `openMigratedDatabase` 调用改为复用 `sqlitetest.OpenMigrated` 的 schema 模板缓存，不再每次完整走迁移注册表。
- 逐点排查后明确排除 `app`、`container`、`requestlog` 部分调用点——分别因为是被测启动流程本身、依赖真实迁移账本状态、或依赖真实磁盘文件路径，不适用同一手法。
- 本地实测（用户环境）全量 `go test -race -count=1 . ./internal/...`：4m31s → 1m30s。

**CI / Release workflow 结构优化**：
- `race-tests` 建立独立的 `setup-go` 缓存命名空间：此前与 `test`/`database-contract(*)` 共用同一个基于 `go.sum` 的缓存 key，命中即不保存，race-instrumented `GOCACHE` 永远无法写回，每次都要重新完整编译（约 124s）。**该收益需连续两次运行才能体现**（首次运行 cache key 是新的，必然 miss）；且 `release.yml` 中的 `race-tests` 会在同 commit CI 已验证通过时跳过，要观察这项收益应看 `ci.yml` 在 `v2` 上连续两次的运行耗时，而非发布流程。
- 移除 `publish-images` 中零命中的 GHA buildx image cache：两次真实 beta 发布实测均为 0 命中层，且 cache 导出子步骤失败会拖累整个推送步骤失败，导致下游 job 被判定为 `partial`/`blocked` 卡住重试，移除后此风险一并消除。
- 三个只读 job（`publication-preflight`、`post-publish-verify`、`reconcile-publication`，均只用 `docker buildx imagetools` 查询）移除多余的 buildx 初始化，已确认 `ubuntu-24.04` runner 默认预装 Buildx。
- `native-artifact-smoke` 改为按需下载单个 binary + 独立 checksums，不再下载完整 `release-assets`（145MB）；同步更新了 `internal/webui/workflow_test.go` 中对下载方式的既有断言。

验证：
- `make check`（含全量 `go test -count=1 . ./internal/...`，58 包 ok）
- `go test -count=1 -run TestReleaseWorkflow ./internal/webui/...`
- `ruby -ryaml` 校验 workflow YAML 语法（未引入新依赖）
- 用户本地 `go test -race -count=1 . ./internal/...` 全量验证

无法本地验证的部分：GHA cache 的实际命中率与 `publish-images` 等 job 的真实墙钟耗时收益，依赖 GitHub 云端基础设施状态，需通过后续真实 tag 推送观测。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.（测试基础设施与 CI/CD 内部配置调整，不涉及用户可见功能或公开文档）
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.（不涉及数据迁移或对外契约变更）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **发布流程改进**
  * 优化发布产物与校验和的处理及验证流程，提升发布可靠性。
  * 精简发布验证步骤，减少不必要的构建操作。
  * 隔离竞态测试缓存，降低不同测试任务间的相互影响。

* **测试与质量**
  * 统一加密服务和数据库测试环境初始化方式，提升测试稳定性。
  * 扩大测试并行执行范围，加快测试反馈，同时保持既有业务行为与验证结果不变。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->