### PR TITLE
perf(release): 镜像复用预编译产物 + GOPROXY 网络容错

### DIFF
--- a/.github/scripts/release-docker-smoke.sh
+++ b/.github/scripts/release-docker-smoke.sh
@@ -12,7 +12,8 @@ build_target="${RELEASE_SMOKE_BUILD_TARGET:-}"
 case "${build_target}" in
   "" | prebuilt | source-build) ;;
   *)
-    printf 'RELEASE_SMOKE_BUILD_TARGET must be empty, prebuilt, or source-build\n' >&2
+    printf 'RELEASE_SMOKE_BUILD_TARGET must be empty, prebuilt, or source-build; got %s\n' \
+      "${build_target}" >&2
     exit 1
     ;;
 esac

--- a/.github/scripts/release-docker-smoke.sh
+++ b/.github/scripts/release-docker-smoke.sh
@@ -7,6 +7,15 @@ suffix="${RELEASE_SMOKE_SUFFIX:-local-$$}"
 source_image="${RELEASE_SMOKE_SOURCE_IMAGE:-}"
 trivy_image="${RELEASE_SMOKE_TRIVY_IMAGE:-aquasec/trivy:0.72.0@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f}"
 skip_scan="${RELEASE_SMOKE_SKIP_SCAN:-false}"
+# 留空构建默认 target（源码自包含构建）；发布流程用 prebuilt 验证真正的打包路径。
+build_target="${RELEASE_SMOKE_BUILD_TARGET:-}"
+case "${build_target}" in
+  "" | prebuilt | source-build) ;;
+  *)
+    printf 'RELEASE_SMOKE_BUILD_TARGET must be empty, prebuilt, or source-build\n' >&2
+    exit 1
+    ;;
+esac
 case "${skip_scan}" in
   true | false) ;;
   *)
@@ -124,8 +133,13 @@ if [[ -n "${source_image}" ]]; then
   docker pull --platform "${platform}" "${source_image}"
   docker image tag "${source_image}" "${image}"
 else
+  build_target_args=()
+  if [[ -n "${build_target}" ]]; then
+    build_target_args+=(--target "${build_target}")
+  fi
   docker build \
     --platform "${platform}" \
+    "${build_target_args[@]}" \
     --build-arg "VERSION=${release_version}" \
     -t "${image}" .
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ on:
 permissions:
   contents: read
 
+# 竖线分隔在任何错误（含网络错误）时回退到下一个源；默认的逗号只在
+# 404/410 时回退，proxy.golang.org 瞬时故障会直接让整个 job 失败。
+env:
+  GOPROXY: https://proxy.golang.org|direct
+
 concurrency:
   group: v2-ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -526,6 +526,35 @@ jobs:
           RELEASE_SMOKE_TRIVY_IMAGE: aquasec/trivy:0.72.0@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f
         run: .github/scripts/release-docker-smoke.sh
 
+  prebuilt-image-smoke:
+    # publish-images 实际推送的是 prebuilt target，必须在发布前用完全相同的打包
+    # 路径做 smoke 与漏洞扫描；docker-smoke 覆盖的源码自包含构建是另一条路径，
+    # 两者互相不能替代，删除任一个都会让一条发布路径失去发布前验证。
+    needs: build-binaries
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout tag commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Download prebuilt Linux binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: binary-gpt-load-linux-*
+          path: release
+          merge-multiple: true
+
+      - name: Build and smoke prebuilt image
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ github.ref_name }}
+          RELEASE_SMOKE_SUFFIX: prebuilt-${{ github.run_id }}
+          RELEASE_SMOKE_TRIVY_IMAGE: aquasec/trivy:0.72.0@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f
+          RELEASE_SMOKE_BUILD_TARGET: prebuilt
+        run: .github/scripts/release-docker-smoke.sh
+
   publication-preflight:
     # 这里必须逐个列出全部 gate，即使其中几个已被别的 needs 间接依赖：
     # 下面的 if 只能看到直接 needs 的 result，上游失败会让中间 job 变成 skipped，
@@ -540,6 +569,7 @@ jobs:
       - package-checksums
       - native-artifact-smoke
       - docker-smoke
+      - prebuilt-image-smoke
       - database-contract
     # race-tests、race-cpa 与 database-contract 在 CI 已验证同一 commit 时为 skipped，
     # 这里只拒绝真正失败的 gate，不把 skipped 当作缺失的验证。
@@ -811,6 +841,14 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Download prebuilt Linux binaries
+        if: ${{ needs.publication-preflight.outputs.write_mode == 'publish' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: binary-gpt-load-linux-*
+          path: release
+          merge-multiple: true
+
       - name: Set up QEMU
         if: ${{ needs.publication-preflight.outputs.write_mode == 'publish' }}
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
@@ -861,6 +899,9 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
+          # prebuilt 直接打包 build-binaries 已交叉编译好的产物，不在镜像内重复
+          # 编译 Go 与 Web；镜像内二进制与同名 native 发布产物是同一个文件。
+          target: prebuilt
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ on:
 permissions:
   contents: read
 
+# 竖线分隔在任何错误（含网络错误）时回退到下一个源；默认的逗号只在
+# 404/410 时回退，proxy.golang.org 瞬时故障会直接让整个 job 失败。
+env:
+  GOPROXY: https://proxy.golang.org|direct
+
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -527,11 +527,23 @@ jobs:
         run: .github/scripts/release-docker-smoke.sh
 
   prebuilt-image-smoke:
+    name: Prebuilt image smoke (${{ matrix.arch }})
     # publish-images 实际推送的是 prebuilt target，必须在发布前用完全相同的打包
     # 路径做 smoke 与漏洞扫描；docker-smoke 覆盖的源码自包含构建是另一条路径，
     # 两者互相不能替代，删除任一个都会让一条发布路径失去发布前验证。
     needs: build-binaries
-    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # publish-images 推送 linux/amd64 与 linux/arm64 两个平台，两条 prebuilt
+          # 路径 COPY 的是不同的二进制，必须各自验证。使用原生 arm64 runner 而非
+          # QEMU：QEMU 模拟下的启动行为不能代表真实 arm64 运行时。
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     steps:
       - name: Checkout tag commit
@@ -539,18 +551,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Download prebuilt Linux binaries
+      - name: Download prebuilt Linux binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: binary-gpt-load-linux-*
+          name: binary-gpt-load-linux-${{ matrix.arch }}
           path: release
-          merge-multiple: true
 
       - name: Build and smoke prebuilt image
         shell: bash
         env:
           RELEASE_VERSION: ${{ github.ref_name }}
-          RELEASE_SMOKE_SUFFIX: prebuilt-${{ github.run_id }}
+          RELEASE_SMOKE_SUFFIX: prebuilt-${{ matrix.arch }}-${{ github.run_id }}
           RELEASE_SMOKE_TRIVY_IMAGE: aquasec/trivy:0.72.0@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f
           RELEASE_SMOKE_BUILD_TARGET: prebuilt
         run: .github/scripts/release-docker-smoke.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,11 @@ FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine3.24@sha256:af8d6740070b8906d
 ARG VERSION=2.0.0-dev
 ARG TARGETOS
 ARG TARGETARCH
+# GOPROXY 使用竖线分隔：任何错误（含网络错误）都回退到下一个源。
+# 默认的逗号只在 404/410 时回退，模块代理瞬时故障会直接中断构建。
 ENV GO111MODULE=on \
-    CGO_ENABLED=0
+    CGO_ENABLED=0 \
+    GOPROXY="https://proxy.golang.org|direct"
 
 WORKDIR /build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,10 @@ RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -o gpt-load
 
 
-FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+# runtime 是两条打包路径共用的唯一 runtime 定义：默认的源码自包含构建，
+# 以及发布流程复用 build-binaries 预编译产物的 prebuilt。两者只有二进制来源
+# 不同，其余 runtime 配置全部在这里定义一次，避免出现两套配置各自漂移。
+FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS runtime
 
 WORKDIR /app
 RUN apk add --no-cache ca-certificates tzdata \
@@ -51,7 +54,6 @@ RUN apk add --no-cache ca-certificates tzdata \
 
 ENV HOST=0.0.0.0
 ENV DATA_DIR=/app/data
-COPY --from=go-builder /build/gpt-load .
 COPY LICENSE THIRD_PARTY_NOTICES.md /app/licenses/
 COPY LICENSES/Apache-2.0.txt /app/licenses/Apache-2.0.txt
 COPY LICENSES/MIT.txt /app/licenses/MIT.txt
@@ -59,3 +61,19 @@ COPY LICENSES/MPL-2.0.txt /app/licenses/MPL-2.0.txt
 EXPOSE 3001 1455 54545 51121
 USER 10001:10001
 ENTRYPOINT ["/app/gpt-load"]
+
+
+# 发布路径：直接打包 build-binaries 已交叉编译好的二进制，不在镜像内重复编译。
+# 需要 build context 中存在 release/gpt-load-linux-<arch>。
+FROM runtime AS prebuilt
+
+ARG TARGETARCH
+# GitHub Actions 的 artifact 不保留可执行位，必须在复制时显式恢复为 0755。
+COPY --chmod=0755 release/gpt-load-linux-${TARGETARCH} /app/gpt-load
+
+
+# 默认 target：自包含的源码构建，供本地 `docker build .` 与用户自建使用。
+# 必须保持在文件末尾，否则默认构建会落到 prebuilt 而要求预编译产物。
+FROM runtime AS source-build
+
+COPY --from=go-builder /build/gpt-load .

--- a/internal/webui/container_contract_test.go
+++ b/internal/webui/container_contract_test.go
@@ -204,13 +204,31 @@ func TestOrdinaryNetworkConfigurationExposesOnlyHostAndPort(t *testing.T) {
 
 func TestDockerfileFinalStageDeclaresNonRootPersistentRuntime(t *testing.T) {
 	content := readRepositoryFile(t, "Dockerfile")
-	finalStageIndex := strings.LastIndex(content, "\nFROM ")
-	if finalStageIndex < 0 {
-		t.Fatal("Dockerfile does not contain a final stage")
+	// runtime 是唯一的 runtime 定义，源码自包含构建与发布用的 prebuilt 都继承它。
+	// 每个可发布 stage 必须以它为基，否则某条打包路径会绕开下面全部 runtime 断言。
+	runtimeIndex := strings.Index(content, "\nFROM alpine:")
+	if runtimeIndex < 0 {
+		t.Fatal("Dockerfile does not contain the shared runtime stage")
 	}
-	finalStage := content[finalStageIndex:]
+	if !strings.Contains(content[runtimeIndex:], "AS runtime\n") {
+		t.Fatal("Dockerfile runtime stage is not named runtime")
+	}
+	nextStageIndex := strings.Index(content[runtimeIndex+1:], "\nFROM ")
+	if nextStageIndex < 0 {
+		t.Fatal("Dockerfile does not derive any stage from the shared runtime stage")
+	}
+	finalStage := content[runtimeIndex : runtimeIndex+1+nextStageIndex]
+	for _, derived := range []string{"FROM runtime AS prebuilt", "FROM runtime AS source-build"} {
+		if !strings.Contains(content, derived) {
+			t.Fatalf("Dockerfile does not derive a publishable stage via %q", derived)
+		}
+	}
+	// 除 runtime 自身外，不允许出现直接以 alpine 为基的可发布 stage。
+	if strings.Count(content, "\nFROM alpine:") != 1 {
+		t.Fatal("Dockerfile declares a publishable stage that bypasses the shared runtime stage")
+	}
 	if !strings.Contains(finalStage, "EXPOSE 3001 1455 54545 51121") {
-		t.Fatal("Dockerfile final stage does not expose the application and all fixed OAuth callback ports")
+		t.Fatal("Dockerfile runtime stage does not expose the application and all fixed OAuth callback ports")
 	}
 
 	orderedBeforeUser := []string{


### PR DESCRIPTION
### 关联 Issue / Related Issue
N/A

### 变更内容 / Change Content
- [ ] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [x] 其他改动 / Other changes

承接 #465，继续优化发布流水线。当前 release 全绿约 563s，其中 `publish-images` 单项占 242s（43%）。

**1. `publish-images` 复用预编译产物（预期 -180s 量级）**

`build-binaries` 已交叉编译出 `gpt-load-linux-amd64`/`arm64`，正是镜像需要的文件；但 `publish-images` 此前在 Docker 内从 `go mod download` 开始把 Go 与 Web 重新编译一遍（两平台各一次，实测 216s）。

Dockerfile 拆出共享 `runtime` stage，两条打包路径都以它为基：
- `source-build`：默认 target，自包含源码构建，供本地与用户自建；保持在文件末尾，否则默认构建会落到 `prebuilt` 而要求预编译产物
- `prebuilt`：发布用，直接 `COPY --chmod=0755` 预编译二进制（GitHub artifact 不保留可执行位，必须显式恢复）

runtime 配置只定义一次，避免两套配置漂移。副作用是镜像内二进制与同名 native 发布产物成为同一个文件，一致性更强。

**2. 发布证据链：新增 `prebuilt-image-smoke`**

发布前的 smoke 与 Trivy 扫描必须针对**真正的打包路径**。新增该 job，用与 `publish-images` 完全相同的 `prebuilt` target 做 smoke + 漏洞扫描，并加入 `publication-preflight` 的 `needs`；`docker-smoke` 继续覆盖源码自包含路径。两者互不可替代，删除任一个都会让一条路径失去发布前验证。

代价：该 job 依赖 `build-binaries`，会成为关键路径上的新节点（预估 +15~45s），但相对 `publish-images` 省下的时间仍是大幅净收益。

**3. GOPROXY 网络容错（可靠性，非性能）**

默认 `GOPROXY=https://proxy.golang.org,direct` 用逗号分隔，**只在 404/410 时回退**；`proxy.golang.org` 的瞬时网络故障（如实际遇到的 HTTP/2 `stream INTERNAL_ERROR`）会直接让 job 失败，默认配置里的 `direct` 后备源在最需要它时形同虚设。改用竖线分隔，任何错误都回退。

实验验证：逗号 → 首个源 EOF 直接失败；竖线 → 成功回退并完成下载。不引入第三方镜像源，避免为发布链路增加新的信任方。

**4. 既有测试契约同步更新**

`container_contract_test.go` 原用「最后一个 `FROM`」定位 runtime 契约，多 stage 后不再成立。改为定位共享 `runtime` stage，并**新增两条断言**：每个可发布 stage 必须派生自 `runtime`、除 `runtime` 外不得再有直接以 alpine 为基的 stage——防止将来新增打包路径绕开全部 runtime 断言。已反向验证两条断言都能拦截对应破坏方式。

验证：
- `make check`（58 包 ok，0 FAIL）
- 本地实跑 `release-docker-smoke.sh` 完整验证 prebuilt 镜像：`--chmod` 恢复可执行位、非 root(10001) 运行、数据目录权限、健康检查、Web UI、认证边界全部通过
- 删除 `release/` 后默认 target 仍能正常源码构建
- 反向验证新增断言的防护力
- YAML 语法（`ruby -ryaml`）、`bash -n` 脚本语法

未验证范围：`publish-images` 的真实耗时收益与多平台 QEMU 打包行为，需真实 tag 触发 `release.yml` 观测。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.（CI/CD 与镜像打包内部调整，默认 `docker build .` 行为不变，不影响用户可见接口）
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.（不涉及数据迁移；镜像 runtime 配置与对外契约完全不变）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 发布镜像支持使用预编译二进制构建，减少重复编译。
  - Docker 构建支持选择 `prebuilt` 或 `source-build` 模式，并提供参数校验。
  - 支持多平台预编译镜像发布。

- **改进**
  - 优化 Go 依赖下载失败时的回退机制，提升构建稳定性。
  - 发布流程新增镜像运行验证与安全扫描，确保发布镜像可用。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->