### PR TITLE
fix(gateway): 完善统一错误规则

### DIFF
--- a/internal/execution/cpa/adapter.go
+++ b/internal/execution/cpa/adapter.go
@@ -6,7 +6,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -480,10 +482,27 @@ func unaryExecutionError(
 	credential providerCredential,
 ) execution.AttemptResult {
 	status, evidence := provider.ClassifyError(ctx, err, credential)
+	dispatchState := execution.DispatchMaybeSent
+	if status == 0 && definitelyNotSentNetworkError(err) {
+		dispatchState = execution.DispatchNotSent
+	}
 	return execution.AttemptResult{
-		DispatchState: execution.DispatchMaybeSent, ResponseStarted: status != 0,
+		DispatchState: dispatchState, ResponseStarted: status != 0,
 		StatusCode: status, Error: evidence,
 	}
+}
+
+func definitelyNotSentNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var dnsError *net.DNSError
+	if errors.As(err, &dnsError) && dnsError != nil {
+		return true
+	}
+	var operationError *net.OpError
+	return errors.As(err, &operationError) && operationError != nil &&
+		strings.EqualFold(strings.TrimSpace(operationError.Op), "dial")
 }
 
 func streamExecutionError(

--- a/internal/execution/cpa/adapter.go
+++ b/internal/execution/cpa/adapter.go
@@ -497,13 +497,12 @@ func definitelyNotSentNetworkError(err error) bool {
 	if err == nil {
 		return false
 	}
-	var dnsError *net.DNSError
-	if errors.As(err, &dnsError) && dnsError != nil {
-		return true
-	}
 	var operationError *net.OpError
-	return errors.As(err, &operationError) && operationError != nil &&
-		strings.EqualFold(strings.TrimSpace(operationError.Op), "dial")
+	if errors.As(err, &operationError) && operationError != nil {
+		return strings.EqualFold(strings.TrimSpace(operationError.Op), "dial")
+	}
+	var dnsError *net.DNSError
+	return errors.As(err, &dnsError) && dnsError != nil
 }
 
 func streamExecutionError(

--- a/internal/execution/cpa/adapter.go
+++ b/internal/execution/cpa/adapter.go
@@ -483,7 +483,8 @@ func unaryExecutionError(
 ) execution.AttemptResult {
 	status, evidence := provider.ClassifyError(ctx, err, credential)
 	dispatchState := execution.DispatchMaybeSent
-	if status == 0 && definitelyNotSentNetworkError(err) {
+	if status == 0 && (evidence == nil || evidence.StatusCode == 0) &&
+		definitelyNotSentNetworkError(err) {
 		dispatchState = execution.DispatchNotSent
 	}
 	return execution.AttemptResult{

--- a/internal/execution/cpa/adapter_test.go
+++ b/internal/execution/cpa/adapter_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"reflect"
 	"strings"
@@ -981,6 +982,43 @@ type statusError struct {
 
 func (e statusError) Error() string   { return e.message }
 func (e statusError) StatusCode() int { return e.status }
+
+func TestUnaryExecutionErrorDistinguishesDefinitelyUnsentNetworkFailures(t *testing.T) {
+	t.Parallel()
+
+	bridge := newCodexProviderBridge()
+	credential := codexProviderCredential{}
+	tests := []struct {
+		name string
+		err  error
+		want execution.DispatchState
+	}{
+		{
+			name: "DNS lookup failed",
+			err:  &net.DNSError{Err: "no such host", Name: "upstream.invalid"},
+			want: execution.DispatchNotSent,
+		},
+		{
+			name: "dial failed",
+			err:  &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")},
+			want: execution.DispatchNotSent,
+		},
+		{
+			name: "read failed",
+			err:  &net.OpError{Op: "read", Net: "tcp", Err: io.ErrUnexpectedEOF},
+			want: execution.DispatchMaybeSent,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := unaryExecutionError(t.Context(), bridge, test.err, credential)
+			if result.DispatchState != test.want {
+				t.Fatalf("unaryExecutionError() dispatch = %q, want %q", result.DispatchState, test.want)
+			}
+		})
+	}
+}
 
 func newAdapterFixture(t *testing.T, canonical []byte) (*Adapter, *gorm.DB, *state.CredentialRegistry, encryption.Service, models.Credential) {
 	t.Helper()

--- a/internal/execution/cpa/adapter_test.go
+++ b/internal/execution/cpa/adapter_test.go
@@ -1018,6 +1018,19 @@ func TestUnaryExecutionErrorDistinguishesDefinitelyUnsentNetworkFailures(t *test
 			}
 		})
 	}
+
+	responseEvidence := &recordingProviderBridge{
+		classificationEvidence: &execution.ErrorEvidence{
+			Kind: execution.ErrorKindHTTP, StatusCode: http.StatusBadGateway,
+			Summary: "upstream response started",
+		},
+	}
+	result := unaryExecutionError(t.Context(), responseEvidence, &net.DNSError{
+		Err: "no such host", Name: "upstream.invalid",
+	}, nil)
+	if result.DispatchState != execution.DispatchMaybeSent {
+		t.Fatalf("evidence status dispatch = %q, want %q", result.DispatchState, execution.DispatchMaybeSent)
+	}
 }
 
 func newAdapterFixture(t *testing.T, canonical []byte) (*Adapter, *gorm.DB, *state.CredentialRegistry, encryption.Service, models.Credential) {

--- a/internal/execution/cpa/adapter_test.go
+++ b/internal/execution/cpa/adapter_test.go
@@ -1008,6 +1008,13 @@ func TestUnaryExecutionErrorDistinguishesDefinitelyUnsentNetworkFailures(t *test
 			err:  &net.OpError{Op: "read", Net: "tcp", Err: io.ErrUnexpectedEOF},
 			want: execution.DispatchMaybeSent,
 		},
+		{
+			name: "read wrapped DNS failure",
+			err: &net.OpError{Op: "read", Net: "tcp", Err: &net.DNSError{
+				Err: "temporary lookup failure", Name: "upstream.invalid",
+			}},
+			want: execution.DispatchMaybeSent,
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/execution/cpa/claude_provider.go
+++ b/internal/execution/cpa/claude_provider.go
@@ -194,10 +194,13 @@ func (*claudeProviderBridge) ClassifyError(
 	case requestScopedFailure(err):
 		evidence.Hint = execution.FailureHintRequestRejected
 	case status == http.StatusTooManyRequests:
-		if credentialScoped, known := credentialScopedFailure(err); known && !credentialScoped {
-			evidence.Hint = execution.FailureHintRequestRejected
-		} else {
-			evidence.Hint = execution.FailureHintRateLimited
+		evidence.Hint = execution.FailureHintRateLimited
+		if credentialScoped, known := credentialScopedFailure(err); known {
+			if credentialScoped {
+				evidence.ScopeHint = execution.ErrorScopeCredential
+			} else {
+				evidence.ScopeHint = execution.ErrorScopeModel
+			}
 		}
 	case status >= http.StatusInternalServerError:
 		evidence.Hint = execution.FailureHintHostError

--- a/internal/execution/cpa/claude_provider_test.go
+++ b/internal/execution/cpa/claude_provider_test.go
@@ -145,7 +145,8 @@ func TestClaudeProviderMapsExecutionAndRequestScopedErrors(t *testing.T) {
 
 	requestRejected.requestScoped = false
 	_, evidence = bridge.ClassifyError(t.Context(), requestRejected, credential)
-	if evidence == nil || evidence.Hint != execution.FailureHintRequestRejected {
+	if evidence == nil || evidence.Hint != execution.FailureHintRateLimited ||
+		evidence.ScopeHint != execution.ErrorScopeModel {
 		t.Fatalf("model-scoped rate-limit evidence = %#v", evidence)
 	}
 

--- a/internal/execution/cpa/codex_provider.go
+++ b/internal/execution/cpa/codex_provider.go
@@ -328,8 +328,9 @@ func (*codexProviderBridge) ClassifyError(
 		return 0, nil
 	}
 	status := 0
-	if value, ok := err.(interface{ StatusCode() int }); ok {
-		status = value.StatusCode()
+	var statusError interface{ StatusCode() int }
+	if errors.As(err, &statusError) && statusError != nil {
+		status = statusError.StatusCode()
 	}
 	kind := execution.ErrorKindTransport
 	if status != 0 {
@@ -338,20 +339,35 @@ func (*codexProviderBridge) ClassifyError(
 		kind = execution.ErrorKindTimeout
 	} else if errors.Is(err, context.Canceled) || ctx != nil && errors.Is(context.Cause(ctx), context.Canceled) {
 		kind = execution.ErrorKindCanceled
-	} else if _, ok := err.(net.Error); ok {
-		kind = execution.ErrorKindTransport
+	} else {
+		var networkError net.Error
+		if errors.As(err, &networkError) && networkError != nil {
+			kind = execution.ErrorKindTransport
+		}
 	}
-	typeValue, codeValue := errorTypeCode(err.Error())
+	typeValue, codeValue := codexErrorTypeCode(err)
 	evidence := &execution.ErrorEvidence{
 		Kind: kind, StatusCode: status, Type: typeValue, Code: codeValue,
 		Summary: safeErrorSummary(err, credential.redactionValues()),
 	}
-	if retry, ok := err.(interface{ RetryAfter() *time.Duration }); ok && retry.RetryAfter() != nil && *retry.RetryAfter() > 0 {
-		evidence.RetryAfter = *retry.RetryAfter()
+	var retry interface{ RetryAfter() *time.Duration }
+	if errors.As(err, &retry) && retry != nil {
+		if value := retry.RetryAfter(); value != nil && *value > 0 {
+			evidence.RetryAfter = *value
+		}
 	}
 	switch {
 	case status == http.StatusUnauthorized:
 		evidence.Hint = execution.FailureHintRefreshRequired
+		evidence.ReplaySafety = execution.ReplaySafetyRejectedBeforeProcessing
+	case status == http.StatusTooManyRequests && typeValue == "usage_limit_reached":
+		evidence.Hint = execution.FailureHintRateLimited
+		evidence.ScopeHint = execution.ErrorScopeCredential
+		evidence.ReplaySafety = execution.ReplaySafetyRejectedBeforeProcessing
+	case status == http.StatusTooManyRequests && codexModelCapacityError(err):
+		evidence.Hint = execution.FailureHintCandidateUnavailable
+		evidence.ScopeHint = execution.ErrorScopeModel
+		evidence.Code = "selected_model_at_capacity"
 		evidence.ReplaySafety = execution.ReplaySafetyRejectedBeforeProcessing
 	case status == http.StatusTooManyRequests:
 		evidence.Hint = execution.FailureHintRateLimited
@@ -362,6 +378,51 @@ func (*codexProviderBridge) ClassifyError(
 	}
 	annotateProviderErrorEvidence(evidence, err)
 	return status, evidence
+}
+
+func codexErrorTypeCode(err error) (string, string) {
+	var typed interface {
+		ErrorType() string
+		ErrorCode() string
+	}
+	if errors.As(err, &typed) && typed != nil {
+		return safeScalar(typed.ErrorType()), safeScalar(typed.ErrorCode())
+	}
+	for current := err; current != nil; current = errors.Unwrap(current) {
+		if typeValue, codeValue := errorTypeCode(current.Error()); typeValue != "" || codeValue != "" {
+			return typeValue, codeValue
+		}
+	}
+	return "", ""
+}
+
+func codexModelCapacityError(err error) bool {
+	for current := err; current != nil; current = errors.Unwrap(current) {
+		message := strings.TrimSpace(current.Error())
+		var payload struct {
+			Error struct {
+				Message string `json:"message"`
+			} `json:"error"`
+			Message string `json:"message"`
+		}
+		if json.Unmarshal([]byte(message), &payload) == nil {
+			if payload.Error.Message != "" {
+				message = payload.Error.Message
+			} else if payload.Message != "" {
+				message = payload.Message
+			}
+		}
+		switch strings.ToLower(strings.TrimSpace(message)) {
+		case "selected model is at capacity",
+			"selected model is at capacity. please try a different model",
+			"selected model is at capacity. please try a different model.",
+			"the selected model is at capacity. please try a different model.",
+			"model is at capacity. please try a different model",
+			"model is at capacity. please try a different model.":
+			return true
+		}
+	}
+	return false
 }
 
 var _ providerBridge = (*codexProviderBridge)(nil)

--- a/internal/execution/cpa/codex_provider_test.go
+++ b/internal/execution/cpa/codex_provider_test.go
@@ -1,0 +1,87 @@
+package cpa
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"gpt-load/internal/execution"
+)
+
+type codexClassifiedTestError struct {
+	status     int
+	payload    string
+	retryAfter time.Duration
+}
+
+func (err *codexClassifiedTestError) Error() string   { return err.payload }
+func (err *codexClassifiedTestError) StatusCode() int { return err.status }
+func (err *codexClassifiedTestError) RetryAfter() *time.Duration {
+	if err.retryAfter <= 0 {
+		return nil
+	}
+	value := err.retryAfter
+	return &value
+}
+
+func TestCodexProviderClassifiesStructuredRateLimitEvidence(t *testing.T) {
+	t.Parallel()
+
+	bridge := newCodexProviderBridge()
+	credential := codexProviderCredential{}
+	tests := []struct {
+		name       string
+		err        error
+		wantType   string
+		wantCode   string
+		wantHint   execution.FailureHint
+		wantScope  execution.ErrorScope
+		wantReplay execution.ReplaySafety
+		wantRetry  time.Duration
+	}{
+		{
+			name: "wrapped credential usage limit",
+			err: fmt.Errorf("wrapped: %w", &codexClassifiedTestError{
+				status:     http.StatusTooManyRequests,
+				payload:    `{"error":{"type":"usage_limit_reached","message":"usage limit reached"}}`,
+				retryAfter: 17 * time.Second,
+			}),
+			wantType: "usage_limit_reached", wantHint: execution.FailureHintRateLimited,
+			wantScope:  execution.ErrorScopeCredential,
+			wantReplay: execution.ReplaySafetyRejectedBeforeProcessing,
+			wantRetry:  17 * time.Second,
+		},
+		{
+			name: "model capacity",
+			err: &codexClassifiedTestError{
+				status:  http.StatusTooManyRequests,
+				payload: `{"error":{"message":"The selected model is at capacity. Please try a different model."}}`,
+			},
+			wantCode:   "selected_model_at_capacity",
+			wantHint:   execution.FailureHintCandidateUnavailable,
+			wantScope:  execution.ErrorScopeModel,
+			wantReplay: execution.ReplaySafetyRejectedBeforeProcessing,
+		},
+		{
+			name: "generic rate limit remains unscoped",
+			err: &codexClassifiedTestError{
+				status:  http.StatusTooManyRequests,
+				payload: `{"error":{"type":"rate_limit_error","message":"too many requests"}}`,
+			},
+			wantType: "rate_limit_error", wantHint: execution.FailureHintRateLimited,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			status, evidence := bridge.ClassifyError(t.Context(), test.err, credential)
+			if status != http.StatusTooManyRequests || evidence == nil ||
+				evidence.Type != test.wantType || evidence.Code != test.wantCode ||
+				evidence.Hint != test.wantHint || evidence.ScopeHint != test.wantScope ||
+				evidence.ReplaySafety != test.wantReplay || evidence.RetryAfter != test.wantRetry {
+				t.Fatalf("ClassifyError() = %d / %#v", status, evidence)
+			}
+		})
+	}
+}

--- a/internal/execution/cpa/provider_test.go
+++ b/internal/execution/cpa/provider_test.go
@@ -64,8 +64,10 @@ func (credentialScopedTestError) Error() string                { return "credent
 func (err credentialScopedTestError) IsCredentialScoped() bool { return bool(err) }
 
 type recordingProviderBridge struct {
-	kind           channel.ProviderKind
-	validatedRoute channel.RouteDescriptor
+	kind                   channel.ProviderKind
+	validatedRoute         channel.RouteDescriptor
+	classificationStatus   int
+	classificationEvidence *execution.ErrorEvidence
 }
 
 func (bridge *recordingProviderBridge) ProviderKind() channel.ProviderKind { return bridge.kind }
@@ -83,8 +85,8 @@ func (*recordingProviderBridge) Execute(context.Context, string, providerCredent
 func (*recordingProviderBridge) ExecuteStream(context.Context, string, providerCredential, providerRequest) (*providerStreamResponse, error) {
 	return nil, nil
 }
-func (*recordingProviderBridge) ClassifyError(context.Context, error, providerCredential) (int, *execution.ErrorEvidence) {
-	return 0, nil
+func (bridge *recordingProviderBridge) ClassifyError(context.Context, error, providerCredential) (int, *execution.ErrorEvidence) {
+	return bridge.classificationStatus, bridge.classificationEvidence
 }
 
 func TestAdapterDelegatesRouteValidationByProviderKind(t *testing.T) {

--- a/internal/gateway/execution_boundary.go
+++ b/internal/gateway/execution_boundary.go
@@ -139,17 +139,25 @@ func decisionEvidence(result UpstreamResult) (*execution.ErrorEvidence, error) {
 		if evidence == nil && errors.Is(downstreamErr, ErrUpstreamProtocol) {
 			return &execution.ErrorEvidence{
 				Kind: execution.ErrorKindProvider, OriginHint: execution.ErrorOriginUpstream,
+				ScopeHint:  execution.ErrorScopeRequest,
 				StatusCode: result.StatusCode, Code: "upstream_protocol_error",
 				Summary: fixedErrorSummary("upstream_protocol_error"),
 			}, nil
 		}
 		return evidence, downstreamErr
-	case StreamEndCleanEOF, StreamEndProviderIncomplete:
+	case StreamEndCleanEOF:
 		return nil, nil
+	case StreamEndProviderIncomplete:
+		return &execution.ErrorEvidence{
+			Kind: execution.ErrorKindProvider, OriginHint: execution.ErrorOriginUpstream,
+			ScopeHint:  execution.ErrorScopeRequest,
+			StatusCode: result.StatusCode, Code: "upstream_response_incomplete", Summary: summary,
+		}, nil
 	case StreamEndSSEError:
 		if evidence == nil {
 			evidence = &execution.ErrorEvidence{
 				Kind: execution.ErrorKindProvider, OriginHint: execution.ErrorOriginUpstream,
+				ScopeHint:  execution.ErrorScopeRequest,
 				StatusCode: result.StatusCode, Code: "upstream_sse_error", Summary: summary,
 			}
 		}
@@ -157,16 +165,19 @@ func decisionEvidence(result UpstreamResult) (*execution.ErrorEvidence, error) {
 	case StreamEndUpstreamTerminated:
 		return &execution.ErrorEvidence{
 			Kind: execution.ErrorKindTransport, OriginHint: execution.ErrorOriginUpstream,
+			ScopeHint:  execution.ErrorScopeRequest,
 			StatusCode: result.StatusCode, Code: "upstream_stream_terminated", Summary: summary,
 		}, nil
 	case StreamEndUpstreamProtocolError:
 		return &execution.ErrorEvidence{
 			Kind: execution.ErrorKindProvider, OriginHint: execution.ErrorOriginUpstream,
+			ScopeHint:  execution.ErrorScopeRequest,
 			StatusCode: result.StatusCode, Code: "upstream_protocol_error", Summary: summary,
 		}, nil
 	case StreamEndIdleTimeout:
 		return &execution.ErrorEvidence{
 			Kind: execution.ErrorKindTimeout, OriginHint: execution.ErrorOriginUpstream,
+			ScopeHint:  execution.ErrorScopeRequest,
 			StatusCode: result.StatusCode, Code: "upstream_stream_idle_timeout", Summary: summary,
 		}, nil
 	case StreamEndDownstreamWriteFailure:

--- a/internal/gateway/execution_boundary_test.go
+++ b/internal/gateway/execution_boundary_test.go
@@ -159,10 +159,47 @@ func TestJudgeUpstreamResultClassifiesUncommittedProtocolFailureAsUpstream(t *te
 	}, time.Now(), health.DecisionContext{})
 	if decision.Category != health.FailureCategoryAmbiguous ||
 		decision.Origin != execution.ErrorOriginUpstream ||
+		decision.Scope != execution.ErrorScopeRequest ||
 		decision.Retry != health.RetryNone ||
 		decision.Effect != health.EffectNone ||
-		decision.RuleID != "fallback.ambiguous" {
+		decision.RuleID != "stream.protocol_error" {
 		t.Fatalf("protocol decision = %#v", decision)
+	}
+}
+
+func TestJudgeUpstreamResultUsesStableStreamTerminalRules(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		endReason  StreamEndReason
+		wantRule   health.RuleID
+		wantOrigin execution.ErrorOrigin
+		wantScope  execution.ErrorScope
+	}{
+		{name: "provider error", endReason: StreamEndSSEError, wantRule: "stream.provider_error", wantOrigin: execution.ErrorOriginUpstream, wantScope: execution.ErrorScopeRequest},
+		{name: "upstream terminated", endReason: StreamEndUpstreamTerminated, wantRule: "stream.upstream_terminated", wantOrigin: execution.ErrorOriginUpstream, wantScope: execution.ErrorScopeRequest},
+		{name: "protocol error", endReason: StreamEndUpstreamProtocolError, wantRule: "stream.protocol_error", wantOrigin: execution.ErrorOriginUpstream, wantScope: execution.ErrorScopeRequest},
+		{name: "idle timeout", endReason: StreamEndIdleTimeout, wantRule: "stream.idle_timeout", wantOrigin: execution.ErrorOriginUpstream, wantScope: execution.ErrorScopeRequest},
+		{name: "provider incomplete", endReason: StreamEndProviderIncomplete, wantRule: "stream.provider_incomplete", wantOrigin: execution.ErrorOriginUpstream, wantScope: execution.ErrorScopeRequest},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			decision := judgeUpstreamResult(UpstreamResult{
+				DispatchState:   execution.DispatchMaybeSent,
+				ResponseStarted: true,
+				StatusCode:      http.StatusOK,
+				Committed:       true,
+				Stream:          streamTerminalObservation(test.endReason),
+			}, time.Now(), health.DecisionContext{})
+			if decision.Category != health.FailureCategoryAmbiguous ||
+				decision.Origin != test.wantOrigin || decision.Scope != test.wantScope ||
+				decision.Retry != health.RetryNone || decision.Effect != health.EffectNone ||
+				decision.RuleID != test.wantRule {
+				t.Fatalf("judgeUpstreamResult() = %#v", decision)
+			}
+		})
 	}
 }
 

--- a/internal/health/execution_judge.go
+++ b/internal/health/execution_judge.go
@@ -539,8 +539,7 @@ func constrainCommittedDecision(result Decision, attempt ExecutionAttempt) Decis
 	}
 	if result.Category == FailureCategoryRateLimited && result.Effect == EffectCooldownCredential {
 		result.RuleID = "rate_limit.credential.committed"
-	} else if result.Effect == EffectNone &&
-		(originalRetry != RetryNone || originalEffect != EffectNone) {
+	} else if originalRetry != result.Retry || originalEffect != result.Effect {
 		result.RuleID = "safety.committed"
 	}
 	return result

--- a/internal/health/execution_judge.go
+++ b/internal/health/execution_judge.go
@@ -179,7 +179,8 @@ func JudgeExecution(attempt ExecutionAttempt, decisionContext DecisionContext) D
 	}
 	category := classifyExecutionEvidence(attempt)
 	result := decisionForExecutionCategory(category, attempt, decisionContext)
-	if attempt.Evidence.ReplaySafety == execution.ReplaySafetyUnknown && result.Retry == RetryNone {
+	if attempt.Evidence.ReplaySafety == execution.ReplaySafetyUnknown &&
+		result.RuleID == "fallback.ambiguous" {
 		result.RuleID = "safety.replay_unknown"
 	}
 	return constrainCommittedDecision(result, attempt)
@@ -345,7 +346,10 @@ func decisionForExecutionCategory(
 	case FailureCategoryUpstreamHostError:
 		retry := RetryNone
 		ruleID := RuleID("upstream.host_error.replay_unsafe")
-		if attempt.Evidence.ReplaySafety != execution.ReplaySafetyUnknown &&
+		if attempt.Evidence.ReplaySafety == execution.ReplaySafetyRejectedBeforeProcessing {
+			retry = RetryNextCandidate
+			ruleID = "upstream.host_error.rejected_before_processing"
+		} else if attempt.Evidence.ReplaySafety != execution.ReplaySafetyUnknown &&
 			requestMayReplayAfterResponse(decisionContext) {
 			retry = RetryNextCandidate
 			ruleID = "upstream.host_error.read_only"
@@ -379,7 +383,27 @@ func decisionForExecutionCategory(
 	case FailureCategoryOK:
 		return decision(category, origin, scope, RetryNone, EffectNone, "success.upstream_response")
 	default:
-		return decision(category, origin, scope, RetryNone, EffectNone, "fallback.ambiguous")
+		return decision(category, origin, scope, RetryNone, EffectNone, ambiguousRuleID(attempt.Evidence))
+	}
+}
+
+func ambiguousRuleID(evidence *execution.ErrorEvidence) RuleID {
+	if evidence == nil {
+		return "fallback.ambiguous"
+	}
+	switch evidence.Code {
+	case "upstream_sse_error":
+		return "stream.provider_error"
+	case "upstream_stream_terminated":
+		return "stream.upstream_terminated"
+	case "upstream_protocol_error":
+		return "stream.protocol_error"
+	case "upstream_stream_idle_timeout":
+		return "stream.idle_timeout"
+	case "upstream_response_incomplete":
+		return "stream.provider_incomplete"
+	default:
+		return "fallback.ambiguous"
 	}
 }
 
@@ -500,6 +524,8 @@ func constrainCommittedDecision(result Decision, attempt ExecutionAttempt) Decis
 	if !attempt.DownstreamCommitted {
 		return result
 	}
+	originalRetry := result.Retry
+	originalEffect := result.Effect
 	result.Retry = RetryNone
 	switch result.Effect {
 	case EffectCooldownCredential, EffectRecordCredentialFailure:
@@ -513,6 +539,9 @@ func constrainCommittedDecision(result Decision, attempt ExecutionAttempt) Decis
 	}
 	if result.Category == FailureCategoryRateLimited && result.Effect == EffectCooldownCredential {
 		result.RuleID = "rate_limit.credential.committed"
+	} else if result.Effect == EffectNone &&
+		(originalRetry != RetryNone || originalEffect != EffectNone) {
+		result.RuleID = "safety.committed"
 	}
 	return result
 }

--- a/internal/health/execution_judge_v2_test.go
+++ b/internal/health/execution_judge_v2_test.go
@@ -79,7 +79,8 @@ func TestJudgeExecutionCommittedKeepsOnlyTrustedCredentialEffect(t *testing.T) {
 		},
 		Now: now,
 	}, context)
-	if unscoped.Retry != RetryNone || unscoped.Effect != EffectNone || unscoped.Scope != "" {
+	if unscoped.Retry != RetryNone || unscoped.Effect != EffectNone || unscoped.Scope != "" ||
+		unscoped.RuleID != "safety.committed" {
 		t.Fatalf("unscoped committed decision = %#v", unscoped)
 	}
 }
@@ -252,6 +253,22 @@ func TestJudgeExecutionPreservesReplayCompatibilityRules(t *testing.T) {
 			wantRetry: RetryNone,
 			wantRule:  RuleID("upstream.host_error.replay_unsafe"),
 		},
+		{
+			name: "explicitly rejected mutating host error retries",
+			attempt: ExecutionAttempt{
+				DispatchState: execution.DispatchMaybeSent,
+				StatusCode:    http.StatusServiceUnavailable,
+				Evidence: &execution.ErrorEvidence{
+					Kind: execution.ErrorKindHTTP, Hint: execution.FailureHintHostError,
+					StatusCode:   http.StatusServiceUnavailable,
+					ReplaySafety: execution.ReplaySafetyRejectedBeforeProcessing,
+					Summary:      "request rejected before processing",
+				},
+			},
+			context:   DecisionContext{Method: http.MethodPost, Operation: execution.OperationChatCompletion},
+			wantRetry: RetryNextCandidate,
+			wantRule:  RuleID("upstream.host_error.rejected_before_processing"),
+		},
 	}
 
 	for _, test := range tests {
@@ -259,6 +276,119 @@ func TestJudgeExecutionPreservesReplayCompatibilityRules(t *testing.T) {
 			decision := JudgeExecution(test.attempt, test.context)
 			if decision.Retry != test.wantRetry || decision.RuleID != test.wantRule {
 				t.Fatalf("JudgeExecution() = %#v, want retry=%q rule=%q", decision, test.wantRetry, test.wantRule)
+			}
+		})
+	}
+}
+
+func TestJudgeExecutionReplayUnknownKeepsUnaffectedRuleID(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   int
+		evidence execution.ErrorEvidence
+		wantRule RuleID
+	}{
+		{
+			name:   "request scoped rate limit",
+			status: http.StatusTooManyRequests,
+			evidence: execution.ErrorEvidence{
+				Kind: execution.ErrorKindHTTP, Hint: execution.FailureHintRateLimited,
+				ScopeHint: execution.ErrorScopeRequest, StatusCode: http.StatusTooManyRequests,
+				ReplaySafety: execution.ReplaySafetyUnknown, Summary: "request rate limited",
+			},
+			wantRule: "rate_limit.scoped",
+		},
+		{
+			name:   "generic client error",
+			status: http.StatusForbidden,
+			evidence: execution.ErrorEvidence{
+				Kind: execution.ErrorKindHTTP, StatusCode: http.StatusForbidden,
+				ReplaySafety: execution.ReplaySafetyUnknown, Summary: "permission denied",
+			},
+			wantRule: "fallback.http_client_error",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			decision := JudgeExecution(ExecutionAttempt{
+				DispatchState: execution.DispatchMaybeSent,
+				StatusCode:    test.status,
+				Evidence:      &test.evidence,
+			}, DecisionContext{})
+			if decision.Retry != RetryNone || decision.RuleID != test.wantRule {
+				t.Fatalf("JudgeExecution() = %#v, want rule %q", decision, test.wantRule)
+			}
+		})
+	}
+}
+
+func TestJudgeExecutionStableFallbackRuleMatrix(t *testing.T) {
+	tests := []struct {
+		name    string
+		attempt ExecutionAttempt
+		want    RuleID
+	}{
+		{
+			name:    "missing evidence",
+			attempt: ExecutionAttempt{DispatchState: execution.DispatchNotSent},
+			want:    "fallback.missing_evidence",
+		},
+		{
+			name: "execution canceled",
+			attempt: ExecutionAttempt{
+				DispatchState: execution.DispatchMaybeSent,
+				Evidence:      &execution.ErrorEvidence{Kind: execution.ErrorKindCanceled, Summary: "canceled"},
+			},
+			want: "safety.execution_canceled",
+		},
+		{
+			name: "unclassified not sent",
+			attempt: ExecutionAttempt{
+				DispatchState: execution.DispatchNotSent,
+				Evidence:      &execution.ErrorEvidence{Kind: execution.ErrorKindInternal, Summary: "internal failure"},
+			},
+			want: "fallback.not_sent",
+		},
+		{
+			name: "invalid dispatch state",
+			attempt: ExecutionAttempt{
+				DispatchState: execution.DispatchState("invalid"),
+				Evidence:      &execution.ErrorEvidence{Kind: execution.ErrorKindInternal, Summary: "invalid state"},
+			},
+			want: "fallback.invalid_dispatch_state",
+		},
+		{
+			name: "transport outcome unknown",
+			attempt: ExecutionAttempt{
+				DispatchState: execution.DispatchMaybeSent,
+				Evidence:      &execution.ErrorEvidence{Kind: execution.ErrorKindTransport, Summary: "connection lost"},
+			},
+			want: "transport.outcome_unknown",
+		},
+		{
+			name: "authentication replay unsafe",
+			attempt: ExecutionAttempt{
+				DispatchState: execution.DispatchMaybeSent,
+				StatusCode:    http.StatusUnauthorized,
+				Evidence: &execution.ErrorEvidence{
+					Kind: execution.ErrorKindHTTP, Hint: execution.FailureHintRefreshRequired,
+					StatusCode: http.StatusUnauthorized, ReplaySafety: execution.ReplaySafetyUnknown,
+					Summary: "authentication failed",
+				},
+			},
+			want: "auth.replay_unsafe",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			decision := JudgeExecution(test.attempt, DecisionContext{CredentialRefreshable: true})
+			if decision.RuleID != test.want {
+				t.Fatalf("JudgeExecution() = %#v, want rule %q", decision, test.want)
+			}
+			if err := decision.Validate(); err != nil {
+				t.Fatalf("Decision.Validate() error = %v", err)
 			}
 		})
 	}

--- a/internal/health/execution_judge_v2_test.go
+++ b/internal/health/execution_judge_v2_test.go
@@ -83,6 +83,24 @@ func TestJudgeExecutionCommittedKeepsOnlyTrustedCredentialEffect(t *testing.T) {
 		unscoped.RuleID != "safety.committed" {
 		t.Fatalf("unscoped committed decision = %#v", unscoped)
 	}
+
+	invalidCredential := JudgeExecution(ExecutionAttempt{
+		DispatchState:       execution.DispatchMaybeSent,
+		StatusCode:          http.StatusUnauthorized,
+		DownstreamCommitted: true,
+		Evidence: &execution.ErrorEvidence{
+			Kind: execution.ErrorKindHTTP, Hint: execution.FailureHintInvalidCredential,
+			ScopeHint: execution.ErrorScopeCredential, StatusCode: http.StatusUnauthorized,
+			ReplaySafety: execution.ReplaySafetyRejectedBeforeProcessing,
+			Summary:      "credential rejected",
+		},
+		Now: now,
+	}, context)
+	if invalidCredential.Retry != RetryNone ||
+		invalidCredential.Effect != EffectRecordCredentialFailure ||
+		invalidCredential.RuleID != "safety.committed" {
+		t.Fatalf("invalid credential committed decision = %#v", invalidCredential)
+	}
 }
 
 func TestJudgeExecutionDoesNotRotateCredentialsForScopedRateLimit(t *testing.T) {


### PR DESCRIPTION
### 关联 Issue / Related Issue
Follow-up to #466

### 变更内容 / Change Content
- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

- 修正明确在处理前被拒绝的 HostError 重试语义，并保证 committed 与 replay safety 约束后的 RuleID 描述最终决策。
- 为流式 Provider 错误、异常断流、协议错误、idle timeout 和 incomplete 响应补充稳定规则；incomplete 不再记录为成功 Attempt。
- 仅将 CPA 中确定未发送的 DNS/dial 失败标记为 `not_sent`，read/EOF 等结果未知错误继续保守处理。
- 精确区分 Claude 的 Credential/Model 级 429，并补充 Codex usage limit、模型容量和包装错误分类。
- 增加 Judge、Gateway 与 CPA 的紧凑回归测试和规则矩阵覆盖。

兼容性说明：不涉及数据库迁移、API 或配置变化；保留未定 Scope 429、普通 402/403 及不安全重放的既有保守行为。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.

本次是既有统一错误核心的规则修正，不改变公开使用方式，因此无需新增公开文档或发布说明。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **错误处理**
  * 改进网络连接、DNS 和读取失败的区分，提升请求发送状态判断准确性。
  * 优化 Claude 与 Codex 的限流、模型容量不足及凭证用量错误分类。
* **流式响应**
  * 更准确识别响应不完整、协议错误和超时等终止情况，避免将异常流误判为成功。
* **重试与安全性**
  * 优化重试、重放安全及已提交响应的判定，降低重复执行风险。
  * 为不同执行失败场景提供稳定、明确的错误规则。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->