### PR TITLE
fix(monitor): 调整尝试详情自适应布局

### DIFF
--- a/web/src/features/monitor/LogDetailDrawer.vue
+++ b/web/src/features/monitor/LogDetailDrawer.vue
@@ -586,7 +586,7 @@ function toggleAttemptErrorMessage(sequence: number): void {
               </StatusBadge>
             </header>
             <dl class="log-detail__grid">
-              <div v-if="!isFinalAttempt(attempt)" class="log-detail__wide">
+              <div v-if="!isFinalAttempt(attempt)">
                 <dt>{{ t('monitor.logs.drawer.routeIdentity') }}</dt>
                 <dd>
                   <LogRouteIdentity
@@ -607,12 +607,7 @@ function toggleAttemptErrorMessage(sequence: number): void {
                 <div>
                   <dt>{{ t('monitor.logs.drawer.upstreamModel') }}</dt>
                   <dd class="log-detail__model-value">
-                    <code>{{ attempt.upstream_model ?? '—' }}</code
-                    ><small
-                      v-if="upstreamReasoningLabel(attempt.reasoning, attempt.route_mode)"
-                      class="log-detail__reasoning"
-                      >{{ upstreamReasoningLabel(attempt.reasoning, attempt.route_mode) }}</small
-                    >
+                    <code>{{ attempt.upstream_model ?? '—' }}</code>
                   </dd>
                 </div>
               </template>
@@ -632,12 +627,6 @@ function toggleAttemptErrorMessage(sequence: number): void {
                       ? t('monitor.logs.drawer.clientStreamStarted')
                       : t('monitor.logs.drawer.clientStreamNotStarted')
                   }}
-                </dd>
-              </div>
-              <div v-if="attempt.upstream_request_id">
-                <dt>{{ t('monitor.logs.drawer.upstreamRequestId') }}</dt>
-                <dd>
-                  <code>{{ attempt.upstream_request_id }}</code>
                 </dd>
               </div>
               <div>
@@ -665,10 +654,6 @@ function toggleAttemptErrorMessage(sequence: number): void {
                 <dd>
                   <code>{{ attempt.rule_id }}</code>
                 </dd>
-              </div>
-              <div v-if="!attempt.retry_directive && !attempt.effect">
-                <dt>{{ t('monitor.logs.drawer.action') }}</dt>
-                <dd>{{ t(`monitor.logs.action.${attempt.action}`) }}</dd>
               </div>
               <div>
                 <dt>{{ t('monitor.logs.drawer.subsequentAttempt') }}</dt>

--- a/web/src/features/monitor/LogDetailDrawer.vue
+++ b/web/src/features/monitor/LogDetailDrawer.vue
@@ -660,7 +660,7 @@ function toggleAttemptErrorMessage(sequence: number): void {
                 <dt>{{ t('monitor.logs.drawer.effect') }}</dt>
                 <dd>{{ t(`monitor.logs.effect.${attempt.effect}`) }}</dd>
               </div>
-              <div v-if="attempt.rule_id" class="log-detail__wide">
+              <div v-if="attempt.rule_id">
                 <dt>{{ t('monitor.logs.drawer.ruleId') }}</dt>
                 <dd>
                   <code>{{ attempt.rule_id }}</code>


### PR DESCRIPTION
### 关联 Issue / Related Issue
Follow-up to #466 and #468

### 变更内容 / Change Content
- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

- 移除尝试详情中“命中规则”强制跨越两列的布局约束。
- 保持所有可选字段按实际存在情况和 DOM 顺序自动填充两列网格，不增加固定配对或空占位。
- 保留现有窄屏单列布局，较长 RuleID 继续使用既有自动换行规则。

兼容性说明：仅调整管理端请求日志详情布局，不涉及 API、数据结构、数据库迁移或业务规则变化。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.

本次不改变公开使用方式，无需新增公开文档或发布说明。仓库不编写前端测试，已通过 lint、format、type-check、前端构建及完整后端门禁。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **样式**
  - 优化日志详情尝试信息的网格布局，路由身份与规则 ID 不再独占整行。
  - 移除上游模型的推理标注展示。
  - 移除上游请求 ID 与操作信息，界面更加简洁。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->