### PR TITLE
fix(groups): 同步模型变更后的关联缓存

### DIFF
--- a/web/src/app/resources/groups.ts
+++ b/web/src/app/resources/groups.ts
@@ -794,7 +794,7 @@ export function cacheGroupSettings(
   queryClient.setQueryData(controlQueryKeys.groups.settings(groupID), settings)
 }
 
-/** Refresh cached resources whose representations derive from Group models. */
+/** Invalidate cached resources whose representations derive from Group models. */
 export async function invalidateGroupModelDependents(
   queryClient: QueryClient,
   groupID: number,

--- a/web/src/app/resources/groups.ts
+++ b/web/src/app/resources/groups.ts
@@ -794,14 +794,28 @@ export function cacheGroupSettings(
   queryClient.setQueryData(controlQueryKeys.groups.settings(groupID), settings)
 }
 
-/** Model changes can change summary status; refresh the active summary and stale aggregate resources. */
-export async function invalidateGroupSummary(
+/** Refresh cached resources whose representations derive from Group models. */
+export async function invalidateGroupModelDependents(
   queryClient: QueryClient,
   groupID: number,
 ): Promise<void> {
   await Promise.all([
     queryClient.invalidateQueries({
       queryKey: controlQueryKeys.groups.summary(groupID),
+      exact: true,
+      refetchType: 'active',
+    }),
+    queryClient.invalidateQueries({
+      queryKey: controlQueryKeys.groups.collectionAll,
+      refetchType: 'active',
+    }),
+    queryClient.invalidateQueries({
+      queryKey: controlQueryKeys.groups.options(),
+      exact: true,
+      refetchType: 'active',
+    }),
+    queryClient.invalidateQueries({
+      queryKey: controlQueryKeys.home.base(),
       exact: true,
       refetchType: 'active',
     }),
@@ -864,6 +878,12 @@ export function cacheGroupModels(
   queryClient.setQueryData(controlQueryKeys.groups.models(groupID), models)
   queryClient.setQueryData<GroupSummaryDto>(controlQueryKeys.groups.summary(groupID), (summary) =>
     summary === undefined ? summary : { ...summary, model_count: models.total },
+  )
+  const clientModels = models.items.map(({ client_model: clientModel }) => clientModel)
+  queryClient.setQueryData<GroupOptionDto[]>(controlQueryKeys.groups.options(), (options) =>
+    options?.map((option) =>
+      option.id === groupID ? { ...option, models: clientModels } : option,
+    ),
   )
 }
 

--- a/web/src/features/groups/models/GroupModelsTab.vue
+++ b/web/src/features/groups/models/GroupModelsTab.vue
@@ -13,9 +13,9 @@ import {
   cacheGroupModels,
   discoverGroupModels,
   groupModelsQueryOptions,
+  invalidateGroupModelDependents,
   replaceGroupModelsResource,
 } from '@/app/resources/groups'
-import { invalidateGroupSummary } from '@/app/resources/groups'
 import type { ModelCandidate } from '@/app/resources/providers'
 import { useUnsavedChanges } from '@/app/unsaved-changes'
 import { useTransientFlag } from '@/app/use-transient-flag'
@@ -394,7 +394,7 @@ async function save(): Promise<void> {
     serverConflicts.value = []
     emptyConfirmOpen.value = false
     cacheGroupModels(queryClient, props.groupId, result)
-    await invalidateGroupSummary(queryClient, props.groupId)
+    await invalidateGroupModelDependents(queryClient, props.groupId)
     showSavedFeedback()
   } catch (cause: unknown) {
     if (cause instanceof RequestCancelledError || controller !== active) return


### PR DESCRIPTION
### 关联 Issue / Related Issue

N/A（未关联 Issue）

### 变更内容 / Change Content

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

- Group 模型保存成功后，使用服务端返回的 `client_model` 立即同步共享 Group 选项缓存，切换到路由检查或访问密钥页面时不再继续显示旧模型列表。
- 统一失效 Group 模型派生的详情摘要、Group 集合、Group 选项、首页基础统计、模型中心与价格缓存，避免模型数量和 `no_models` 状态滞后。
- 不修改后端 API、持久化格式或全局缓存策略。

验证：`make check` 通过；提交后 ESLint 与 TypeScript 类型检查再次通过。

### 自查清单 / Checklist

- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.

本次修复不需要公开文档更新，不包含兼容性变化或数据迁移。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **错误修复**
  - 修复保存模型后相关数据未及时更新的问题。
  - 更新模型后，活动中的群组列表、群组配置选项及首页内容会自动刷新。
  - 群组配置中的模型列表将与最新保存结果保持同步。
  - 改善模型更新后的缓存刷新机制，确保相关页面及时显示最新信息。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->