### PR TITLE
fix(gateway): 放宽请求体大小限制

### DIFF
--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -38,7 +38,7 @@ import (
 
 const (
 	maxAttempts               = 3
-	maxRequestBodyBytes       = int64(32 << 20)
+	maxRequestBodyBytes       = int64(128 << 20)
 	maxDataPlaneModelBytes    = 255
 	fixedCooldown             = time.Minute
 	subscriptionFixedCooldown = 10 * time.Minute

--- a/internal/gateway/handler_test.go
+++ b/internal/gateway/handler_test.go
@@ -2124,6 +2124,10 @@ func TestHandlerCapturesKeyIdentityOnlyAfterDecodedInspection(t *testing.T) {
 			contentLength: maxRequestBodyBytes + 1, wantStatus: http.StatusRequestEntityTooLarge,
 		},
 		{
+			name: "request within expanded limit", body: []byte(`{"model":"gpt-4o"}`),
+			contentLength: 64 << 20, wantStatus: http.StatusOK, wantCapture: 1,
+		},
+		{
 			name: "invalid JSON", body: []byte(`{"model":`),
 			wantStatus: http.StatusBadRequest,
 		},
@@ -2574,8 +2578,8 @@ func assertGatewayReasonTest(
 }
 
 func TestHandlerRejectsOversizedRequestBody(t *testing.T) {
-	if maxRequestBodyBytes != 32<<20 {
-		t.Fatalf("maxRequestBodyBytes = %d, want %d", maxRequestBodyBytes, 32<<20)
+	if maxRequestBodyBytes != 128<<20 {
+		t.Fatalf("maxRequestBodyBytes = %d, want %d", maxRequestBodyBytes, 128<<20)
 	}
 	forwarder := &scriptedForwarder{}
 	engine, _, _ := newHandlerTestRuntime(t, forwarder, "sk-unused")

--- a/internal/gateway/handler_test.go
+++ b/internal/gateway/handler_test.go
@@ -2124,7 +2124,7 @@ func TestHandlerCapturesKeyIdentityOnlyAfterDecodedInspection(t *testing.T) {
 			contentLength: maxRequestBodyBytes + 1, wantStatus: http.StatusRequestEntityTooLarge,
 		},
 		{
-			name: "request within expanded limit", body: []byte(`{"model":"gpt-4o"}`),
+			name: "content length within expanded limit", body: []byte(`{"model":"gpt-4o"}`),
 			contentLength: 64 << 20, wantStatus: http.StatusOK, wantCapture: 1,
 		},
 		{


### PR DESCRIPTION
### 关联 Issue / Related Issue
无

### 变更内容 / Change Content
- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

将数据面全局请求体限制从 32 MiB 提高到 128 MiB，以支持包含多张图片的正常 Responses 请求。

保留原有请求体限制机制：编码前和解码后均限制为 128 MiB；超过限制仍返回 413 `request_too_large`，不进入上游尝试、不重试、不影响凭据健康状态。

新增回归覆盖：Content-Length 位于扩展上限内的请求可继续进入上游，超过 128 MiB 的请求仍被本地拒绝。

兼容性说明：仅放宽数据面请求体上限，不改变错误分类、重试、调度或上游协议行为；无数据库迁移。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [ ] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.

本次不改变公开 API 结构，无需新增公开文档或发布说明。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 网关支持处理最大 128 MiB 的请求体，提升大请求的处理能力。
  * 新增 64 MiB 请求处理验证，确保请求可正常完成。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
