### PR TITLE
fix(release): 修复 Alpine OpenSSL 漏洞扫描阻断

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,8 @@ RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
 FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS runtime
 
 WORKDIR /app
-RUN apk add --no-cache ca-certificates tzdata \
+RUN apk upgrade --no-cache libcrypto3 libssl3 \
+    && apk add --no-cache ca-certificates tzdata \
     && update-ca-certificates \
     && addgroup -S -g 10001 gpt-load \
     && adduser -S -D -H -u 10001 -G gpt-load gpt-load \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
 FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS runtime
 
 WORKDIR /app
-RUN apk upgrade --no-cache libcrypto3 libssl3 \
+RUN apk add --no-cache libcrypto3=3.5.8-r0 libssl3=3.5.8-r0 \
     && apk add --no-cache ca-certificates tzdata \
     && update-ca-certificates \
     && addgroup -S -g 10001 gpt-load \

--- a/internal/webui/workflow_test.go
+++ b/internal/webui/workflow_test.go
@@ -1955,11 +1955,36 @@ func TestDockerfilePinsBuildAndRuntimeImagesByVersionAndDigest(t *testing.T) {
 		"pnpm@11.17.0",
 		"golang:1.26.6-alpine3.24@sha256:af8d6740070b8906d12eae1c3e3ea0957fb63f492051ea05e354c38ef9fe88df",
 		"alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b",
-		"apk upgrade --no-cache libcrypto3 libssl3",
 	} {
 		if !strings.Contains(content, required) {
 			t.Errorf("Dockerfile does not contain %q", required)
 		}
+	}
+}
+
+func TestDockerfileRuntimePinsPatchedOpenSSLPackages(t *testing.T) {
+	content := readRepositoryFile(t, "Dockerfile")
+	runtimeStart := strings.Index(content, "\nFROM alpine:")
+	if runtimeStart < 0 {
+		t.Fatal("Dockerfile does not contain the shared runtime stage")
+	}
+	runtimeEnd := strings.Index(content[runtimeStart+1:], "\nFROM ")
+	if runtimeEnd < 0 {
+		t.Fatal("Dockerfile runtime stage has no following stage")
+	}
+	runtimeStage := content[runtimeStart : runtimeStart+1+runtimeEnd]
+
+	upgrade := "apk add --no-cache libcrypto3=3.5.8-r0 libssl3=3.5.8-r0"
+	upgradeIndex := strings.Index(runtimeStage, upgrade)
+	if upgradeIndex < 0 {
+		t.Fatalf("Dockerfile runtime stage does not pin patched OpenSSL packages via %q", upgrade)
+	}
+	packageInstallIndex := strings.Index(runtimeStage, "apk add --no-cache ca-certificates tzdata")
+	if packageInstallIndex < 0 {
+		t.Fatal("Dockerfile runtime stage does not install certificate and timezone packages")
+	}
+	if upgradeIndex >= packageInstallIndex {
+		t.Fatal("Dockerfile upgrades OpenSSL after installing certificate and timezone packages")
 	}
 }
 

--- a/internal/webui/workflow_test.go
+++ b/internal/webui/workflow_test.go
@@ -1955,6 +1955,7 @@ func TestDockerfilePinsBuildAndRuntimeImagesByVersionAndDigest(t *testing.T) {
 		"pnpm@11.17.0",
 		"golang:1.26.6-alpine3.24@sha256:af8d6740070b8906d12eae1c3e3ea0957fb63f492051ea05e354c38ef9fe88df",
 		"alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b",
+		"apk upgrade --no-cache libcrypto3 libssl3",
 	} {
 		if !strings.Contains(content, required) {
 			t.Errorf("Dockerfile does not contain %q", required)


### PR DESCRIPTION
### 关联 Issue / Related Issue
N/A

### 变更内容 / Change Content
- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

在固定的 Alpine 3.24.1 runtime 中，显式升级 `libcrypto3` 与 `libssl3`。这会将镜像内的 OpenSSL 从 3.5.7-r0 更新至 3.5.8-r0，消除导致 beta.18 发布扫描失败的 CVE-2026-14456。

补充 Dockerfile 契约测试，防止后续移除该运行时安全更新。未改变基础镜像 digest、应用二进制构建路径、公开 API 或数据格式。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.（无公开文档或发布说明变更需要）
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.（无兼容性或数据迁移影响）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **安全性**
  - 更新运行环境中的加密库，提升应用运行时的安全性与稳定性。
- **质量改进**
  - 增加构建流程校验，确保关键安全组件能够按预期完成升级。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->