### PR TITLE
fix(groups): 切页时重新获取分组选项

### DIFF
--- a/web/src/app/resources/groups.ts
+++ b/web/src/app/resources/groups.ts
@@ -654,6 +654,8 @@ export function groupOptionsQueryOptions(
     queryKey: controlQueryKeys.groups.options(),
     queryFn: ({ signal }) => listGroupOptions(client, signal),
     enabled: computed(() => toValue(enabled)),
+    // Group 选项目录可能由其他页面或标签页修改，进入消费者页面时必须重新校验。
+    refetchOnMount: 'always',
   })
 }
 

--- a/web/src/features/monitor/UsageTab.vue
+++ b/web/src/features/monitor/UsageTab.vue
@@ -73,7 +73,6 @@ const filterErrors = ref<UsageFilterErrors>({})
 
 const groupsQuery = useQuery({
   ...groupOptionsQueryOptions(client, () => !isAccessKey.value),
-  refetchOnMount: false,
 })
 const channelsQuery = useQuery({
   queryKey: controlQueryKeys.channels.list(''),


### PR DESCRIPTION
### 关联 Issue / Related Issue

N/A（PR #470 的后续修复）

### 变更内容 / Change Content

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

- 修正 PR #470 只依赖模型保存方更新/失效 Vue Query 缓存的错误边界。
- `/api/groups/options` 是可由其他页面、标签页或 API 修改的动态基础目录；现在共享查询在消费者页面挂载时始终重新向后端校验，不再把跨页面缓存永久视为新鲜数据。
- 访问密钥模型范围、路由检查、日志筛选和现有 Group 导入因此会在普通 SPA 切页后获取最新 Group 选项，无需整页刷新。
- 保留既有模型派生缓存失效，不修改后端 API、持久化格式或全局缓存策略。

已核对 v2.0.0-beta.18 的实际发布二进制包含 PR #470 前端代码，因此问题属于原方案边界错误，不是 Release 制品漏打包。

验证：`make check` 通过；提交后 ESLint 与 TypeScript 类型检查再次通过。

### 自查清单 / Checklist

- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.

本次修复不需要公开文档更新，不包含兼容性变化或数据迁移。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 组件挂载时始终刷新 Group 选项数据，确保显示最新内容。
  * 优化用量页面的 Group 数据刷新行为，提升数据时效性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->