### PR TITLE
fix(release): 统一使用版本号作为标题

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1039,7 +1039,7 @@ jobs:
         if: ${{ needs.publication-preflight.outputs.write_mode == 'publish' }}
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
-          name: GPT-Load ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           target_commitish: ${{ github.sha }}
           draft: true
           prerelease: ${{ needs.validate-tag.outputs.prerelease }}

--- a/internal/webui/workflow_test.go
+++ b/internal/webui/workflow_test.go
@@ -1303,6 +1303,13 @@ func TestReleaseWorkflowKeepsReleaseNotesConciseAndWarnsAboutDataIncompatibility
 	releaseJob := workflowJobBlock(t, content, "publish-github")
 	draftStep := workflowStepBlock(t, releaseJob, "Create or update GitHub Release draft")
 
+	if !strings.Contains(draftStep, "name: ${{ github.ref_name }}") {
+		t.Fatalf("release draft title must be the tag version only:\n%s", draftStep)
+	}
+	if strings.Contains(draftStep, "name: GPT-Load ${{ github.ref_name }}") {
+		t.Fatalf("release draft title must not include the product prefix:\n%s", draftStep)
+	}
+
 	// generate_release_notes 已经从 commit 历史生成"本次变更"部分，手写 body
 	// 只需要保留一次性读不到就可能造成数据损坏的警告，其余标准运维信息
 	// （备份、tag 语义、usage 是 estimate 等）都是跨版本不变的事实，交给 README


### PR DESCRIPTION
### 关联 Issue / Related Issue
无（本次为发布标题格式修复，无关联 Issue）。

### 变更内容 / Change Content
- [ ] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [x] 其他改动 / Other changes

将 GitHub Release draft 的标题改为直接使用 `github.ref_name`，后续发布标题统一为 `v2.0.0-beta.18` 这类仅版本号格式；同时增加工作流回归断言，防止重新加入 `GPT-Load` 前缀。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / 本次仅变更 Release 标题格式，无需更新公开文档或发布说明。
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / 本次无兼容性或数据迁移影响。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **发布**
  - GitHub Release 草稿标题将仅显示版本号，不再添加产品名称前缀。

- **测试**
  - 增加了对 Release 草稿标题格式的校验，确保其符合新的展示规范。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->