### PR TITLE
fix(subscription): 统一合并 CPA 模型目录

### DIFF
--- a/internal/subscription/providers/antigravity/driver.go
+++ b/internal/subscription/providers/antigravity/driver.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	cpaembedded "github.com/router-for-me/CLIProxyAPI/v7/gptload-embedded/embedded"
+
 	"gpt-load/internal/channel/modules"
 	"gpt-load/internal/channel/spec"
 	subscriptionruntime "gpt-load/internal/subscription/runtime"
@@ -130,7 +132,7 @@ func (*antigravityDriver) DiscoverModels(ctx context.Context, credential subscri
 	for _, model := range models {
 		result = append(result, model.ID)
 	}
-	return result, nil
+	return cpaembedded.MergeModelCatalog(cpaembedded.ProviderAntigravity, result), nil
 }
 
 func (*antigravityDriver) Observe(ctx context.Context, credential subscriptionruntime.Credential) (subscriptionruntime.Observation, error) {

--- a/internal/subscription/providers/codex/driver.go
+++ b/internal/subscription/providers/codex/driver.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	cpaembedded "github.com/router-for-me/CLIProxyAPI/v7/gptload-embedded/embedded"
+
 	"gpt-load/internal/channel/modules"
 	"gpt-load/internal/channel/spec"
 	subscriptionruntime "gpt-load/internal/subscription/runtime"
@@ -142,7 +144,7 @@ func (*codexDriver) DiscoverModels(ctx context.Context, credential subscriptionr
 	for _, model := range models {
 		result = append(result, model.ID)
 	}
-	return result, nil
+	return cpaembedded.MergeModelCatalog(cpaembedded.ProviderCodex, result), nil
 }
 
 func (*codexDriver) Observe(ctx context.Context, credential subscriptionruntime.Credential) (subscriptionruntime.Observation, error) {

--- a/internal/subscription/providers/grok/driver.go
+++ b/internal/subscription/providers/grok/driver.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	cpaembedded "github.com/router-for-me/CLIProxyAPI/v7/gptload-embedded/embedded"
+
 	"gpt-load/internal/channel/modules"
 	"gpt-load/internal/channel/spec"
 	subscriptionruntime "gpt-load/internal/subscription/runtime"
@@ -141,7 +143,7 @@ func (*grokDriver) DiscoverModels(ctx context.Context, credential subscriptionru
 		}
 		return nil, err
 	}
-	return models, nil
+	return cpaembedded.MergeModelCatalog(cpaembedded.ProviderGrok, models), nil
 }
 
 func (*grokDriver) Observe(ctx context.Context, credential subscriptionruntime.Credential) (subscriptionruntime.Observation, error) {

--- a/third_party/cpaembedded/embedded/model_catalog.go
+++ b/third_party/cpaembedded/embedded/model_catalog.go
@@ -1,0 +1,68 @@
+package embedded
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+// MergeModelCatalog is the narrow CPA-owned model catalog seam used by
+// subscription discovery. The caller must invoke it only after the account's
+// live model request succeeds.
+func MergeModelCatalog(provider string, upstream []string) []string {
+	provider = strings.TrimSpace(provider)
+	result := normalizeModelIDs(upstream)
+	if strings.EqualFold(provider, ProviderAntigravity) {
+		filtered := result[:0]
+		for _, id := range result {
+			if _, excluded := antigravityExcludedModelIDs[id]; excluded {
+				continue
+			}
+			filtered = append(filtered, id)
+		}
+		result = filtered
+	}
+	seen := make(map[string]struct{}, len(result))
+	for _, value := range result {
+		seen[value] = struct{}{}
+	}
+	for _, model := range registry.GetStaticModelDefinitionsByChannel(provider) {
+		if model == nil {
+			continue
+		}
+		id := strings.TrimSpace(model.ID)
+		if id == "" || strings.ContainsAny(id, "\r\n\x00") {
+			continue
+		}
+		if strings.EqualFold(provider, ProviderAntigravity) {
+			if _, excluded := antigravityExcludedModelIDs[id]; excluded {
+				continue
+			}
+		}
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = struct{}{}
+		result = append(result, id)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func normalizeModelIDs(values []string) []string {
+	result := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		id := strings.TrimSpace(value)
+		if id == "" || strings.ContainsAny(id, "\r\n\x00") {
+			continue
+		}
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = struct{}{}
+		result = append(result, id)
+	}
+	return result
+}

--- a/third_party/cpaembedded/embedded/model_catalog_test.go
+++ b/third_party/cpaembedded/embedded/model_catalog_test.go
@@ -1,0 +1,79 @@
+package embedded
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+func TestMergeModelCatalogUsesCPAStaticDefinitionsForEverySubscriptionChannel(t *testing.T) {
+	t.Parallel()
+
+	for _, provider := range []string{ProviderCodex, ProviderClaude, ProviderAntigravity, ProviderGrok} {
+		t.Run(provider, func(t *testing.T) {
+			static := registry.GetStaticModelDefinitionsByChannel(provider)
+			if len(static) == 0 {
+				t.Fatalf("CPA static catalog for %q is empty", provider)
+			}
+			catalogID := ""
+			for _, model := range static {
+				if model != nil && strings.TrimSpace(model.ID) != "" {
+					candidate := strings.TrimSpace(model.ID)
+					if provider == ProviderAntigravity {
+						if _, excluded := antigravityExcludedModelIDs[candidate]; excluded {
+							continue
+						}
+					}
+					catalogID = candidate
+					break
+				}
+			}
+			if catalogID == "" {
+				t.Fatalf("CPA static catalog for %q has no usable model ID", provider)
+			}
+
+			got := MergeModelCatalog(provider, []string{" upstream-only ", catalogID, catalogID})
+			if !sort.StringsAreSorted(got) || !containsModelID(got, "upstream-only") || !containsModelID(got, catalogID) {
+				t.Fatalf("merged model IDs = %#v", got)
+			}
+			if len(got) != len(uniqueModelIDs(got)) {
+				t.Fatalf("merged model IDs contain duplicates: %#v", got)
+			}
+		})
+	}
+}
+
+func TestMergeModelCatalogKeepsAntigravityExcludedModelsOut(t *testing.T) {
+	t.Parallel()
+
+	got := MergeModelCatalog("antigravity", []string{"gemini-2.5-pro"})
+	for id := range antigravityExcludedModelIDs {
+		if containsModelID(got, id) {
+			t.Fatalf("merged Antigravity catalog retained excluded model %q: %#v", id, got)
+		}
+	}
+}
+
+func containsModelID(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func uniqueModelIDs(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}


### PR DESCRIPTION
### 关联 Issue / Related Issue
暂无关联 Issue。

### 变更内容 / Change Content
- [ ] Bug 修复 / Bug fix
- [x] 新功能 / New feature
- [ ] 其他改动 / Other changes

为 CPA 订阅模型发现补齐统一的目录合并行为：

- Codex、Antigravity、Grok 先请求账号真实上游模型列表，成功后再由 CPA 嵌入依赖提供对应静态目录并合并。
- CPA 目录合并统一做去空白、去重和稳定排序；重复模型 ID 保留上游结果。
- Antigravity 沿用 CPA 已有的可靠排除项，避免目录重新加入被排除模型。
- Claude 保留现有 bootstrap entitlement、CPA 静态目录及 denied 过滤路径。
- 上游请求失败保持发现失败，不使用 CPA 目录伪装可用模型。

范围保持在现有 `[]string` discovery 契约和 `ModelDiscoveryResult` 公共返回结构；未新增 source 元数据或前端展示，不自动保存 Group、不改变路由、不建立 model-operation 能力表，也未实现图片 usage 或计价。对于没有可靠显式排除语义的渠道，继续按当前 CPA/上游可确认信息处理。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented any compatibility or data-migration impact.

验证：`go test ./embedded -count=1`（third_party/cpaembedded）、`go test ./internal/subscription/... ./internal/control/... -count=1`、`make check`。无数据迁移。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 优化多个订阅渠道的模型发现结果，自动补充内置模型目录中的可用模型。
  - 模型列表现已自动清理重复项、过滤无效项并排序，展示结果更加稳定一致。
  - 针对特定渠道自动排除不支持的模型，避免显示无法使用的选项。

- **测试**
  - 增加模型目录合并、去重排序及渠道专属过滤规则的验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->