### PR TITLE
feat(usage): 接入 OpenAI 图片用量计价

### DIFF
--- a/internal/dialect/openai_images_usage.go
+++ b/internal/dialect/openai_images_usage.go
@@ -9,11 +9,14 @@ import (
 )
 
 func (d *OpenAIImages) ExtractUsage(body []byte) (usage.Result, error) {
-	object, err := decodeJSONObject(body)
+	envelope, err := decodeOpenAIImagesUsageEnvelope(body)
 	if err != nil {
 		return usage.Result{}, fmt.Errorf("decode OpenAI Images usage response")
 	}
-	patch, found := openAIImagesUsagePatch(object, true)
+	patch, found := openAIImagesUsagePatch(
+		openAIImagesUsageRoot(envelope.Usage),
+		true,
+	)
 	var accumulator usage.Accumulator
 	if found {
 		if err := accumulator.ReplaceSnapshot(patch); err != nil {
@@ -36,7 +39,7 @@ type openAIImagesUsageStreamExtractor struct {
 	terminal       bool
 }
 
-type openAIImagesUsageStreamEnvelope struct {
+type openAIImagesUsageEnvelope struct {
 	Type  json.RawMessage `json:"type"`
 	Usage json.RawMessage `json:"usage"`
 }
@@ -48,7 +51,7 @@ func (e *openAIImagesUsageStreamExtractor) Observe(payload []byte) error {
 func (e *openAIImagesUsageStreamExtractor) ObserveStreamEvent(
 	event StreamEvent,
 ) error {
-	envelope, err := decodeOpenAIImagesUsageStreamEnvelope(event.Payload)
+	envelope, err := decodeOpenAIImagesUsageEnvelope(event.Payload)
 	if err != nil {
 		e.invalidPayload = true
 		return e.accumulator.MergePatch(usage.Patch{
@@ -80,11 +83,10 @@ func (e *openAIImagesUsageStreamExtractor) ObserveStreamEvent(
 	}
 
 	terminal := openAIImagesUsageTerminal(eventType)
-	root := make(map[string]json.RawMessage, 1)
-	if len(envelope.Usage) > 0 {
-		root["usage"] = envelope.Usage
-	}
-	patch, found := openAIImagesUsagePatch(root, terminal)
+	patch, found := openAIImagesUsagePatch(
+		openAIImagesUsageRoot(envelope.Usage),
+		terminal,
+	)
 
 	if terminal || found {
 		if err := e.accumulator.ReplaceSnapshot(patch); err != nil {
@@ -96,17 +98,25 @@ func (e *openAIImagesUsageStreamExtractor) ObserveStreamEvent(
 	return e.accumulator.MergePatch(patch)
 }
 
-func decodeOpenAIImagesUsageStreamEnvelope(
+func decodeOpenAIImagesUsageEnvelope(
 	payload []byte,
-) (openAIImagesUsageStreamEnvelope, error) {
+) (openAIImagesUsageEnvelope, error) {
 	if trimmed := bytes.TrimSpace(payload); len(trimmed) == 0 || trimmed[0] != '{' {
-		return openAIImagesUsageStreamEnvelope{}, fmt.Errorf("decode JSON object")
+		return openAIImagesUsageEnvelope{}, fmt.Errorf("decode JSON object")
 	}
-	var envelope openAIImagesUsageStreamEnvelope
+	var envelope openAIImagesUsageEnvelope
 	if err := json.Unmarshal(payload, &envelope); err != nil {
-		return openAIImagesUsageStreamEnvelope{}, fmt.Errorf("decode JSON object")
+		return openAIImagesUsageEnvelope{}, fmt.Errorf("decode JSON object")
 	}
 	return envelope, nil
+}
+
+func openAIImagesUsageRoot(raw json.RawMessage) map[string]json.RawMessage {
+	root := make(map[string]json.RawMessage, 1)
+	if len(raw) > 0 {
+		root["usage"] = raw
+	}
+	return root
 }
 
 func openAIImagesUsageStreamEventType(raw json.RawMessage) (string, bool) {
@@ -156,9 +166,6 @@ func openAIImagesUsagePatch(
 	diagnostics.Merge(outputDiagnostics)
 	total, totalDiagnostics := usageInteger(usageObject, "total_tokens", false)
 	diagnostics.Merge(totalDiagnostics)
-
-	_, detailDiagnostics := usageOptionalObject(usageObject, "input_tokens_details")
-	diagnostics.Merge(detailDiagnostics)
 
 	patch := usage.Patch{Final: final, Diagnostics: diagnostics}
 	if input != nil {

--- a/internal/dialect/openai_images_usage.go
+++ b/internal/dialect/openai_images_usage.go
@@ -1,6 +1,7 @@
 package dialect
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -35,6 +36,11 @@ type openAIImagesUsageStreamExtractor struct {
 	terminal       bool
 }
 
+type openAIImagesUsageStreamEnvelope struct {
+	Type  json.RawMessage `json:"type"`
+	Usage json.RawMessage `json:"usage"`
+}
+
 func (e *openAIImagesUsageStreamExtractor) Observe(payload []byte) error {
 	return e.ObserveStreamEvent(StreamEvent{Payload: payload})
 }
@@ -42,14 +48,14 @@ func (e *openAIImagesUsageStreamExtractor) Observe(payload []byte) error {
 func (e *openAIImagesUsageStreamExtractor) ObserveStreamEvent(
 	event StreamEvent,
 ) error {
-	object, err := decodeJSONObject(event.Payload)
+	envelope, err := decodeOpenAIImagesUsageStreamEnvelope(event.Payload)
 	if err != nil {
 		e.invalidPayload = true
 		return e.accumulator.MergePatch(usage.Patch{
 			Diagnostics: usageDiagnostic(usage.DiagnosticInvalidPayload),
 		})
 	}
-	eventType, typeValid := responsesUsageEventType(object)
+	eventType, typeValid := openAIImagesUsageStreamEventType(envelope.Type)
 	if !typeValid {
 		e.invalidPayload = true
 		if err := e.accumulator.MergePatch(usage.Patch{
@@ -74,7 +80,11 @@ func (e *openAIImagesUsageStreamExtractor) ObserveStreamEvent(
 	}
 
 	terminal := openAIImagesUsageTerminal(eventType)
-	patch, found := openAIImagesUsagePatch(object, terminal)
+	root := make(map[string]json.RawMessage, 1)
+	if len(envelope.Usage) > 0 {
+		root["usage"] = envelope.Usage
+	}
+	patch, found := openAIImagesUsagePatch(root, terminal)
 
 	if terminal || found {
 		if err := e.accumulator.ReplaceSnapshot(patch); err != nil {
@@ -84,6 +94,30 @@ func (e *openAIImagesUsageStreamExtractor) ObserveStreamEvent(
 		return nil
 	}
 	return e.accumulator.MergePatch(patch)
+}
+
+func decodeOpenAIImagesUsageStreamEnvelope(
+	payload []byte,
+) (openAIImagesUsageStreamEnvelope, error) {
+	if trimmed := bytes.TrimSpace(payload); len(trimmed) == 0 || trimmed[0] != '{' {
+		return openAIImagesUsageStreamEnvelope{}, fmt.Errorf("decode JSON object")
+	}
+	var envelope openAIImagesUsageStreamEnvelope
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return openAIImagesUsageStreamEnvelope{}, fmt.Errorf("decode JSON object")
+	}
+	return envelope, nil
+}
+
+func openAIImagesUsageStreamEventType(raw json.RawMessage) (string, bool) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return "", true
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil || value == "" {
+		return "", false
+	}
+	return value, true
 }
 
 func (e *openAIImagesUsageStreamExtractor) Finalize() (usage.Result, bool) {

--- a/internal/dialect/openai_images_usage.go
+++ b/internal/dialect/openai_images_usage.go
@@ -1,0 +1,146 @@
+package dialect
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"gpt-load/internal/usage"
+)
+
+func (d *OpenAIImages) ExtractUsage(body []byte) (usage.Result, error) {
+	object, err := decodeJSONObject(body)
+	if err != nil {
+		return usage.Result{}, fmt.Errorf("decode OpenAI Images usage response")
+	}
+	patch, found := openAIImagesUsagePatch(object, true)
+	var accumulator usage.Accumulator
+	if found {
+		if err := accumulator.ReplaceSnapshot(patch); err != nil {
+			return usage.Result{}, fmt.Errorf("normalize OpenAI Images usage response")
+		}
+	} else if err := accumulator.MergePatch(patch); err != nil {
+		return usage.Result{}, fmt.Errorf("normalize OpenAI Images usage response")
+	}
+	result, _ := accumulator.Finalize(true)
+	return result, nil
+}
+
+func (d *OpenAIImages) NewUsageStreamExtractor() UsageStreamExtractor {
+	return &openAIImagesUsageStreamExtractor{}
+}
+
+type openAIImagesUsageStreamExtractor struct {
+	accumulator    usage.Accumulator
+	invalidPayload bool
+	terminal       bool
+}
+
+func (e *openAIImagesUsageStreamExtractor) Observe(payload []byte) error {
+	return e.ObserveStreamEvent(StreamEvent{Payload: payload})
+}
+
+func (e *openAIImagesUsageStreamExtractor) ObserveStreamEvent(
+	event StreamEvent,
+) error {
+	object, err := decodeJSONObject(event.Payload)
+	if err != nil {
+		e.invalidPayload = true
+		return e.accumulator.MergePatch(usage.Patch{
+			Diagnostics: usageDiagnostic(usage.DiagnosticInvalidPayload),
+		})
+	}
+	eventType, typeValid := responsesUsageEventType(object)
+	if !typeValid {
+		e.invalidPayload = true
+		if err := e.accumulator.MergePatch(usage.Patch{
+			Diagnostics: usageDiagnostic(usage.DiagnosticInvalidPayload),
+		}); err != nil {
+			return err
+		}
+	}
+	if event.Name != "" && eventType != "" && event.Name != eventType {
+		e.invalidPayload = true
+		return e.accumulator.MergePatch(usage.Patch{
+			Diagnostics: usageDiagnostic(usage.DiagnosticInvalidPayload),
+		})
+	}
+	if e.terminal {
+		return e.accumulator.MergePatch(usage.Patch{
+			Diagnostics: usageDiagnostic(usage.DiagnosticInvalidEventSequence),
+		})
+	}
+	if event.Name != "" {
+		eventType = event.Name
+	}
+
+	terminal := openAIImagesUsageTerminal(eventType)
+	patch, found := openAIImagesUsagePatch(object, terminal)
+
+	if terminal || found {
+		if err := e.accumulator.ReplaceSnapshot(patch); err != nil {
+			return err
+		}
+		e.terminal = terminal
+		return nil
+	}
+	return e.accumulator.MergePatch(patch)
+}
+
+func (e *openAIImagesUsageStreamExtractor) Finalize() (usage.Result, bool) {
+	result, finalized := e.accumulator.Finalize(true)
+	if !finalized {
+		return result, false
+	}
+	if e.invalidPayload {
+		result.Diagnostics.Add(usage.DiagnosticInvalidPayload)
+	}
+	return result, true
+}
+
+func openAIImagesUsageTerminal(eventType string) bool {
+	switch eventType {
+	case "image_generation.completed", "image_edit.completed",
+		"image_generation.failed", "image_edit.failed", "error":
+		return true
+	default:
+		return false
+	}
+}
+
+func openAIImagesUsagePatch(
+	root map[string]json.RawMessage,
+	final bool,
+) (usage.Patch, bool) {
+	usageObject, diagnostics := usageOptionalObject(root, "usage")
+	if usageObject == nil {
+		return usage.Patch{Final: final, Diagnostics: diagnostics}, false
+	}
+
+	input, inputDiagnostics := usageInteger(usageObject, "input_tokens", true)
+	diagnostics.Merge(inputDiagnostics)
+	output, outputDiagnostics := usageInteger(usageObject, "output_tokens", true)
+	diagnostics.Merge(outputDiagnostics)
+	total, totalDiagnostics := usageInteger(usageObject, "total_tokens", false)
+	diagnostics.Merge(totalDiagnostics)
+
+	_, detailDiagnostics := usageOptionalObject(usageObject, "input_tokens_details")
+	diagnostics.Merge(detailDiagnostics)
+
+	patch := usage.Patch{Final: final, Diagnostics: diagnostics}
+	if input != nil {
+		patch.UncachedInput = input
+	}
+	if output != nil {
+		patch.Output = output
+	}
+
+	tokens := usage.Tokens{}
+	if patch.UncachedInput != nil {
+		tokens.UncachedInput = *patch.UncachedInput
+	}
+	if patch.Output != nil {
+		tokens.Output = *patch.Output
+	}
+	usageNormalizedTotal(total, tokens, &patch.Diagnostics)
+	return patch, true
+}

--- a/internal/dialect/openai_images_usage_test.go
+++ b/internal/dialect/openai_images_usage_test.go
@@ -1,6 +1,7 @@
 package dialect
 
 import (
+	"strings"
 	"testing"
 
 	"gpt-load/internal/usage"
@@ -200,5 +201,27 @@ func TestOpenAIImagesUsageStreamingRejectsEventNameConflict(t *testing.T) {
 	if !finalized || result.State != usage.StateMissing ||
 		!result.Diagnostics.Has(usage.DiagnosticInvalidPayload) {
 		t.Fatalf("Finalize() = %#v, %t, want missing invalid-payload result", result, finalized)
+	}
+}
+
+func TestOpenAIImagesUsageStreamEnvelopeSkipsImageData(t *testing.T) {
+	t.Parallel()
+
+	imageData := strings.Repeat("A", 1<<20)
+	payload := []byte(`{"type":"image_generation.completed","b64_json":"` + imageData + `","usage":{"input_tokens":100,"output_tokens":30,"total_tokens":130}}`)
+	envelope, err := decodeOpenAIImagesUsageStreamEnvelope(payload)
+	if err != nil || string(envelope.Type) != `"image_generation.completed"` ||
+		string(envelope.Usage) != `{"input_tokens":100,"output_tokens":30,"total_tokens":130}` {
+		t.Fatalf("decodeOpenAIImagesUsageStreamEnvelope() = %#v, %v", envelope, err)
+	}
+
+	stream := NewOpenAIImages().NewUsageStreamExtractor()
+	if err := stream.Observe(payload); err != nil {
+		t.Fatalf("Observe() error = %v", err)
+	}
+	result, finalized := stream.Finalize()
+	if !finalized || result.State != usage.StateComplete ||
+		result.Tokens != (usage.Tokens{UncachedInput: 100, Output: 30}) {
+		t.Fatalf("Finalize() = %#v, %t", result, finalized)
 	}
 }

--- a/internal/dialect/openai_images_usage_test.go
+++ b/internal/dialect/openai_images_usage_test.go
@@ -45,6 +45,18 @@ func TestOpenAIImagesUsageNonStreaming(t *testing.T) {
 			want: usage.Tokens{UncachedInput: 100, Output: 30},
 		},
 		{
+			name: "input token details are ignored",
+			body: `{
+				"usage": {
+					"input_tokens": 100,
+					"input_tokens_details": "ignored",
+					"output_tokens": 30,
+					"total_tokens": 130
+				}
+			}`,
+			want: usage.Tokens{UncachedInput: 100, Output: 30},
+		},
+		{
 			name:        "negative input is diagnosed",
 			body:        `{"usage":{"input_tokens":-1,"output_tokens":30,"total_tokens":30}}`,
 			want:        usage.Tokens{Output: 30},
@@ -204,19 +216,31 @@ func TestOpenAIImagesUsageStreamingRejectsEventNameConflict(t *testing.T) {
 	}
 }
 
-func TestOpenAIImagesUsageStreamEnvelopeSkipsImageData(t *testing.T) {
+func TestOpenAIImagesUsageEnvelopeSkipsImageData(t *testing.T) {
 	t.Parallel()
 
 	imageData := strings.Repeat("A", 1<<20)
-	payload := []byte(`{"type":"image_generation.completed","b64_json":"` + imageData + `","usage":{"input_tokens":100,"output_tokens":30,"total_tokens":130}}`)
-	envelope, err := decodeOpenAIImagesUsageStreamEnvelope(payload)
+	usageJSON := `{"input_tokens":100,"output_tokens":30,"total_tokens":130}`
+	unaryPayload := []byte(`{"data":[{"b64_json":"` + imageData + `"}],"usage":` + usageJSON + `}`)
+	envelope, err := decodeOpenAIImagesUsageEnvelope(unaryPayload)
+	if err != nil || len(envelope.Type) != 0 || string(envelope.Usage) != usageJSON {
+		t.Fatalf("decodeOpenAIImagesUsageEnvelope(unary) = %#v, %v", envelope, err)
+	}
+	unaryResult, err := NewOpenAIImages().ExtractUsage(unaryPayload)
+	if err != nil || unaryResult.State != usage.StateComplete ||
+		unaryResult.Tokens != (usage.Tokens{UncachedInput: 100, Output: 30}) {
+		t.Fatalf("ExtractUsage() = %#v, %v", unaryResult, err)
+	}
+
+	streamPayload := []byte(`{"type":"image_generation.completed","b64_json":"` + imageData + `","usage":` + usageJSON + `}`)
+	envelope, err = decodeOpenAIImagesUsageEnvelope(streamPayload)
 	if err != nil || string(envelope.Type) != `"image_generation.completed"` ||
-		string(envelope.Usage) != `{"input_tokens":100,"output_tokens":30,"total_tokens":130}` {
-		t.Fatalf("decodeOpenAIImagesUsageStreamEnvelope() = %#v, %v", envelope, err)
+		string(envelope.Usage) != usageJSON {
+		t.Fatalf("decodeOpenAIImagesUsageEnvelope(stream) = %#v, %v", envelope, err)
 	}
 
 	stream := NewOpenAIImages().NewUsageStreamExtractor()
-	if err := stream.Observe(payload); err != nil {
+	if err := stream.Observe(streamPayload); err != nil {
 		t.Fatalf("Observe() error = %v", err)
 	}
 	result, finalized := stream.Finalize()

--- a/internal/dialect/openai_images_usage_test.go
+++ b/internal/dialect/openai_images_usage_test.go
@@ -1,0 +1,204 @@
+package dialect
+
+import (
+	"testing"
+
+	"gpt-load/internal/usage"
+)
+
+func TestOpenAIImagesUsageNonStreaming(t *testing.T) {
+	t.Parallel()
+
+	extractor, ok := any(NewOpenAIImages()).(UsageExtractor)
+	if !ok {
+		t.Fatal("OpenAI Images does not expose UsageExtractor capability")
+	}
+	tests := []struct {
+		name        string
+		body        string
+		want        usage.Tokens
+		diagnostics []usage.DiagnosticCode
+		wantDelta   *int64
+	}{
+		{
+			name: "generation includes text and image input details",
+			body: `{
+				"created": 123,
+				"data": [{"b64_json":"AA=="}],
+				"usage": {
+					"input_tokens": 100,
+					"input_tokens_details": {"text_tokens": 4, "image_tokens": 96},
+					"output_tokens": 30,
+					"total_tokens": 130
+				}
+			}`,
+			want: usage.Tokens{UncachedInput: 100, Output: 30},
+		},
+		{
+			name: "edit uses the same standard usage fields",
+			body: `{
+				"created": 123,
+				"data": [{"b64_json":"AA=="}],
+				"usage": {"input_tokens": 100, "output_tokens": 30, "total_tokens": 130}
+			}`,
+			want: usage.Tokens{UncachedInput: 100, Output: 30},
+		},
+		{
+			name:        "negative input is diagnosed",
+			body:        `{"usage":{"input_tokens":-1,"output_tokens":30,"total_tokens":30}}`,
+			want:        usage.Tokens{Output: 30},
+			diagnostics: []usage.DiagnosticCode{usage.DiagnosticNegativeValue},
+		},
+		{
+			name:        "fractional input is diagnosed",
+			body:        `{"usage":{"input_tokens":1.5,"output_tokens":30,"total_tokens":30}}`,
+			want:        usage.Tokens{Output: 30},
+			diagnostics: []usage.DiagnosticCode{usage.DiagnosticInvalidNumber},
+		},
+		{
+			name:        "missing required input is diagnosed",
+			body:        `{"usage":{"output_tokens":30}}`,
+			want:        usage.Tokens{Output: 30},
+			diagnostics: []usage.DiagnosticCode{usage.DiagnosticMissingRequiredField},
+		},
+		{
+			name:        "missing required output is diagnosed",
+			body:        `{"usage":{"input_tokens":100}}`,
+			want:        usage.Tokens{UncachedInput: 100},
+			diagnostics: []usage.DiagnosticCode{usage.DiagnosticMissingRequiredField},
+		},
+		{
+			name:        "inconsistent total is diagnosed",
+			body:        `{"usage":{"input_tokens":100,"output_tokens":30,"total_tokens":140}}`,
+			want:        usage.Tokens{UncachedInput: 100, Output: 30},
+			diagnostics: []usage.DiagnosticCode{usage.DiagnosticInconsistentTotal},
+			wantDelta:   int64Pointer(10),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := extractor.ExtractUsage([]byte(test.body))
+			if err != nil {
+				t.Fatalf("ExtractUsage() error = %v", err)
+			}
+			if result.State != usage.StateComplete || result.Tokens != test.want {
+				t.Fatalf("ExtractUsage() = %#v, want complete with %#v", result, test.want)
+			}
+			requireUsageDiagnostics(t, result.Diagnostics, test.diagnostics...)
+			if test.wantDelta != nil {
+				delta, present := result.Diagnostics.TotalDelta()
+				if !present || delta != *test.wantDelta {
+					t.Fatalf("TotalDelta() = %d, %t, want %d, true", delta, present, *test.wantDelta)
+				}
+			}
+		})
+	}
+}
+
+func TestOpenAIImagesUsageStreamingCompletedEvents(t *testing.T) {
+	t.Parallel()
+
+	extractor, ok := any(NewOpenAIImages()).(UsageExtractor)
+	if !ok {
+		t.Fatal("OpenAI Images does not expose UsageExtractor capability")
+	}
+	tests := []struct {
+		name        string
+		events      []StreamEvent
+		want        usage.Tokens
+		state       usage.State
+		diagnostics []usage.DiagnosticCode
+	}{
+		{
+			name: "generation completed event finalizes usage",
+			events: []StreamEvent{
+				{Payload: []byte(`{"type":"image_generation.partial_image","usage":{"input_tokens":100,"output_tokens":10,"total_tokens":110}}`)},
+				{Payload: []byte(`{"type":"image_generation.completed","usage":{"input_tokens":100,"input_tokens_details":{"text_tokens":4,"image_tokens":96},"output_tokens":30,"total_tokens":130}}`)},
+			},
+			want:  usage.Tokens{UncachedInput: 100, Output: 30},
+			state: usage.StateComplete,
+		},
+		{
+			name: "edit completed event can use explicit SSE name",
+			events: []StreamEvent{
+				{Name: "image_edit.completed", Payload: []byte(`{"usage":{"input_tokens":100,"output_tokens":30,"total_tokens":130}}`)},
+			},
+			want:  usage.Tokens{UncachedInput: 100, Output: 30},
+			state: usage.StateComplete,
+		},
+		{
+			name: "completed without usage discards earlier partial snapshot",
+			events: []StreamEvent{
+				{Payload: []byte(`{"type":"image_generation.partial_image","usage":{"input_tokens":100,"output_tokens":10}}`)},
+				{Payload: []byte(`{"type":"image_generation.completed","b64_json":"AA=="}`)},
+			},
+			state: usage.StateMissing,
+		},
+		{
+			name: "usage without completed event remains partial",
+			events: []StreamEvent{
+				{Payload: []byte(`{"type":"image_edit.partial_image","usage":{"input_tokens":100,"output_tokens":30}}`)},
+			},
+			want:  usage.Tokens{UncachedInput: 100, Output: 30},
+			state: usage.StatePartial,
+		},
+		{
+			name: "event after completed is diagnosed and ignored",
+			events: []StreamEvent{
+				{Payload: []byte(`{"type":"image_generation.completed","usage":{"input_tokens":100,"output_tokens":30,"total_tokens":130}}`)},
+				{Payload: []byte(`{"type":"image_generation.partial_image","usage":{"input_tokens":200,"output_tokens":40,"total_tokens":240}}`)},
+			},
+			want:        usage.Tokens{UncachedInput: 100, Output: 30},
+			state:       usage.StateComplete,
+			diagnostics: []usage.DiagnosticCode{usage.DiagnosticInvalidEventSequence},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			stream := extractor.NewUsageStreamExtractor()
+			observer, ok := stream.(UsageStreamEventObserver)
+			if !ok {
+				t.Fatal("OpenAI Images usage stream does not observe SSE event names")
+			}
+			for _, event := range test.events {
+				if err := observer.ObserveStreamEvent(event); err != nil {
+					t.Fatalf("ObserveStreamEvent() error = %v", err)
+				}
+			}
+			result, finalized := stream.Finalize()
+			if !finalized || result.State != test.state || result.Tokens != test.want {
+				t.Fatalf("Finalize() = %#v, %t, want state %q tokens %#v", result, finalized, test.state, test.want)
+			}
+			requireUsageDiagnostics(t, result.Diagnostics, test.diagnostics...)
+		})
+	}
+}
+
+func TestOpenAIImagesUsageStreamingRejectsEventNameConflict(t *testing.T) {
+	t.Parallel()
+
+	extractor, ok := any(NewOpenAIImages()).(UsageExtractor)
+	if !ok {
+		t.Fatal("OpenAI Images does not expose UsageExtractor capability")
+	}
+	stream := extractor.NewUsageStreamExtractor()
+	observer, ok := stream.(UsageStreamEventObserver)
+	if !ok {
+		t.Fatal("OpenAI Images usage stream does not observe SSE event names")
+	}
+	if err := observer.ObserveStreamEvent(StreamEvent{
+		Name:    "image_generation.completed",
+		Payload: []byte(`{"type":"image_edit.completed","usage":{"input_tokens":100,"output_tokens":30}}`),
+	}); err != nil {
+		t.Fatalf("ObserveStreamEvent() error = %v", err)
+	}
+	result, finalized := stream.Finalize()
+	if !finalized || result.State != usage.StateMissing ||
+		!result.Diagnostics.Has(usage.DiagnosticInvalidPayload) {
+		t.Fatalf("Finalize() = %#v, %t, want missing invalid-payload result", result, finalized)
+	}
+}

--- a/internal/dialect/stream_event.go
+++ b/internal/dialect/stream_event.go
@@ -43,5 +43,7 @@ type StreamEventClassifier interface {
 // UsageStreamEventObserver optionally lets a usage extractor observe the
 // explicit SSE event name in addition to its JSON payload.
 type UsageStreamEventObserver interface {
+	// ObserveStreamEvent consumes a borrowed payload valid only for this call.
+	// Implementations must not mutate or retain it.
 	ObserveStreamEvent(event StreamEvent) error
 }

--- a/internal/dialect/usage.go
+++ b/internal/dialect/usage.go
@@ -22,6 +22,7 @@ type StreamUsageInjector interface {
 
 var _ UsageExtractor = (*OpenAI)(nil)
 var _ UsageExtractor = (*OpenAIResponses)(nil)
+var _ UsageExtractor = (*OpenAIImages)(nil)
 var _ UsageExtractor = (*Anthropic)(nil)
 var _ UsageExtractor = (*Gemini)(nil)
 var _ StreamUsageInjector = (*OpenAI)(nil)

--- a/internal/dialect/usage.go
+++ b/internal/dialect/usage.go
@@ -4,12 +4,16 @@ import "gpt-load/internal/usage"
 
 // UsageExtractor optionally exposes provider-specific usage extraction.
 type UsageExtractor interface {
+	// ExtractUsage consumes a borrowed body valid only for this call.
+	// Implementations must not mutate or retain it.
 	ExtractUsage(body []byte) (usage.Result, error)
 	NewUsageStreamExtractor() UsageStreamExtractor
 }
 
 // UsageStreamExtractor extracts usage from one provider response stream.
 type UsageStreamExtractor interface {
+	// Observe consumes a borrowed payload valid only for this call.
+	// Implementations must not mutate or retain it.
 	Observe(payload []byte) error
 	Finalize() (usage.Result, bool)
 }

--- a/internal/gateway/execution_forward.go
+++ b/internal/gateway/execution_forward.go
@@ -46,16 +46,17 @@ func (forwarder *ExecutionForwarder) Forward(
 		return invalidExecutionAttemptResult(executionResult)
 	}
 	result := upstreamFromExecutionResult(ctx, input, executionResult)
+	result = forwarder.prepareBufferedResult(input, result)
 	if input.ClientProtocol == protocol.OpenAIImages && input.ObserveUsage &&
-		result.StatusCode >= http.StatusOK &&
+		result.HasResponse() && result.StatusCode >= http.StatusOK &&
 		result.StatusCode < http.StatusMultipleChoices &&
 		result.Usage.State == usage.StateMissing && forwarder.usageCapture != nil {
 		result.Usage = forwarder.usageCapture.extractNonStreamingPlain(
 			input.Dialect,
-			result.Body,
+			result.ClassificationBody,
 		)
 	}
-	return forwarder.prepareBufferedResult(input, result)
+	return result
 }
 
 func invalidExecutionAttemptResult(result execution.AttemptResult) UpstreamResult {

--- a/internal/gateway/execution_forward.go
+++ b/internal/gateway/execution_forward.go
@@ -46,6 +46,15 @@ func (forwarder *ExecutionForwarder) Forward(
 		return invalidExecutionAttemptResult(executionResult)
 	}
 	result := upstreamFromExecutionResult(ctx, input, executionResult)
+	if input.ClientProtocol == protocol.OpenAIImages && input.ObserveUsage &&
+		result.StatusCode >= http.StatusOK &&
+		result.StatusCode < http.StatusMultipleChoices &&
+		result.Usage.State == usage.StateMissing && forwarder.usageCapture != nil {
+		result.Usage = forwarder.usageCapture.extractNonStreamingPlain(
+			input.Dialect,
+			result.Body,
+		)
+	}
 	return forwarder.prepareBufferedResult(input, result)
 }
 

--- a/internal/gateway/execution_forward_test.go
+++ b/internal/gateway/execution_forward_test.go
@@ -86,6 +86,42 @@ func TestExecutionForwarderBuildsFrozenAttemptAndMapsUnaryResult(t *testing.T) {
 	}
 }
 
+func TestExecutionForwarderCapturesImagesUsageFromUnaryBody(t *testing.T) {
+	t.Parallel()
+
+	const responseBody = `{"created":123,"model":"upstream-image","data":[{"b64_json":"AA=="}],"usage":{"input_tokens":100,"input_tokens_details":{"text_tokens":4,"image_tokens":96},"output_tokens":30,"total_tokens":130}}`
+	executor := fakeExecutionExecutor{unary: func(
+		_ context.Context,
+		_ execution.AttemptSpec,
+	) execution.AttemptResult {
+		return execution.AttemptResult{
+			DispatchState:   execution.DispatchMaybeSent,
+			ResponseStarted: true,
+			StatusCode:      http.StatusOK,
+			Header:          http.Header{"Content-Type": {"application/json"}},
+			Body:            []byte(responseBody),
+			Model:           "upstream-image",
+		}
+	}}
+	input := executionForwardInput()
+	input.Dialect = dialect.NewOpenAIImages()
+	input.ClientProtocol = protocol.OpenAIImages
+	input.ObserveUsage = true
+	input.Operation = execution.OperationImagesGenerate
+	input.RouteRequirement = execution.RouteRequirementNative
+	input.Request.Path = "/v1/images/generations"
+	input.Request.Body = []byte(`{"model":"public-image","prompt":"draw"}`)
+
+	result := NewExecutionForwarder(executor).Forward(context.Background(), input)
+	want := usage.Result{
+		State:  usage.StateComplete,
+		Tokens: usage.Tokens{UncachedInput: 100, Output: 30},
+	}
+	if result.Err != nil || result.Usage != want {
+		t.Fatalf("Forward() usage = %#v, want %#v; result=%#v", result.Usage, want, result)
+	}
+}
+
 func TestExecutionForwarderKeepsHTTPFailureAsUncommittedResponse(t *testing.T) {
 	t.Parallel()
 
@@ -311,7 +347,7 @@ func TestExecutionForwarderAllowsImagesEventAboveDefaultLimit(t *testing.T) {
 		"data: {\"type\":\"image_generation.partial_image\",\"b64_json\":\"" +
 		strings.Repeat("A", maxSSEEventBytes+1) + "\"}\n\n"
 	completed := "event: image_generation.completed\n" +
-		"data: {\"type\":\"image_generation.completed\",\"b64_json\":\"AA==\"}\n\n"
+		"data: {\"type\":\"image_generation.completed\",\"b64_json\":\"AA==\",\"usage\":{\"input_tokens\":100,\"input_tokens_details\":{\"text_tokens\":4,\"image_tokens\":96},\"output_tokens\":30,\"total_tokens\":130}}\n\n"
 	executor := fakeExecutionExecutor{stream: func(
 		_ context.Context,
 		_ execution.AttemptSpec,
@@ -337,13 +373,16 @@ func TestExecutionForwarderAllowsImagesEventAboveDefaultLimit(t *testing.T) {
 	input := executionForwardInput()
 	input.Dialect = dialect.NewOpenAIImages()
 	input.ClientProtocol = protocol.OpenAIImages
+	input.ObserveUsage = true
 	input.Operation = execution.OperationImagesGenerate
 	input.Request.Path = "/v1/images/generations"
 	input.Request.RawQuery = ""
 	input.Request.Body = []byte(`{"model":"public","stream":true}`)
 	recorder := httptest.NewRecorder()
 	result := NewExecutionForwarder(executor).ForwardStream(context.Background(), input, recorder)
-	if result.Err != nil || !result.Committed || result.Stream.EndReason != StreamEndCleanEOF {
+	if result.Err != nil || !result.Committed || result.Stream.EndReason != StreamEndCleanEOF ||
+		result.Usage.State != usage.StateComplete ||
+		result.Usage.Tokens != (usage.Tokens{UncachedInput: 100, Output: 30}) {
 		t.Fatalf("ForwardStream() = %#v", result)
 	}
 	if !bytes.Equal(recorder.Body.Bytes(), []byte(partial+completed)) {

--- a/internal/gateway/execution_forward_test.go
+++ b/internal/gateway/execution_forward_test.go
@@ -16,6 +16,7 @@ import (
 	"gpt-load/internal/dialect"
 	"gpt-load/internal/execution"
 	"gpt-load/internal/health"
+	"gpt-load/internal/platform/contentcoding"
 	"gpt-load/internal/protocol"
 	"gpt-load/internal/reasoning"
 	"gpt-load/internal/state"
@@ -25,6 +26,31 @@ import (
 type fakeExecutionExecutor struct {
 	unary  func(context.Context, execution.AttemptSpec) execution.AttemptResult
 	stream func(context.Context, execution.AttemptSpec, execution.StreamSink) execution.StreamResult
+}
+
+type observingUsageDialect struct {
+	body []byte
+}
+
+func (*observingUsageDialect) Protocol() protocol.Protocol {
+	return protocol.OpenAIImages
+}
+
+func (*observingUsageDialect) InspectRequest(
+	*dialect.ParsedRequest,
+) (dialect.RequestMetadata, error) {
+	return dialect.RequestMetadata{}, nil
+}
+
+func (d *observingUsageDialect) ExtractUsage(
+	body []byte,
+) (usage.Result, error) {
+	d.body = body
+	return usage.Result{State: usage.StateComplete}, nil
+}
+
+func (*observingUsageDialect) NewUsageStreamExtractor() dialect.UsageStreamExtractor {
+	return nil
 }
 
 func (value fakeExecutionExecutor) Execute(
@@ -119,6 +145,68 @@ func TestExecutionForwarderCapturesImagesUsageFromUnaryBody(t *testing.T) {
 	}
 	if result.Err != nil || result.Usage != want {
 		t.Fatalf("Forward() usage = %#v, want %#v; result=%#v", result.Usage, want, result)
+	}
+}
+
+func TestExecutionForwarderCapturesCompressedImagesUsageAfterDecoding(t *testing.T) {
+	t.Parallel()
+
+	plain := []byte(`{"created":123,"model":"upstream-image","data":[{"b64_json":"AA=="}],"usage":{"input_tokens":100,"input_tokens_details":{"text_tokens":4,"image_tokens":96},"output_tokens":30,"total_tokens":130}}`)
+	for _, encoding := range []contentcoding.Encoding{
+		contentcoding.Gzip,
+		contentcoding.Brotli,
+	} {
+		t.Run(string(encoding), func(t *testing.T) {
+			compressed := encodeContentCodingForGatewayTest(t, encoding, plain)
+			executor := fakeExecutionExecutor{unary: func(
+				_ context.Context,
+				_ execution.AttemptSpec,
+			) execution.AttemptResult {
+				return execution.AttemptResult{
+					DispatchState:   execution.DispatchMaybeSent,
+					ResponseStarted: true,
+					StatusCode:      http.StatusOK,
+					Header: http.Header{
+						"Content-Type":     {"application/json"},
+						"Content-Encoding": {string(encoding)},
+					},
+					Body: compressed,
+				}
+			}}
+			input := executionForwardInput()
+			input.Dialect = dialect.NewOpenAIImages()
+			input.ClientProtocol = protocol.OpenAIImages
+			input.ObserveUsage = true
+			input.Operation = execution.OperationImagesGenerate
+			input.RouteRequirement = execution.RouteRequirementNative
+			input.ExternalModel = "upstream-image"
+			input.UpstreamModelID = "upstream-image"
+			input.Request.Path = "/v1/images/generations"
+			input.Request.Body = []byte(`{"model":"upstream-image","prompt":"draw"}`)
+
+			result := NewExecutionForwarder(executor).Forward(context.Background(), input)
+			want := usage.Result{
+				State:  usage.StateComplete,
+				Tokens: usage.Tokens{UncachedInput: 100, Output: 30},
+			}
+			if result.Err != nil || result.Usage != want ||
+				!bytes.Equal(result.Body, plain) ||
+				result.Header.Get("Content-Encoding") != "" {
+				t.Fatalf("Forward() = %#v", result)
+			}
+		})
+	}
+}
+
+func TestUsageCaptureNonStreamingPlainDoesNotCloneBody(t *testing.T) {
+	t.Parallel()
+
+	selected := &observingUsageDialect{}
+	body := []byte(`{"usage":{"input_tokens":1,"output_tokens":1}}`)
+	result := newUsageCaptureBoundary().extractNonStreamingPlain(selected, body)
+	if result.State != usage.StateComplete || len(selected.body) != len(body) ||
+		&selected.body[0] != &body[0] {
+		t.Fatalf("extractNonStreamingPlain() body = %p/%d, want original %p/%d", selected.body, len(selected.body), body, len(body))
 	}
 }
 

--- a/internal/gateway/execution_forward_test.go
+++ b/internal/gateway/execution_forward_test.go
@@ -29,7 +29,13 @@ type fakeExecutionExecutor struct {
 }
 
 type observingUsageDialect struct {
-	body []byte
+	expectedBody []byte
+	matchedBody  bool
+}
+
+type observingUsageStreamExtractor struct {
+	expectedBody []byte
+	matchedBody  bool
 }
 
 func (*observingUsageDialect) Protocol() protocol.Protocol {
@@ -45,12 +51,23 @@ func (*observingUsageDialect) InspectRequest(
 func (d *observingUsageDialect) ExtractUsage(
 	body []byte,
 ) (usage.Result, error) {
-	d.body = body
+	d.matchedBody = len(body) == len(d.expectedBody) &&
+		len(body) > 0 && &body[0] == &d.expectedBody[0]
 	return usage.Result{State: usage.StateComplete}, nil
 }
 
 func (*observingUsageDialect) NewUsageStreamExtractor() dialect.UsageStreamExtractor {
 	return nil
+}
+
+func (e *observingUsageStreamExtractor) Observe(body []byte) error {
+	e.matchedBody = len(body) == len(e.expectedBody) &&
+		len(body) > 0 && &body[0] == &e.expectedBody[0]
+	return nil
+}
+
+func (*observingUsageStreamExtractor) Finalize() (usage.Result, bool) {
+	return usage.Result{State: usage.StateComplete}, true
 }
 
 func (value fakeExecutionExecutor) Execute(
@@ -201,12 +218,28 @@ func TestExecutionForwarderCapturesCompressedImagesUsageAfterDecoding(t *testing
 func TestUsageCaptureNonStreamingPlainDoesNotCloneBody(t *testing.T) {
 	t.Parallel()
 
-	selected := &observingUsageDialect{}
 	body := []byte(`{"usage":{"input_tokens":1,"output_tokens":1}}`)
+	selected := &observingUsageDialect{expectedBody: body}
 	result := newUsageCaptureBoundary().extractNonStreamingPlain(selected, body)
-	if result.State != usage.StateComplete || len(selected.body) != len(body) ||
-		&selected.body[0] != &body[0] {
-		t.Fatalf("extractNonStreamingPlain() body = %p/%d, want original %p/%d", selected.body, len(selected.body), body, len(body))
+	if result.State != usage.StateComplete || !selected.matchedBody {
+		t.Fatal("extractNonStreamingPlain() did not borrow the original body")
+	}
+}
+
+func TestUsageCaptureStreamEventDoesNotCloneBody(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"type":"image_generation.partial_image","b64_json":"AA=="}`)
+	extractor := &observingUsageStreamExtractor{expectedBody: body}
+	capture := &streamUsageCapture{
+		boundary:  newUsageCaptureBoundary(),
+		protocol:  protocol.OpenAIImages,
+		extractor: extractor,
+		active:    true,
+	}
+	capture.observeEvent(dialect.StreamEvent{Payload: body})
+	if !capture.active || !extractor.matchedBody {
+		t.Fatal("observeEvent() did not borrow the original body")
 	}
 }
 

--- a/internal/gateway/usage_capture.go
+++ b/internal/gateway/usage_capture.go
@@ -252,11 +252,7 @@ func (capture *streamUsageCapture) observeEvent(event dialect.StreamEvent) {
 	if capture == nil || !capture.active || capture.finalized {
 		return
 	}
-	safeEvent := dialect.StreamEvent{
-		Name:    event.Name,
-		Payload: bytes.Clone(event.Payload),
-	}
-	err, panicked := safeObserveUsage(capture.extractor, safeEvent)
+	err, panicked := safeObserveUsage(capture.extractor, event)
 	if panicked {
 		capture.boundary.recordFailure("stream_observe", capture.protocol)
 		capture.active = false

--- a/internal/gateway/usage_capture.go
+++ b/internal/gateway/usage_capture.go
@@ -296,7 +296,7 @@ func (boundary *usageCaptureBoundary) extractNonStreamingPlain(
 	if !ok {
 		return missingUsage(false)
 	}
-	result, err, panicked := safeExtractUsage(extractor, bytes.Clone(plain))
+	result, err, panicked := safeExtractUsage(extractor, plain)
 	if err != nil || panicked || !validCapturedUsage(result) {
 		boundary.recordFailure("extract", selected.Protocol())
 		return missingUsage(true)


### PR DESCRIPTION
### 关联 Issue / Related Issue
<!-- 请填写此 PR 关联的 issue 编号，例如：Closes #123 / Please link the issue number, e.g., Closes #123 -->
无关联 Issue / No related issue.

### 变更内容 / Change Content
<!-- 请简要描述本次变更的核心内容 / Please describe the core changes of this PR -->
- [ ] Bug 修复 / Bug fix
- [x] 新功能 / New feature
- [ ] 其他改动 / Other changes

OpenAI Images 普通响应与流式 completed 事件现在通过现有 UsageExtractor/usage capture 链路归一化为标准 input/output/total 用量：

- `/v1/images/generations` 与 `/v1/images/edits` 使用同一 Images usage extractor。
- `input_tokens` 映射为现有输入用量，`output_tokens` 映射为输出用量；`total_tokens` 做一致性校验。
- `input_tokens_details` 只校验为对象，不解析或单独计价 `text_tokens`、`image_tokens`，也不臆造缓存字段。
- 普通响应使用现有通用 `extractNonStreamingPlain` fallback；流式使用现有 SSE usage capture 和终态校验。
- 沿用现有 pricing/request-log/aggregation/UI 消费标准字段；未修改模型发现、依赖、数据库或前端。
- 基线为已合并的 PR #482（`6a71f52f`）。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 本次改动不需要新增公开文档或发布说明。 / No public documentation or release note changes are required.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive information.
- [x] 无数据迁移或兼容性变更；只接入现有标准 usage 字段。 / No data migration or compatibility change; this only consumes existing standard usage fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持从 OpenAI Images 的非流式响应中提取图片生成与编辑用量。
  * 支持从流式事件中追踪并汇总成功、失败及错误终态的用量。
  * 自动识别并记录输入、输出及总令牌用量。

* **改进**
  * 启用用量观测时，将图片请求用量回填至执行结果。
  * 支持处理压缩响应后提取用量。
  * 增强异常数据校验，处理缺失字段、负值、类型冲突及总量不一致。
  * 优化大尺寸图片响应的用量解析，减少不必要的数据复制。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->