### PR TITLE
fix: 接入首个流错误安全切换

### DIFF
--- a/internal/execution/bifrost/converted.go
+++ b/internal/execution/bifrost/converted.go
@@ -611,7 +611,9 @@ func (r *Runtime) executeConvertedResponsesStream(
 	preResponse.stop()
 	if outcome.err != nil {
 		captureAppliedReasoning(&outcome.err.ExtraFields.RawRequest, &appliedReasoning)
-		return convertedStreamErrorResult(outcome.err, bifrostContext, prepared.secrets, false, 0, nil, "", nil)
+		result := convertedStreamErrorResult(outcome.err, bifrostContext, prepared.secrets, false, 0, nil, "", nil)
+		markPromotedStreamRejectionReplaySafe(&result)
+		return result
 	}
 	if outcome.stream == nil {
 		return attemptedStreamFailure(execution.ErrorKindInternal, "execution runtime returned no stream")

--- a/internal/execution/bifrost/converted_protocols_test.go
+++ b/internal/execution/bifrost/converted_protocols_test.go
@@ -948,11 +948,47 @@ func TestConvertedResponsesStreamHonorsCancellationAndUpstreamError(t *testing.T
 			result.Error.Summary != "input is too large" ||
 			result.Error.Hint != execution.FailureHintRequestRejected ||
 			result.Error.OriginHint != execution.ErrorOriginClient ||
-			result.Error.ScopeHint != execution.ErrorScopeRequest {
+			result.Error.ScopeHint != execution.ErrorScopeRequest ||
+			result.Error.ReplaySafety != "" {
 			t.Fatalf("response.failed result = %+v evidence=%+v events=%+v", result, result.Error, events)
 		}
 		if len(events) != 1 || events[0].Kind != execution.StreamEventReady {
 			t.Fatalf("response.failed events = %+v, want ready metadata only", events)
+		}
+	})
+
+	t.Run("capacity error after generated data is not replay safe", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			if request.URL.Path != "/v1/responses" {
+				t.Errorf("request path = %q, want /v1/responses", request.URL.Path)
+			}
+			_, _ = io.Copy(io.Discard, request.Body)
+			writer.Header().Set("Content-Type", "text/event-stream")
+			_, _ = io.WriteString(writer,
+				"data: {\"type\":\"response.created\",\"sequence_number\":0,\"response\":{\"id\":\"resp_failed\",\"status\":\"in_progress\",\"model\":\"gpt-upstream\",\"output\":[]}}\n\n"+
+					"data: {\"type\":\"response.output_text.delta\",\"sequence_number\":1,\"output_index\":0,\"content_index\":0,\"item_id\":\"msg_1\",\"delta\":\"partial\"}\n\n"+
+					"data: {\"type\":\"response.failed\",\"sequence_number\":2,\"response\":{\"id\":\"resp_failed\",\"status\":\"failed\",\"model\":\"gpt-upstream\",\"output\":[],\"error\":{\"type\":\"service_unavailable_error\",\"code\":\"server_is_overloaded\",\"message\":\"try another credential\"}}}\n\n",
+			)
+		}))
+		defer server.Close()
+
+		runtime := newProtocolTestRuntime(t, testRuntimeOptions{allowPrivateNetwork: true, openAIBaseURL: server.URL})
+		spec := convertedSpec(
+			channel.OpenAI,
+			protocol.Anthropic,
+			execution.OperationChatCompletion,
+			"/v1/messages",
+			[]byte(`{"model":"client-model","max_tokens":16,"messages":[{"role":"user","content":"hello"}]}`),
+		)
+		var events []execution.StreamEvent
+		result := runtime.ExecuteStream(context.Background(), spec, func(event execution.StreamEvent) error {
+			events = append(events, event.Clone())
+			return nil
+		})
+
+		if result.Error == nil || result.Error.Code != "server_is_overloaded" ||
+			result.Error.ReplaySafety != "" || len(events) < 2 {
+			t.Fatalf("later stream error result = %+v events=%+v", result, events)
 		}
 	})
 }

--- a/internal/execution/bifrost/executor.go
+++ b/internal/execution/bifrost/executor.go
@@ -225,10 +225,14 @@ func (r *Runtime) ExecuteStream(
 	preResponse.stop()
 	if outcome.err != nil {
 		captureAppliedReasoning(&outcome.err.ExtraFields.RawRequest, &appliedReasoning)
+		var result execution.StreamResult
 		if prepared.mode == channel.RouteConverted {
-			return convertedStreamErrorResult(outcome.err, bifrostContext, prepared.secrets, false, 0, nil, "", nil)
+			result = convertedStreamErrorResult(outcome.err, bifrostContext, prepared.secrets, false, 0, nil, "", nil)
+		} else {
+			result = streamErrorResult(outcome.err, bifrostContext, prepared.secrets, false, 0, nil, "", nil)
 		}
-		return streamErrorResult(outcome.err, bifrostContext, prepared.secrets, false, 0, nil, "", nil)
+		markPromotedStreamRejectionReplaySafe(&result)
+		return result
 	}
 	if outcome.stream == nil {
 		return attemptedStreamFailure(execution.ErrorKindInternal, "execution runtime returned no stream")

--- a/internal/execution/bifrost/executor_test.go
+++ b/internal/execution/bifrost/executor_test.go
@@ -1066,6 +1066,75 @@ func TestRuntimeStreamCancellationAndHTTPErrorDoNotEmitDone(t *testing.T) {
 	})
 }
 
+func TestRuntimeMarksPromotedFirstStreamCapacityErrorReplaySafe(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		errorType string
+		errorCode string
+	}{
+		{name: "server overload", errorType: "service_unavailable_error", errorCode: "server_is_overloaded"},
+		{name: "transient rate limit", errorType: "rate_limit_error", errorCode: "rate_limit_exceeded"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				writer.Header().Set("Content-Type", "text/event-stream")
+				_, _ = io.WriteString(writer,
+					`data: {"type":"response.failed","response":{"id":"resp_1","status":"failed","error":{"type":"`+test.errorType+`","code":"`+test.errorCode+`","message":"try another credential"}}}`+"\n\n",
+				)
+			}))
+			defer server.Close()
+
+			runtime := newProtocolTestRuntime(t, testRuntimeOptions{
+				allowPrivateNetwork: true,
+				openAIBaseURL:       server.URL,
+			})
+			spec := convertedSpec(
+				channel.OpenAI,
+				protocol.Anthropic,
+				execution.OperationChatCompletion,
+				"/v1/messages",
+				[]byte(`{"model":"client-model","max_tokens":16,"messages":[{"role":"user","content":"hello"}]}`),
+			)
+			var events []execution.StreamEvent
+			result := runtime.ExecuteStream(context.Background(), spec, func(event execution.StreamEvent) error {
+				events = append(events, event.Clone())
+				return nil
+			})
+			if result.Error == nil || result.Error.Type != test.errorType || result.Error.Code != test.errorCode ||
+				result.Error.ReplaySafety != execution.ReplaySafetyRejectedBeforeProcessing || len(events) != 0 {
+				t.Fatalf("result = %#v, events = %#v", result, events)
+			}
+		})
+	}
+}
+
+func TestRuntimeMarksPromotedFirstChatStreamCapacityErrorReplaySafe(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/tenant/openai/chat/completions" {
+			t.Errorf("request path = %q", request.URL.Path)
+		}
+		writer.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(writer,
+			"data: {\"error\":{\"type\":\"service_unavailable_error\",\"code\":\"server_is_overloaded\",\"message\":\"try another credential\"}}\n\n",
+		)
+	}))
+	defer server.Close()
+
+	runtime := newTestRuntime(t)
+	spec := compatibleSpec(server.URL)
+	spec.TargetConfig = json.RawMessage(`{"base_url":"` + server.URL + `/tenant/openai"}`)
+	spec = freezeTestAttempt(spec)
+	var events []execution.StreamEvent
+	result := runtime.ExecuteStream(t.Context(), spec, func(event execution.StreamEvent) error {
+		events = append(events, event.Clone())
+		return nil
+	})
+	if result.Error == nil || result.Error.Code != "server_is_overloaded" ||
+		result.Error.ReplaySafety != execution.ReplaySafetyRejectedBeforeProcessing || len(events) != 0 {
+		t.Fatalf("result = %#v, events = %#v", result, events)
+	}
+}
+
 func TestRuntimeFirstByteAndStreamIdleTimeouts(t *testing.T) {
 	t.Parallel()
 

--- a/internal/execution/bifrost/mapping.go
+++ b/internal/execution/bifrost/mapping.go
@@ -527,6 +527,19 @@ func streamErrorResult(
 	return result
 }
 
+func markPromotedStreamRejectionReplaySafe(result *execution.StreamResult) {
+	if result == nil || result.Error == nil ||
+		!streamCapacityRejection(result.Error.Code) {
+		return
+	}
+	result.Error.ReplaySafety = execution.ReplaySafetyRejectedBeforeProcessing
+}
+
+func streamCapacityRejection(codeValue string) bool {
+	codeValue = strings.ToLower(strings.TrimSpace(codeValue))
+	return codeValue == "server_is_overloaded" || codeValue == "rate_limit_exceeded"
+}
+
 func convertedStreamErrorResult(
 	bifrostError *schemas.BifrostError,
 	bifrostContext *schemas.BifrostContext,

--- a/internal/execution/cpa/adapter_test.go
+++ b/internal/execution/cpa/adapter_test.go
@@ -1078,7 +1078,8 @@ func TestAdapterReturnsFirstStreamErrorBeforeReady(t *testing.T) {
 		events = append(events, event.Clone())
 		return nil
 	})
-	if result.Error == nil || result.StatusCode != http.StatusBadRequest || len(events) != 0 {
+	if result.Error == nil || result.StatusCode != http.StatusBadRequest ||
+		result.Error.ReplaySafety != "" || len(events) != 0 {
 		t.Fatalf("result = %#v, events = %#v", result, events)
 	}
 }
@@ -1301,6 +1302,28 @@ func TestAdapterStreamsRealCPAResponsesAsCompleteClientSSE(t *testing.T) {
 				t.Fatalf("Responses terminal event is incomplete: %q", wire.String())
 			}
 		})
+	}
+}
+
+func TestAdapterReturnsCodexBootstrapRejectionBeforeReady(t *testing.T) {
+	adapter, _, _, keyService, row := newAdapterFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
+	setCodexExecutor(t, adapter, &fakeExecutor{
+		stream: &codex.ExecuteStreamResponse{UpstreamRequestPath: "/backend-api/codex/responses"},
+		err: statusError{
+			status:  http.StatusServiceUnavailable,
+			message: `{"error":{"type":"service_unavailable_error","code":"server_is_overloaded","message":"try another credential"}}`,
+		},
+	})
+
+	var events []execution.StreamEvent
+	result := adapter.ExecuteStream(t.Context(), validSpec(t, row, keyService), func(event execution.StreamEvent) error {
+		events = append(events, event.Clone())
+		return nil
+	})
+	if result.Error == nil || result.StatusCode != http.StatusServiceUnavailable ||
+		result.Error.Type != "service_unavailable_error" || result.Error.Code != "server_is_overloaded" ||
+		result.Error.ReplaySafety != execution.ReplaySafetyRejectedBeforeProcessing || len(events) != 0 {
+		t.Fatalf("result = %#v, events = %#v", result, events)
 	}
 }
 

--- a/internal/execution/cpa/codex_provider.go
+++ b/internal/execution/cpa/codex_provider.go
@@ -29,6 +29,13 @@ type codexProviderBridge struct {
 	executor codex.Executor
 }
 
+type codexBootstrapRejectionError struct {
+	cause error
+}
+
+func (err *codexBootstrapRejectionError) Error() string { return err.cause.Error() }
+func (err *codexBootstrapRejectionError) Unwrap() error { return err.cause }
+
 const localTokenCountHeader = "X-GPT-Load-Token-Count"
 
 func newCodexProviderBridge() *codexProviderBridge {
@@ -323,6 +330,17 @@ func (bridge *codexProviderBridge) ExecuteStream(
 	if response == nil {
 		return nil, err
 	}
+	convertedResponse := &providerStreamResponse{
+		Headers:                response.Headers.Clone(),
+		AppliedReasoningEffort: response.AppliedReasoningEffort,
+		UpstreamProtocol:       codexUpstreamProtocol(response.UpstreamRequestPath),
+	}
+	if err != nil {
+		if codexBootstrapCapacityRejection(err) {
+			err = &codexBootstrapRejectionError{cause: err}
+		}
+		return convertedResponse, err
+	}
 	chunks := make(chan providerStreamChunk)
 	go func() {
 		defer close(chunks)
@@ -335,11 +353,8 @@ func (bridge *codexProviderBridge) ExecuteStream(
 			}
 		}
 	}()
-	return &providerStreamResponse{
-		Headers: response.Headers.Clone(), Chunks: chunks,
-		AppliedReasoningEffort: response.AppliedReasoningEffort,
-		UpstreamProtocol:       codexUpstreamProtocol(response.UpstreamRequestPath),
-	}, err
+	convertedResponse.Chunks = chunks
+	return convertedResponse, nil
 }
 
 func (*codexProviderBridge) ClassifyError(
@@ -369,6 +384,8 @@ func (*codexProviderBridge) ClassifyError(
 		}
 	}
 	typeValue, codeValue := codexErrorTypeCode(err)
+	var bootstrapRejection *codexBootstrapRejectionError
+	isBootstrapRejection := errors.As(err, &bootstrapRejection)
 	evidence := &execution.ErrorEvidence{
 		Kind: kind, StatusCode: status, Type: typeValue, Code: codeValue,
 		Summary: safeErrorSummary(err, credential.redactionValues()),
@@ -392,6 +409,8 @@ func (*codexProviderBridge) ClassifyError(
 		evidence.ScopeHint = execution.ErrorScopeModel
 		evidence.Code = "selected_model_at_capacity"
 		evidence.ReplaySafety = execution.ReplaySafetyRejectedBeforeProcessing
+	case isBootstrapRejection && codexBootstrapRateLimit(codeValue):
+		evidence.Hint = execution.FailureHintRateLimited
 	case status == http.StatusTooManyRequests:
 		evidence.Hint = execution.FailureHintRateLimited
 	default:
@@ -400,7 +419,23 @@ func (*codexProviderBridge) ClassifyError(
 		}
 	}
 	annotateProviderErrorEvidence(evidence, err)
+	if isBootstrapRejection {
+		evidence.ReplaySafety = execution.ReplaySafetyRejectedBeforeProcessing
+	}
 	return status, evidence
+}
+
+func codexBootstrapCapacityRejection(err error) bool {
+	_, codeValue := codexErrorTypeCode(err)
+	return codexBootstrapOverload(codeValue) || codexBootstrapRateLimit(codeValue)
+}
+
+func codexBootstrapOverload(codeValue string) bool {
+	return strings.EqualFold(strings.TrimSpace(codeValue), "server_is_overloaded")
+}
+
+func codexBootstrapRateLimit(codeValue string) bool {
+	return strings.EqualFold(strings.TrimSpace(codeValue), "rate_limit_exceeded")
 }
 
 func codexErrorTypeCode(err error) (string, string) {

--- a/internal/execution/cpa/codex_provider_test.go
+++ b/internal/execution/cpa/codex_provider_test.go
@@ -105,3 +105,49 @@ func TestCodexProviderClassifiesStructuredRateLimitEvidence(t *testing.T) {
 		})
 	}
 }
+
+func TestCodexProviderClassifiesBootstrapRejections(t *testing.T) {
+	bridge := newCodexProviderBridge()
+	credential := codexProviderCredential{}
+	for _, test := range []struct {
+		name      string
+		payload   string
+		wantType  string
+		wantCode  string
+		wantHint  execution.FailureHint
+		wantScope execution.ErrorScope
+	}{
+		{
+			name:     "server overload",
+			payload:  `{"error":{"type":"service_unavailable_error","code":"server_is_overloaded","message":"overloaded"}}`,
+			wantType: "service_unavailable_error", wantCode: "server_is_overloaded",
+			wantHint: execution.FailureHintHostError, wantScope: execution.ErrorScopeGroup,
+		},
+		{
+			name:     "transient rate limit",
+			payload:  `{"error":{"type":"rate_limit_error","code":"rate_limit_exceeded","message":"slow down"}}`,
+			wantType: "rate_limit_error", wantCode: "rate_limit_exceeded",
+			wantHint: execution.FailureHintRateLimited,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cause := &codexClassifiedTestError{status: http.StatusServiceUnavailable, payload: test.payload}
+			status, evidence := bridge.ClassifyError(
+				t.Context(),
+				&codexBootstrapRejectionError{cause: cause},
+				credential,
+			)
+			if status != http.StatusServiceUnavailable || evidence == nil ||
+				evidence.Type != test.wantType || evidence.Code != test.wantCode ||
+				evidence.Hint != test.wantHint || evidence.ScopeHint != test.wantScope ||
+				evidence.ReplaySafety != execution.ReplaySafetyRejectedBeforeProcessing {
+				t.Fatalf("ClassifyError() = %d / %#v", status, evidence)
+			}
+
+			_, ordinary := bridge.ClassifyError(t.Context(), cause, credential)
+			if ordinary == nil || ordinary.ReplaySafety != "" {
+				t.Fatalf("ordinary ClassifyError() = %#v", ordinary)
+			}
+		})
+	}
+}

--- a/internal/gateway/execution_forward.go
+++ b/internal/gateway/execution_forward.go
@@ -443,7 +443,15 @@ func firstStreamErrorEvidence(
 	case execution.FailureHintHostError:
 		evidence.ScopeHint = execution.ErrorScopeGroup
 	}
+	if streamBootstrapCapacityRejection(evidence.Code) {
+		evidence.ReplaySafety = execution.ReplaySafetyRejectedBeforeProcessing
+	}
 	return &evidence
+}
+
+func streamBootstrapCapacityRejection(codeValue string) bool {
+	codeValue = strings.ToLower(strings.TrimSpace(codeValue))
+	return codeValue == "server_is_overloaded" || codeValue == "rate_limit_exceeded"
 }
 
 func streamErrorEvidenceScalar(value json.RawMessage) string {

--- a/internal/gateway/execution_forward.go
+++ b/internal/gateway/execution_forward.go
@@ -443,7 +443,7 @@ func firstStreamErrorEvidence(
 	case execution.FailureHintHostError:
 		evidence.ScopeHint = execution.ErrorScopeGroup
 	}
-	if streamBootstrapCapacityRejection(evidence.Code) {
+	if evidence.ReplaySafety == "" && streamBootstrapCapacityRejection(evidence.Code) {
 		evidence.ReplaySafety = execution.ReplaySafetyRejectedBeforeProcessing
 	}
 	return &evidence

--- a/internal/gateway/execution_forward_test.go
+++ b/internal/gateway/execution_forward_test.go
@@ -996,7 +996,8 @@ func TestExecutionForwarderPreservesFirstProviderErrorEvidence(t *testing.T) {
 	}
 	if result.ExecutionError.Type != "rate_limit_error" ||
 		result.ExecutionError.Code != "rate_limit" ||
-		result.ExecutionError.Hint != execution.FailureHintRateLimited {
+		result.ExecutionError.Hint != execution.FailureHintRateLimited ||
+		result.ExecutionError.ReplaySafety != "" {
 		t.Fatalf("error evidence = %#v", result.ExecutionError)
 	}
 	now := time.Date(2026, time.July, 28, 10, 0, 0, 0, time.UTC)
@@ -1005,6 +1006,96 @@ func TestExecutionForwarderPreservesFirstProviderErrorEvidence(t *testing.T) {
 		decision.Effect != health.EffectCooldownCredential ||
 		!decision.CooldownUntil.Equal(now.Add(3*time.Second)) {
 		t.Fatalf("health decision = %#v", decision)
+	}
+}
+
+func TestExecutionForwarderMarksFirstCapacityErrorReplaySafe(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		errorType string
+		errorCode string
+	}{
+		{name: "server overload", errorType: "service_unavailable_error", errorCode: "server_is_overloaded"},
+		{name: "transient rate limit", errorType: "rate_limit_error", errorCode: "rate_limit_exceeded"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			failedEvent := "event: error\n" +
+				"data: {\"type\":\"error\",\"error\":{\"type\":\"" + test.errorType + "\",\"code\":\"" + test.errorCode + "\",\"message\":\"try another credential\"}}\n\n"
+			executor := fakeExecutionExecutor{stream: func(
+				_ context.Context,
+				_ execution.AttemptSpec,
+				sink execution.StreamSink,
+			) execution.StreamResult {
+				if err := sink(execution.StreamEvent{
+					Sequence: 1, Kind: execution.StreamEventReady,
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": {"text/event-stream"}},
+				}); err != nil {
+					t.Fatalf("ready sink: %v", err)
+				}
+				if err := sink(execution.StreamEvent{
+					Sequence: 2, Kind: execution.StreamEventData, Data: []byte(failedEvent),
+				}); err != nil {
+					t.Fatalf("data sink: %v", err)
+				}
+				return execution.StreamResult{
+					DispatchState: execution.DispatchMaybeSent, ResponseStarted: true,
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": {"text/event-stream"}},
+				}
+			}}
+			input := executionForwardInput()
+			input.Dialect = dialect.NewOpenAIResponses()
+			result := NewExecutionForwarder(executor).ForwardStream(
+				context.Background(), input, httptest.NewRecorder(),
+			)
+			if result.Committed || !result.ProviderErrorBeforeCommit || result.ExecutionError == nil ||
+				result.ExecutionError.Type != test.errorType || result.ExecutionError.Code != test.errorCode ||
+				result.ExecutionError.ReplaySafety != execution.ReplaySafetyRejectedBeforeProcessing {
+				t.Fatalf("ForwardStream() result = %#v", result)
+			}
+		})
+	}
+}
+
+func TestExecutionForwarderDoesNotPromoteCapacityErrorAfterCommit(t *testing.T) {
+	executor := fakeExecutionExecutor{stream: func(
+		_ context.Context,
+		_ execution.AttemptSpec,
+		sink execution.StreamSink,
+	) execution.StreamResult {
+		emit := func(event execution.StreamEvent) {
+			if err := sink(event); err != nil {
+				t.Fatalf("stream sink: %v", err)
+			}
+		}
+		emit(execution.StreamEvent{
+			Sequence: 1, Kind: execution.StreamEventReady,
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": {"text/event-stream"}},
+		})
+		emit(execution.StreamEvent{
+			Sequence: 2, Kind: execution.StreamEventData,
+			Data: []byte("event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"status\":\"in_progress\",\"output\":[]}}\n\n"),
+		})
+		emit(execution.StreamEvent{
+			Sequence: 3, Kind: execution.StreamEventData,
+			Data: []byte("event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"service_unavailable_error\",\"code\":\"server_is_overloaded\",\"message\":\"too late\"}}\n\n"),
+		})
+		return execution.StreamResult{
+			DispatchState: execution.DispatchMaybeSent, ResponseStarted: true,
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": {"text/event-stream"}},
+		}
+	}}
+	input := executionForwardInput()
+	input.Dialect = dialect.NewOpenAIResponses()
+	result := NewExecutionForwarder(executor).ForwardStream(
+		context.Background(), input, httptest.NewRecorder(),
+	)
+	if !result.Committed || result.ProviderErrorBeforeCommit ||
+		result.ExecutionError != nil && result.ExecutionError.ReplaySafety != "" {
+		t.Fatalf("ForwardStream() result = %#v", result)
 	}
 }
 

--- a/internal/gateway/execution_forward_test.go
+++ b/internal/gateway/execution_forward_test.go
@@ -1009,14 +1009,28 @@ func TestExecutionForwarderPreservesFirstProviderErrorEvidence(t *testing.T) {
 	}
 }
 
-func TestExecutionForwarderMarksFirstCapacityErrorReplaySafe(t *testing.T) {
+func TestExecutionForwarderClassifiesFirstCapacityErrorReplaySafety(t *testing.T) {
 	for _, test := range []struct {
 		name      string
 		errorType string
 		errorCode string
+		existing  execution.ReplaySafety
+		want      execution.ReplaySafety
+		images    bool
 	}{
-		{name: "server overload", errorType: "service_unavailable_error", errorCode: "server_is_overloaded"},
-		{name: "transient rate limit", errorType: "rate_limit_error", errorCode: "rate_limit_exceeded"},
+		{
+			name: "server overload", errorType: "service_unavailable_error",
+			errorCode: "server_is_overloaded", want: execution.ReplaySafetyRejectedBeforeProcessing,
+		},
+		{
+			name: "transient rate limit", errorType: "rate_limit_error",
+			errorCode: "rate_limit_exceeded", want: execution.ReplaySafetyRejectedBeforeProcessing,
+		},
+		{
+			name: "images explicit unknown remains unsafe", errorType: "service_unavailable_error",
+			errorCode: "server_is_overloaded", existing: execution.ReplaySafetyUnknown,
+			want: execution.ReplaySafetyUnknown, images: true,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			failedEvent := "event: error\n" +
@@ -1038,21 +1052,43 @@ func TestExecutionForwarderMarksFirstCapacityErrorReplaySafe(t *testing.T) {
 				}); err != nil {
 					t.Fatalf("data sink: %v", err)
 				}
-				return execution.StreamResult{
+				result := execution.StreamResult{
 					DispatchState: execution.DispatchMaybeSent, ResponseStarted: true,
 					StatusCode: http.StatusOK,
 					Header:     http.Header{"Content-Type": {"text/event-stream"}},
 				}
+				if test.existing != "" {
+					result.Error = &execution.ErrorEvidence{
+						Kind: execution.ErrorKindProvider, Summary: "explicit replay safety evidence",
+						ReplaySafety: test.existing,
+					}
+				}
+				return result
 			}}
 			input := executionForwardInput()
-			input.Dialect = dialect.NewOpenAIResponses()
+			if test.images {
+				input.Dialect = dialect.NewOpenAIImages()
+				input.ClientProtocol = protocol.OpenAIImages
+				input.Operation = execution.OperationImagesGenerate
+				input.Request.Path = "/v1/images/generations"
+			} else {
+				input.Dialect = dialect.NewOpenAIResponses()
+			}
 			result := NewExecutionForwarder(executor).ForwardStream(
 				context.Background(), input, httptest.NewRecorder(),
 			)
 			if result.Committed || !result.ProviderErrorBeforeCommit || result.ExecutionError == nil ||
 				result.ExecutionError.Type != test.errorType || result.ExecutionError.Code != test.errorCode ||
-				result.ExecutionError.ReplaySafety != execution.ReplaySafetyRejectedBeforeProcessing {
+				result.ExecutionError.ReplaySafety != test.want {
 				t.Fatalf("ForwardStream() result = %#v", result)
+			}
+			if test.images {
+				decision := judgeUpstreamResult(result, time.Now(), health.DecisionContext{
+					Method: http.MethodPost, Operation: execution.OperationImagesGenerate,
+				})
+				if decision.Retry != health.RetryNone {
+					t.Fatalf("JudgeExecution() = %#v", decision)
+				}
 			}
 		})
 	}

--- a/internal/gateway/handler_test.go
+++ b/internal/gateway/handler_test.go
@@ -1103,6 +1103,60 @@ func TestHandlerRetriesCandidateUnavailableWithoutCredentialPenalty(t *testing.T
 	}
 }
 
+func TestHandlerRetriesSafeBootstrapCapacityErrorWithoutCredentialPenalty(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		typeValue string
+		code      string
+		scope     execution.ErrorScope
+	}{
+		{name: "server overload", typeValue: "service_unavailable_error", code: "server_is_overloaded", scope: execution.ErrorScopeGroup},
+		{name: "transient rate limit", typeValue: "rate_limit_error", code: "rate_limit_exceeded"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			forwarder := &scriptedForwarder{streamResults: []UpstreamResult{
+				{
+					DispatchState: execution.DispatchMaybeSent, ResponseStarted: true,
+					StatusCode: http.StatusServiceUnavailable,
+					ExecutionError: &execution.ErrorEvidence{
+						Kind: execution.ErrorKindHTTP, OriginHint: execution.ErrorOriginUpstream,
+						ScopeHint: test.scope, StatusCode: http.StatusServiceUnavailable,
+						Type: test.typeValue, Code: test.code, Summary: "rejected before generation",
+						ReplaySafety: execution.ReplaySafetyRejectedBeforeProcessing,
+					},
+				},
+				{
+					DispatchState: execution.DispatchMaybeSent, ResponseStarted: true,
+					StatusCode: http.StatusOK, Committed: true,
+					Stream: StreamObservation{EndReason: StreamEndCleanEOF},
+				},
+			}}
+			engine, handler, registry, _ := newStatsHandlerTestRuntime(t, forwarder, "sk-first", "sk-second")
+			recording := &recordingRuntimeRegistry{CredentialRegistry: registry}
+			handler.registry = recording
+			handler.newRandom = func() *rand.Rand { return rand.New(zeroSource{}) }
+
+			request := httptest.NewRequest(
+				http.MethodPost,
+				"/v1/chat/completions",
+				bytes.NewBufferString(`{"model":"gpt-4o","stream":true}`),
+			)
+			request.Header.Set("Authorization", "Bearer gl-client")
+			recorder := httptest.NewRecorder()
+			engine.ServeHTTP(recorder, request)
+
+			if recorder.Code != http.StatusOK || len(forwarder.streamInputs) != 2 ||
+				forwarder.streamInputs[0].APIKey == forwarder.streamInputs[1].APIKey {
+				t.Fatalf("response/attempts = %d/%d inputs=%#v", recorder.Code, len(forwarder.streamInputs), forwarder.streamInputs)
+			}
+			if recording.cooldownCalls != 0 || recording.incrFailureCalls != 0 || recording.blacklistCalls != 0 {
+				t.Fatalf("credential mutations = cooldown:%d failure:%d blacklist:%d, want none",
+					recording.cooldownCalls, recording.incrFailureCalls, recording.blacklistCalls)
+			}
+		})
+	}
+}
+
 func TestHandlerRecordsStreamSuccessOnlyAfterCleanTerminal(t *testing.T) {
 	now := time.Date(2026, time.July, 22, 10, 0, 0, 0, time.UTC)
 	tests := []struct {

--- a/internal/gateway/request_log.go
+++ b/internal/gateway/request_log.go
@@ -695,7 +695,9 @@ func upstreamErrorCode(result UpstreamResult, category health.FailureCategory) s
 		case "credential_decrypt_failed",
 			"credential_normalization_failed",
 			"credential_proxy_prepare_failed",
-			"group_proxy_prepare_failed":
+			"group_proxy_prepare_failed",
+			"server_is_overloaded",
+			"rate_limit_exceeded":
 			return result.ExecutionError.Code
 		}
 	}

--- a/internal/gateway/request_log_test.go
+++ b/internal/gateway/request_log_test.go
@@ -1313,6 +1313,54 @@ func TestHandlerFirstProviderErrorRequestLogContract(t *testing.T) {
 	}
 }
 
+func TestHandlerBootstrapCapacityRetryRequestLogContract(t *testing.T) {
+	forwarder := &scriptedForwarder{streamResults: []UpstreamResult{
+		{
+			DispatchState: execution.DispatchMaybeSent, ResponseStarted: true,
+			StatusCode: http.StatusServiceUnavailable,
+			ExecutionError: &execution.ErrorEvidence{
+				Kind: execution.ErrorKindHTTP, OriginHint: execution.ErrorOriginUpstream,
+				ScopeHint: execution.ErrorScopeGroup, StatusCode: http.StatusServiceUnavailable,
+				Type: "service_unavailable_error", Code: "server_is_overloaded",
+				Summary:      "rejected before generation",
+				ReplaySafety: execution.ReplaySafetyRejectedBeforeProcessing,
+			},
+		},
+		{
+			DispatchState: execution.DispatchMaybeSent, ResponseStarted: true,
+			StatusCode: http.StatusOK, Committed: true,
+			Stream: StreamObservation{EndReason: StreamEndCleanEOF},
+		},
+	}}
+	sink := &recordingRequestLogSink{}
+	engine, handler, _, _ := newRequestLogHandlerTestRuntime(
+		t, forwarder, &recordingAccessKeyRPMLimiter{}, sink, "sk-first", "sk-second",
+	)
+	handler.newRandom = func() *rand.Rand { return rand.New(zeroSource{}) }
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4o","stream":true}`),
+	)
+	request.Header.Set("Authorization", "Bearer gl-client")
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, request)
+
+	events := sink.snapshot()
+	if response.Code != http.StatusOK || len(events) != 1 || len(events[0].Attempts) != 2 {
+		t.Fatalf("response/events = %d/%#v", response.Code, events)
+	}
+	first := events[0].Attempts[0]
+	if first.FailureCategory != telemetry.FailureCategoryUpstreamHost ||
+		first.FailureOrigin != execution.ErrorOriginUpstream ||
+		first.FailureScope != execution.ErrorScopeGroup ||
+		first.RetryDirective != telemetry.RetryNextCandidate || first.Effect != telemetry.EffectNone ||
+		first.RuleID != "candidate.transient_capacity" || !first.WillRetry ||
+		first.Action != telemetry.ActionRetry || first.ErrorCode != "server_is_overloaded" {
+		t.Fatalf("first attempt = %#v", first)
+	}
+}
+
 func TestHandlerRetryExhaustionUsesProviderErrorAttemptAndItsFrozenPrice(t *testing.T) {
 	firstTable := mustGatewayPriceTable(t, 2_000_000_000, true)
 	secondTable := mustGatewayPriceTable(t, 9_000_000_000, true)

--- a/internal/health/execution_judge.go
+++ b/internal/health/execution_judge.go
@@ -303,6 +303,9 @@ func decisionForExecutionCategory(
 	attempt ExecutionAttempt,
 	decisionContext DecisionContext,
 ) Decision {
+	if transientCapacity, ok := transientCapacityDecision(attempt); ok {
+		return transientCapacity
+	}
 	origin := originForEvidence(attempt.Evidence)
 	scope := attempt.Evidence.ScopeHint
 	if attempt.Evidence != nil && attempt.Evidence.Hint == execution.FailureHintCandidateUnavailable {
@@ -396,6 +399,33 @@ func decisionForExecutionCategory(
 	default:
 		return decision(category, origin, scope, RetryNone, EffectNone, ambiguousRuleID(attempt.Evidence))
 	}
+}
+
+func transientCapacityDecision(attempt ExecutionAttempt) (Decision, bool) {
+	evidence := attempt.Evidence
+	if evidence == nil || evidence.ReplaySafety != execution.ReplaySafetyRejectedBeforeProcessing ||
+		originForEvidence(evidence) != execution.ErrorOriginUpstream ||
+		(evidence.Kind != execution.ErrorKindHTTP && evidence.Kind != execution.ErrorKindProvider) {
+		return Decision{}, false
+	}
+	codeValue := strings.ToLower(strings.TrimSpace(evidence.Code))
+	overloaded := codeValue == "server_is_overloaded"
+	rateLimited := codeValue == "rate_limit_exceeded"
+	if overloaded == rateLimited {
+		return Decision{}, false
+	}
+	category := FailureCategoryUpstreamHostError
+	if rateLimited {
+		category = FailureCategoryRateLimited
+	}
+	return decision(
+		category,
+		execution.ErrorOriginUpstream,
+		evidence.ScopeHint,
+		RetryNextCandidate,
+		EffectNone,
+		"candidate.transient_capacity",
+	), true
 }
 
 func constrainOperationReplay(

--- a/internal/health/execution_judge_v2_test.go
+++ b/internal/health/execution_judge_v2_test.go
@@ -299,6 +299,100 @@ func TestJudgeExecutionPreservesReplayCompatibilityRules(t *testing.T) {
 	}
 }
 
+func TestJudgeExecutionRetriesSafeBootstrapCapacityRejectionsWithoutEffects(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		typeValue string
+		code      string
+		category  FailureCategory
+		scope     execution.ErrorScope
+	}{
+		{
+			name: "server overload", typeValue: "service_unavailable_error",
+			code: "server_is_overloaded", category: FailureCategoryUpstreamHostError,
+			scope: execution.ErrorScopeGroup,
+		},
+		{
+			name: "transient rate limit", typeValue: "rate_limit_error",
+			code: "rate_limit_exceeded", category: FailureCategoryRateLimited,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			decision := JudgeExecution(ExecutionAttempt{
+				DispatchState: execution.DispatchMaybeSent,
+				StatusCode:    http.StatusServiceUnavailable,
+				Evidence: &execution.ErrorEvidence{
+					Kind: execution.ErrorKindHTTP, OriginHint: execution.ErrorOriginUpstream,
+					ScopeHint: test.scope, StatusCode: http.StatusServiceUnavailable,
+					Type: test.typeValue, Code: test.code, Summary: "rejected before generation",
+					ReplaySafety: execution.ReplaySafetyRejectedBeforeProcessing,
+				},
+			}, DecisionContext{Method: http.MethodPost, Operation: execution.OperationChatCompletion})
+			if decision.Category != test.category || decision.Scope != test.scope ||
+				decision.Retry != RetryNextCandidate || decision.Effect != EffectNone ||
+				decision.RuleID != RuleID("candidate.transient_capacity") {
+				t.Fatalf("JudgeExecution() = %#v", decision)
+			}
+		})
+	}
+}
+
+func TestJudgeExecutionDoesNotBroadenBootstrapCapacityRetry(t *testing.T) {
+	tests := []struct {
+		name       string
+		evidence   execution.ErrorEvidence
+		committed  bool
+		wantRetry  RetryDirective
+		wantEffect Effect
+		wantRule   RuleID
+	}{
+		{
+			name: "unknown replay safety",
+			evidence: execution.ErrorEvidence{
+				Kind: execution.ErrorKindHTTP, OriginHint: execution.ErrorOriginUpstream,
+				StatusCode: http.StatusServiceUnavailable, Code: "server_is_overloaded",
+				Summary: "replay is unknown", ReplaySafety: execution.ReplaySafetyUnknown,
+			},
+			wantRetry: RetryNone, wantEffect: EffectSkipGroup,
+			wantRule: "upstream.host_error.replay_unsafe",
+		},
+		{
+			name: "similar code",
+			evidence: execution.ErrorEvidence{
+				Kind: execution.ErrorKindHTTP, OriginHint: execution.ErrorOriginUpstream,
+				StatusCode: http.StatusServiceUnavailable, Code: "server_is_overloaded_later",
+				Summary: "different failure", ReplaySafety: execution.ReplaySafetyRejectedBeforeProcessing,
+			},
+			wantRetry: RetryNextCandidate, wantEffect: EffectSkipGroup,
+			wantRule: "upstream.host_error.rejected_before_processing",
+		},
+		{
+			name: "downstream already committed",
+			evidence: execution.ErrorEvidence{
+				Kind: execution.ErrorKindProvider, OriginHint: execution.ErrorOriginUpstream,
+				ScopeHint: execution.ErrorScopeCredential, Code: "server_is_overloaded",
+				Summary: "too late to retry", ReplaySafety: execution.ReplaySafetyRejectedBeforeProcessing,
+			},
+			committed: true, wantRetry: RetryNone, wantEffect: EffectNone,
+			wantRule: "safety.committed",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			decision := JudgeExecution(ExecutionAttempt{
+				DispatchState:       execution.DispatchMaybeSent,
+				StatusCode:          test.evidence.StatusCode,
+				Evidence:            &test.evidence,
+				DownstreamCommitted: test.committed,
+			}, DecisionContext{Method: http.MethodPost, Operation: execution.OperationChatCompletion})
+			if decision.Retry != test.wantRetry || decision.Effect != test.wantEffect || decision.RuleID != test.wantRule {
+				t.Fatalf("JudgeExecution() = %#v", decision)
+			}
+		})
+	}
+}
+
 func TestJudgeExecutionReplayUnknownKeepsUnaffectedRuleID(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/subscription/providers/codex/codex.go
+++ b/internal/subscription/providers/codex/codex.go
@@ -353,6 +353,14 @@ func (e *executor) ExecuteStream(
 	if response == nil {
 		return nil, err
 	}
+	convertedResponse := &ExecuteStreamResponse{
+		Headers:                response.Headers.Clone(),
+		AppliedReasoningEffort: response.AppliedReasoningEffort,
+		UpstreamRequestPath:    response.UpstreamRequestPath,
+	}
+	if err != nil {
+		return convertedResponse, err
+	}
 	chunks := make(chan ExecuteStreamChunk)
 	go func() {
 		defer close(chunks)
@@ -365,12 +373,8 @@ func (e *executor) ExecuteStream(
 			}
 		}
 	}()
-	return &ExecuteStreamResponse{
-		Headers:                response.Headers.Clone(),
-		Chunks:                 chunks,
-		AppliedReasoningEffort: response.AppliedReasoningEffort,
-		UpstreamRequestPath:    response.UpstreamRequestPath,
-	}, err
+	convertedResponse.Chunks = chunks
+	return convertedResponse, nil
 }
 
 func executeRequestToBridge(value ExecuteRequest) cpaembedded.ExecuteRequest {

--- a/internal/subscription/providers/codex/codex_test.go
+++ b/internal/subscription/providers/codex/codex_test.go
@@ -1,13 +1,47 @@
 package codex
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"reflect"
 	"testing"
 
 	cpaembedded "github.com/router-for-me/CLIProxyAPI/v7/gptload-embedded/embedded"
 )
+
+type streamErrorBridge struct {
+	response *cpaembedded.ExecuteStreamResponse
+	err      error
+}
+
+func (bridge streamErrorBridge) ExecuteCanonical(
+	context.Context,
+	string,
+	cpaembedded.CodexCredential,
+	cpaembedded.ExecuteRequest,
+) (cpaembedded.ExecuteResponse, error) {
+	return cpaembedded.ExecuteResponse{}, errors.New("unexpected unary execution")
+}
+
+func (bridge streamErrorBridge) CountTokensCanonical(
+	context.Context,
+	string,
+	cpaembedded.CodexCredential,
+	cpaembedded.ExecuteRequest,
+) (cpaembedded.ExecuteResponse, error) {
+	return cpaembedded.ExecuteResponse{}, errors.New("unexpected token count")
+}
+
+func (bridge streamErrorBridge) ExecuteStreamCanonical(
+	context.Context,
+	string,
+	cpaembedded.CodexCredential,
+	cpaembedded.ExecuteRequest,
+) (*cpaembedded.ExecuteStreamResponse, error) {
+	return bridge.response, bridge.err
+}
 
 func TestCredentialRoundTripKeepsCPACompatibleSchema(t *testing.T) {
 	raw := []byte(`{
@@ -61,6 +95,23 @@ func TestExecutorCountsTokensWithoutCredential(t *testing.T) {
 	}
 	if err := json.Unmarshal(response.Payload, &result); err != nil || result.InputTokens <= 0 {
 		t.Fatalf("token count = %s / %v", response.Payload, err)
+	}
+}
+
+func TestExecutorDoesNotFanOutNilChunksAfterSynchronousStreamError(t *testing.T) {
+	wantErr := errors.New("bootstrap rejected")
+	executor := &executor{bridge: streamErrorBridge{
+		response: &cpaembedded.ExecuteStreamResponse{
+			Headers:             http.Header{"X-Request-Id": {"request-1"}},
+			UpstreamRequestPath: "/backend-api/codex/responses",
+		},
+		err: wantErr,
+	}}
+
+	response, err := executor.ExecuteStream(t.Context(), "credential-1", Credential{}, ExecuteRequest{})
+	if !errors.Is(err, wantErr) || response == nil || response.Chunks != nil ||
+		response.UpstreamRequestPath != "/backend-api/codex/responses" {
+		t.Fatalf("ExecuteStream() = %#v, %v", response, err)
 	}
 }
 

--- a/third_party/cpaembedded/embedded/embedded.go
+++ b/third_party/cpaembedded/embedded/embedded.go
@@ -366,7 +366,7 @@ type CodexHTTPExecutor struct {
 
 // NewCodexHTTPExecutor constructs an HTTP-only executor with no CPA manager.
 func NewCodexHTTPExecutor() *CodexHTTPExecutor {
-	cfg := &internalconfig.Config{}
+	cfg := &internalconfig.Config{Codex: internalconfig.CodexConfig{StreamBootstrapBuffering: true}}
 	return &CodexHTTPExecutor{cfg: cfg, inner: internalexecutor.NewCodexExecutor(cfg)}
 }
 

--- a/third_party/cpaembedded/embedded/embedded_test.go
+++ b/third_party/cpaembedded/embedded/embedded_test.go
@@ -391,6 +391,88 @@ func TestCodexHTTPExecutorDoesNotFollowRedirects(t *testing.T) {
 	}
 }
 
+func TestCodexHTTPExecutorPromotesBootstrapCapacityErrors(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		errorType string
+		errorCode string
+	}{
+		{name: "server overload", errorType: "service_unavailable_error", errorCode: "server_is_overloaded"},
+		{name: "transient rate limit", errorType: "rate_limit_error", errorCode: "rate_limit_exceeded"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var requests atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requests.Add(1)
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = io.WriteString(w,
+					"data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"status\":\"in_progress\"}}\n\n"+
+						"data: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_1\",\"status\":\"in_progress\"}}\n\n"+
+						"data: {\"type\":\"error\",\"error\":{\"type\":\""+test.errorType+"\",\"code\":\""+test.errorCode+"\",\"message\":\"try another credential\"}}\n\n",
+				)
+			}))
+			defer server.Close()
+
+			executor := NewCodexHTTPExecutor()
+			credential := CodexCredential{
+				Type: ProviderCodex, AccessToken: "access", RefreshToken: "refresh", AccountID: "account-123",
+			}
+			result, err := executor.ExecuteStream(
+				t.Context(),
+				NewCodexAuth("credential-1", credential, server.URL),
+				cliproxyexecutor.Request{
+					Model: "gpt-5.2", Payload: []byte(`{"model":"gpt-5.2","input":"hello"}`), Format: sdktranslator.FormatOpenAIResponse,
+				},
+				cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse},
+			)
+			var statusError interface{ StatusCode() int }
+			if result != nil || !errors.As(err, &statusError) || statusError.StatusCode() != http.StatusServiceUnavailable ||
+				!strings.Contains(err.Error(), test.errorCode) {
+				t.Fatalf("ExecuteStream() = %#v, %v", result, err)
+			}
+			if requests.Load() != 1 {
+				t.Fatalf("upstream requests = %d, want 1", requests.Load())
+			}
+		})
+	}
+}
+
+func TestCodexHTTPExecutorKeepsOtherBootstrapErrorsInStream(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w,
+			"data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"status\":\"in_progress\"}}\n\n"+
+				"data: {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"code\":\"bad_request\",\"message\":\"invalid input\"}}\n\n",
+		)
+	}))
+	defer server.Close()
+
+	executor := NewCodexHTTPExecutor()
+	credential := CodexCredential{
+		Type: ProviderCodex, AccessToken: "access", RefreshToken: "refresh", AccountID: "account-123",
+	}
+	result, err := executor.ExecuteStream(
+		t.Context(),
+		NewCodexAuth("credential-1", credential, server.URL),
+		cliproxyexecutor.Request{
+			Model: "gpt-5.2", Payload: []byte(`{"model":"gpt-5.2","input":"hello"}`), Format: sdktranslator.FormatOpenAIResponse,
+		},
+		cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse},
+	)
+	if err != nil || result == nil {
+		t.Fatalf("ExecuteStream() = %#v, %v", result, err)
+	}
+	var streamErr error
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			streamErr = chunk.Err
+		}
+	}
+	if streamErr == nil || !strings.Contains(streamErr.Error(), "bad_request") {
+		t.Fatalf("stream error = %v", streamErr)
+	}
+}
+
 func TestCodexHTTPExecutorCanonicalFacadeExecutesOnce(t *testing.T) {
 	t.Parallel()
 	var requests atomic.Int32


### PR DESCRIPTION
### 关联 Issue / Related Issue
<!-- 请填写此 PR 关联的 issue 编号，例如：Closes #123 / Please link the issue number, e.g., Closes #123 -->
不适用 / N/A

### 变更内容 / Change Content
<!-- 请简要描述本次变更的核心内容 / Please briefly describe the core changes of this PR -->
- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

<!-- 请在下方详细描述你的变更 / Please describe your changes in detail below -->

- 仅为 CPA Codex HTTP executor 启用 stream bootstrap buffering，并安全处理同步错误下的空 Chunks。
- CPA、Bifrost typed/converted 与 Gateway native passthrough 仅对首个未提交的 `server_is_overloaded` / `rate_limit_exceeded` 精确错误补充 ReplaySafety 证据。
- 继续由 `health.JudgeExecution` 统一输出 `RetryNextCandidate + EffectNone`，保留原始错误 Scope，不冷却、不拉黑、不跳过 Group。
- 复用现有 Gateway 候选迭代、Attempt 上限和请求日志；Scheduler、配置、API、数据库与前端均无改动。
- 普通错误、ReplaySafety unknown、已提交响应及相似错误码保持原行为。

验证：

- `make check`
- `go test -count=1 ./internal/subscription/providers/codex ./internal/execution/cpa ./internal/execution/bifrost ./internal/health ./internal/gateway ./internal/scheduler`
- `third_party/cpaembedded`: `go mod tidy -diff`、`go vet ./...`、`go test -count=1 ./...`
- 按已确认范围未执行真实账号验证；按仓库约定本地未运行 race，交由分支 CI 验证。

兼容性：仅改变上述两个精确错误在处理前拒绝时的安全候选切换行为；无数据迁移和公共 API 变更。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 优化流式请求在上游过载或临时限流时的处理，将处理前拒绝明确标记为可安全重试。
  - 符合条件的请求会自动尝试其他可用通道，且不会影响凭证健康状态。
  - 保留准确的错误类型、重试状态与请求日志信息，便于问题追踪。

- **错误修复**
  - 流式请求在尚未产生数据时发生错误，不再返回无效的数据通道。
  - 已开始输出数据后发生的错误仍按原有规则处理，避免扩大重试范围。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->