### PR TITLE
feat(subscription): 接入 Codex/Claude 被动额度信号观察

### DIFF
--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -87,8 +87,11 @@ func BuildContainer() (*dig.Container, error) {
 			redactor *redact.Redactor,
 			retention requestlog.RetentionPolicyProvider,
 			quotaRuntime *accessquota.Runtime,
+			subscriptionCredentials *subscription.CredentialManager,
 		) *requestlog.Service {
-			return requestlog.NewService(db, redactor, retention, quotaRuntime)
+			service := requestlog.NewService(db, redactor, retention, quotaRuntime)
+			service.SetPassiveQuotaFlusher(subscriptionCredentials)
+			return service
 		},
 		func(service *requestlog.Service) telemetry.RequestLogSink {
 			return service

--- a/internal/control/credential_observations.go
+++ b/internal/control/credential_observations.go
@@ -16,6 +16,7 @@ import (
 	app_errors "gpt-load/internal/platform/errors"
 	"gpt-load/internal/requestlog"
 	"gpt-load/internal/storage/models"
+	providerobservation "gpt-load/internal/subscription/providers/observation"
 	subscriptionruntime "gpt-load/internal/subscription/runtime"
 	"gpt-load/internal/usage"
 )
@@ -462,7 +463,19 @@ func (s *Service) recordCredentialObservationFailure(
 	if len(failed.SnapshotJSON) == 0 {
 		failed.SnapshotJSON = models.JSON(`{}`)
 	}
-	if err := s.upsertCredentialObservation(ctx, failed); err != nil {
+	updates := map[string]any{
+		"identity_fingerprint": failed.IdentityFingerprint,
+		"schema_version":       failed.SchemaVersion,
+		"state":                failed.State,
+		"last_attempt_at_ms":   failed.LastAttemptAtMS,
+		"next_allowed_at_ms":   failed.NextAllowedAtMS,
+		"last_error_code":      failed.LastErrorCode,
+		"updated_at_ms":        failed.UpdatedAtMS,
+	}
+	if authRefreshSecretVersion != nil {
+		updates["last_auth_refresh_secret_version"] = failed.LastAuthRefreshSecretVersion
+	}
+	if err := s.upsertCredentialObservationMetadataOnly(ctx, credential.ID, failed, updates); err != nil {
 		return CredentialObservationResponse{}, err
 	}
 	response := mapCredentialObservation(failed)
@@ -538,6 +551,30 @@ func (s *Service) upsertCredentialObservation(ctx context.Context, row models.Cr
 			return err
 		}
 		return tx.Save(&row).Error
+	})
+}
+
+// upsertCredentialObservationMetadataOnly creates a new row when none exists
+// for credentialID, or otherwise updates only the given columns. It never
+// touches snapshot_json, so an active failure or reset invalidation can never
+// clobber a concurrent passive quota write with the snapshot it read before
+// that write landed.
+func (s *Service) upsertCredentialObservationMetadataOnly(
+	ctx context.Context,
+	credentialID uint,
+	fallback models.CredentialObservation,
+	updates map[string]any,
+) error {
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var existing models.CredentialObservation
+		err := tx.Take(&existing, "credential_id = ?", credentialID).Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return tx.Create(&fallback).Error
+		}
+		if err != nil {
+			return err
+		}
+		return tx.Model(&models.CredentialObservation{}).Where("credential_id = ?", credentialID).Updates(updates).Error
 	})
 }
 
@@ -617,47 +654,24 @@ func (s *Service) applyCredentialQuotaObservation(
 		}
 		return
 	}
-	var remaining *float64
-	var resetAtMS int64
-	for _, window := range response.Snapshot.QuotaWindows {
-		if window.Scope != "account" || window.ResetAtMS == nil {
-			continue
-		}
-		value, known := observationWindowRemainingRatio(window)
-		if !known {
-			continue
-		}
-		if remaining == nil || value < *remaining {
-			cloned := value
-			remaining = &cloned
-			resetAtMS = *window.ResetAtMS
-		} else if value == *remaining && *window.ResetAtMS > resetAtMS {
-			// Equal bottlenecks must all recover before this credential is usable.
-			resetAtMS = *window.ResetAtMS
-		}
-	}
-	if remaining == nil || resetAtMS == 0 {
-		s.registry.SetCredentialQuotaObservation(credentialID, nil, time.Time{})
-		return
-	}
-	s.registry.SetCredentialQuotaObservation(
-		credentialID,
-		remaining,
-		time.UnixMilli(resetAtMS).UTC(),
-	)
+	s.registry.ApplyQuotaWindows(credentialID, providerQuotaWindows(response.Snapshot.QuotaWindows))
 }
 
-func observationWindowRemainingRatio(window ObservationQuotaWindow) (float64, bool) {
-	if window.State == "exhausted" {
-		return 0, true
+// providerQuotaWindows narrows the API-facing snapshot windows to the fields
+// the shared registry bottleneck projection reads. ObservedUsage is a
+// read-time-only annotation and is intentionally not carried across.
+func providerQuotaWindows(windows []ObservationQuotaWindow) []providerobservation.QuotaWindow {
+	result := make([]providerobservation.QuotaWindow, 0, len(windows))
+	for _, window := range windows {
+		result = append(result, providerobservation.QuotaWindow{
+			ID: window.ID, Label: window.Label, LabelKey: window.LabelKey,
+			Scope: window.Scope, Unit: window.Unit,
+			Used: window.Used, Limit: window.Limit, Remaining: window.Remaining, Utilization: window.Utilization,
+			ResetAtMS: window.ResetAtMS, WindowSeconds: window.WindowSeconds, ModelIDs: window.ModelIDs,
+			State: window.State, IsPrimary: window.IsPrimary,
+		})
 	}
-	if window.Utilization != nil {
-		return math.Max(0, math.Min(1, 1-*window.Utilization)), true
-	}
-	if window.Remaining != nil && window.Limit != nil && *window.Limit > 0 {
-		return math.Max(0, math.Min(1, *window.Remaining / *window.Limit)), true
-	}
-	return 0, false
+	return result
 }
 
 // credentialDailyUsageWindow 是账号卡上「近 24 小时成功/失败」的窗口长度。

--- a/internal/control/credential_observations.go
+++ b/internal/control/credential_observations.go
@@ -319,12 +319,21 @@ func (s *Service) refreshCredentialObservationOnce(
 	if err != nil {
 		return CredentialObservationResponse{}, app_errors.ErrInternalServer
 	}
+	// The observation time is when this result was actually obtained, not when
+	// the attempt started: a slow refresh would otherwise be stamped older
+	// than passive samples captured while it was still in flight, letting them
+	// overwrite it. Keeping updated_at_ms on the same instant also guarantees
+	// the passive writer's compare-and-set token changes on every active write.
+	completedMS := s.now().UTC().UnixMilli()
+	if completedMS < attemptMS {
+		completedMS = attemptMS
+	}
 	row := models.CredentialObservation{
 		CredentialID: credential.ID, IdentityFingerprint: credential.IdentityFingerprint,
 		SchemaVersion: 1, ObservationVersion: version, SnapshotJSON: models.JSON(encoded),
-		State: state, ObservedAtMS: &attemptMS,
+		State: state, ObservedAtMS: &completedMS,
 		LastAttemptAtMS: &attemptMS,
-		LastErrorCode:   lastErrorCode, UpdatedAtMS: attemptMS,
+		LastErrorCode:   lastErrorCode, UpdatedAtMS: completedMS,
 	}
 	if err := s.upsertCredentialObservation(ctx, row); err != nil {
 		return CredentialObservationResponse{}, err

--- a/internal/control/credential_observations_test.go
+++ b/internal/control/credential_observations_test.go
@@ -162,6 +162,103 @@ func TestNormalizeCodexObservationDoesNotTreatMeterNameAsModelID(t *testing.T) {
 	}
 }
 
+func TestRecordCredentialObservationFailureDoesNotClobberConcurrentSnapshotWrite(t *testing.T) {
+	t.Parallel()
+	fixture, _, credentialID := newSubscriptionCredentialFixture(t)
+	var credentialRow models.Credential
+	if err := fixture.db.Take(&credentialRow, credentialID).Error; err != nil {
+		t.Fatal(err)
+	}
+	staleSnapshot := `{"plan_summary":{},"quota_windows":[{"id":"primary","scope":"account","unit":"percent","state":"available"}]}`
+	freshSnapshot := `{"plan_summary":{},"quota_windows":[{"id":"primary","scope":"account","unit":"percent","state":"available","used":77}]}`
+	observedAt := int64(1000)
+	previous := models.CredentialObservation{
+		CredentialID: credentialID, IdentityFingerprint: credentialRow.IdentityFingerprint,
+		SchemaVersion: 1, ObservationVersion: 1, SnapshotJSON: models.JSON(staleSnapshot),
+		State: models.CredentialObservationFresh, ObservedAtMS: &observedAt, UpdatedAtMS: 1000,
+	}
+	if err := fixture.db.Create(&previous).Error; err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a passive quota write landing after `previous` was read by the
+	// caller but before this failure gets persisted.
+	if err := fixture.db.Model(&models.CredentialObservation{}).
+		Where("credential_id = ?", credentialID).
+		Updates(map[string]any{
+			"snapshot_json": models.JSON(freshSnapshot), "observed_at_ms": int64(2000), "updated_at_ms": int64(2000),
+		}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := fixture.service.recordCredentialObservationFailure(
+		t.Context(), credentialRow, previous, 3000, "observation_upstream_failed", "refresh subscription information", nil,
+	); err == nil {
+		t.Fatal("recordCredentialObservationFailure() error = nil")
+	}
+
+	var stored models.CredentialObservation
+	if err := fixture.db.Take(&stored, "credential_id = ?", credentialID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if string(stored.SnapshotJSON) != freshSnapshot {
+		t.Fatalf("snapshot_json = %s, want the concurrently-written fresh snapshot preserved", stored.SnapshotJSON)
+	}
+	// A previously fresh observation keeps showing its last-known-good state
+	// across a failed refresh; only the error code advances.
+	if stored.State != models.CredentialObservationFresh || stored.LastErrorCode != "observation_upstream_failed" {
+		t.Fatalf("stored observation = %#v, want fresh state preserved and error code updated", stored)
+	}
+	if stored.ObservedAtMS == nil || *stored.ObservedAtMS != 2000 {
+		t.Fatalf("observed_at_ms = %#v, want the concurrent write's 2000 preserved", stored.ObservedAtMS)
+	}
+}
+
+func TestInvalidateCredentialObservationAfterResetDoesNotClobberConcurrentSnapshotWrite(t *testing.T) {
+	t.Parallel()
+	fixture, _, credentialID := newSubscriptionCredentialFixture(t)
+	var credentialRow models.Credential
+	if err := fixture.db.Take(&credentialRow, credentialID).Error; err != nil {
+		t.Fatal(err)
+	}
+	staleSnapshot := `{"plan_summary":{},"quota_windows":[{"id":"primary","scope":"account","unit":"percent","state":"available"}]}`
+	freshSnapshot := `{"plan_summary":{},"quota_windows":[{"id":"primary","scope":"account","unit":"percent","state":"available","used":77}]}`
+	observedAt := int64(1000)
+	previous := models.CredentialObservation{
+		CredentialID: credentialID, IdentityFingerprint: credentialRow.IdentityFingerprint,
+		SchemaVersion: 1, ObservationVersion: 1, SnapshotJSON: models.JSON(staleSnapshot),
+		State: models.CredentialObservationFresh, LastErrorCode: "previous_error",
+		ObservedAtMS: &observedAt, UpdatedAtMS: 1000,
+	}
+	if err := fixture.db.Create(&previous).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := fixture.db.Model(&models.CredentialObservation{}).
+		Where("credential_id = ?", credentialID).
+		Updates(map[string]any{
+			"snapshot_json": models.JSON(freshSnapshot), "observed_at_ms": int64(2000), "updated_at_ms": int64(2000),
+		}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := fixture.service.invalidateCredentialObservationAfterReset(t.Context(), credentialRow, &previous); err != nil {
+		t.Fatal(err)
+	}
+
+	var stored models.CredentialObservation
+	if err := fixture.db.Take(&stored, "credential_id = ?", credentialID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if string(stored.SnapshotJSON) != freshSnapshot {
+		t.Fatalf("snapshot_json = %s, want the concurrently-written fresh snapshot preserved", stored.SnapshotJSON)
+	}
+	if stored.State != models.CredentialObservationStale || stored.LastErrorCode != "" {
+		t.Fatalf("stored observation = %#v, want state stale and error cleared", stored)
+	}
+	if stored.ObservedAtMS == nil || *stored.ObservedAtMS != 2000 {
+		t.Fatalf("observed_at_ms = %#v, want the concurrent write's 2000 preserved", stored.ObservedAtMS)
+	}
+}
+
 func TestRefreshCredentialObservationPersistsLKGAndAllowsImmediateManualRefresh(t *testing.T) {
 	t.Parallel()
 

--- a/internal/control/credential_observations_test.go
+++ b/internal/control/credential_observations_test.go
@@ -162,6 +162,41 @@ func TestNormalizeCodexObservationDoesNotTreatMeterNameAsModelID(t *testing.T) {
 	}
 }
 
+func TestRefreshCredentialObservationTimestampsUseResponseCompletionNotAttemptStart(t *testing.T) {
+	t.Parallel()
+	fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
+	start := time.UnixMilli(1_800_000_000_000)
+	// The clock advances while the upstream request is in flight, exactly as a
+	// slow manual refresh does in production.
+	current := start
+	fixture.service.now = func() time.Time { return current }
+	setCodexAccountObservation(fixture.service, func(context.Context, codex.Credential) (codex.AccountObservation, error) {
+		current = start.Add(3 * time.Second)
+		return codex.AccountObservation{Payload: []byte(`{"plan_type":"pro","rate_limit":{"primary_window":{"used_percent":25,"limit_window_seconds":18000,"reset_at":1800000600}}}`)}, nil
+	})
+
+	response, err := fixture.service.RefreshCredentialObservation(t.Context(), groupID, credentialID)
+	if err != nil {
+		t.Fatalf("RefreshCredentialObservation() error = %v", err)
+	}
+	if response.ObservedAtMS == nil || *response.ObservedAtMS != start.Add(3*time.Second).UnixMilli() {
+		t.Fatalf("observed_at_ms = %#v, want the response completion time %d",
+			response.ObservedAtMS, start.Add(3*time.Second).UnixMilli())
+	}
+	if response.LastAttemptAtMS == nil || *response.LastAttemptAtMS != start.UnixMilli() {
+		t.Fatalf("last_attempt_at_ms = %#v, want the attempt start time %d",
+			response.LastAttemptAtMS, start.UnixMilli())
+	}
+	var stored models.CredentialObservation
+	if err := fixture.db.Take(&stored, "credential_id = ?", credentialID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if stored.UpdatedAtMS != start.Add(3*time.Second).UnixMilli() {
+		t.Fatalf("updated_at_ms = %d, want the completion time so the passive CAS token actually changes",
+			stored.UpdatedAtMS)
+	}
+}
+
 func TestRecordCredentialObservationFailureDoesNotClobberConcurrentSnapshotWrite(t *testing.T) {
 	t.Parallel()
 	fixture, _, credentialID := newSubscriptionCredentialFixture(t)

--- a/internal/control/credential_reset_credits.go
+++ b/internal/control/credential_reset_credits.go
@@ -178,7 +178,13 @@ func (s *Service) invalidateCredentialObservationAfterReset(
 	previous.NextAllowedAtMS = nil
 	previous.LastErrorCode = ""
 	previous.UpdatedAtMS = s.now().UTC().UnixMilli()
-	if err := s.upsertCredentialObservation(ctx, *previous); err != nil {
+	updates := map[string]any{
+		"state":              previous.State,
+		"next_allowed_at_ms": previous.NextAllowedAtMS,
+		"last_error_code":    previous.LastErrorCode,
+		"updated_at_ms":      previous.UpdatedAtMS,
+	}
+	if err := s.upsertCredentialObservationMetadataOnly(ctx, credential.ID, *previous, updates); err != nil {
 		return nil, err
 	}
 	response := mapCredentialObservation(*previous)

--- a/internal/execution/cpa/adapter.go
+++ b/internal/execution/cpa/adapter.go
@@ -24,6 +24,7 @@ import (
 	"gpt-load/internal/protocol"
 	"gpt-load/internal/reasoning"
 	"gpt-load/internal/subscription"
+	providerobservation "gpt-load/internal/subscription/providers/observation"
 	subscriptionruntime "gpt-load/internal/subscription/runtime"
 	"gpt-load/internal/usage"
 )
@@ -47,6 +48,26 @@ type Adapter struct {
 
 type credentialPreparer interface {
 	Prepare(context.Context, channel.ID, execution.CredentialSnapshot, bool) (subscriptionruntime.Credential, *execution.ErrorEvidence)
+	RecordPassiveQuotaObservation(credentialID uint, identityGeneration uint64, observedAtMS int64, windows []providerobservation.QuotaWindow)
+}
+
+// recordPassiveQuotaObservation forwards one execution's passive quota
+// windows, if any, to the credential's pending observation. It is a no-op
+// for providers that never populate a response's QuotaWindows.
+func (a *Adapter) recordPassiveQuotaObservation(
+	spec execution.AttemptSpec,
+	observedAt time.Time,
+	windows []providerobservation.QuotaWindow,
+) {
+	if a == nil || a.credentials == nil || len(windows) == 0 {
+		return
+	}
+	a.credentials.RecordPassiveQuotaObservation(
+		spec.Credential.ID,
+		spec.Credential.IdentityGeneration,
+		observedAt.UnixMilli(),
+		windows,
+	)
 }
 
 // NewAdapter creates the shared CPA subscription execution adapter.
@@ -182,6 +203,7 @@ func (a *Adapter) Execute(ctx context.Context, spec execution.AttemptSpec) (resu
 			credential,
 			request,
 		)
+		a.recordPassiveQuotaObservation(spec, response.QuotaObservedAt, response.QuotaWindows)
 	}
 	if err != nil {
 		result := unaryExecutionError(execCtx, provider, err, credential)
@@ -294,6 +316,7 @@ func (a *Adapter) ExecuteStream(
 	upstreamProtocol := provider.UpstreamProtocol()
 	if response != nil {
 		upstreamProtocol = effectiveUpstreamProtocol(provider, response.UpstreamProtocol)
+		a.recordPassiveQuotaObservation(spec, response.QuotaObservedAt, response.QuotaWindows)
 	}
 	if err != nil {
 		result := unaryExecutionError(streamCtx, provider, err, credential)

--- a/internal/execution/cpa/adapter_test.go
+++ b/internal/execution/cpa/adapter_test.go
@@ -37,6 +37,7 @@ import (
 	subscriptionproviders "gpt-load/internal/subscription/providers"
 	"gpt-load/internal/subscription/providers/antigravity"
 	"gpt-load/internal/subscription/providers/codex"
+	providerobservation "gpt-load/internal/subscription/providers/observation"
 	subscriptionruntime "gpt-load/internal/subscription/runtime"
 	"gpt-load/internal/testutil/encryptiontest"
 )
@@ -73,6 +74,17 @@ func (f *fakeCredentialPreparer) Prepare(
 		return f.delegate.Prepare(ctx, channelID, credential, force)
 	}
 	return f.credential, f.evidence
+}
+
+func (f *fakeCredentialPreparer) RecordPassiveQuotaObservation(
+	credentialID uint,
+	identityGeneration uint64,
+	observedAtMS int64,
+	windows []providerobservation.QuotaWindow,
+) {
+	if f.delegate != nil {
+		f.delegate.RecordPassiveQuotaObservation(credentialID, identityGeneration, observedAtMS, windows)
+	}
 }
 
 type roundTripperFunc func(*http.Request) (*http.Response, error)
@@ -115,6 +127,69 @@ func setCodexExecutor(t *testing.T, adapter *Adapter, executor codex.Executor) {
 		t.Fatal("Codex provider bridge is unavailable")
 	}
 	bridge.executor = executor
+}
+
+func TestAdapterExecuteRecordsPassiveQuotaObservationOnSuccessAndHTTPError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "success"},
+		{name: "HTTP error", err: &codex.UpstreamHTTPError{Operation: "responses", StatusCode: 429}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			adapter, _, _, keyService, row := newAdapterFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
+			manager, ok := adapter.credentials.(*subscription.CredentialManager)
+			if !ok {
+				t.Fatal("adapter credentials is not a *subscription.CredentialManager")
+			}
+			observedAt := time.Date(2026, 8, 28, 9, 0, 0, 0, time.UTC)
+			setCodexExecutor(t, adapter, &fakeExecutor{
+				result: codex.ExecuteResponse{
+					Payload:         []byte(`{"id":"resp_1","model":"gpt-5","output":[]}`),
+					QuotaObservedAt: observedAt,
+					QuotaSignals:    map[string]string{"X-Codex-Primary-Used-Percent": "55"},
+				},
+				err: test.err,
+			})
+			spec := validSpec(t, row, keyService)
+
+			adapter.Execute(t.Context(), spec)
+
+			dirty := manager.DirtyPassiveQuotaObservations(1)
+			if len(dirty) != 1 || dirty[0].CredentialID != spec.Credential.ID ||
+				dirty[0].ObservedAtMS != observedAt.UnixMilli() || len(dirty[0].Windows) != 1 ||
+				dirty[0].Windows[0].ID != "primary" {
+				t.Fatalf("dirty observations = %#v", dirty)
+			}
+		})
+	}
+}
+
+func TestAdapterExecuteStreamRecordsPassiveQuotaObservationOnHandshake(t *testing.T) {
+	adapter, _, _, keyService, row := newAdapterFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
+	manager, ok := adapter.credentials.(*subscription.CredentialManager)
+	if !ok {
+		t.Fatal("adapter credentials is not a *subscription.CredentialManager")
+	}
+	chunks := make(chan codex.ExecuteStreamChunk, 1)
+	chunks <- codex.ExecuteStreamChunk{Payload: []byte(`data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt-5"}}`)}
+	close(chunks)
+	observedAt := time.Date(2026, 8, 28, 9, 0, 0, 0, time.UTC)
+	setCodexExecutor(t, adapter, &fakeExecutor{stream: &codex.ExecuteStreamResponse{
+		Headers:         http.Header{"X-Oai-Request-Id": {"oai-request-1"}},
+		Chunks:          chunks,
+		QuotaObservedAt: observedAt,
+		QuotaSignals:    map[string]string{"X-Codex-Primary-Used-Percent": "55"},
+	}})
+
+	adapter.ExecuteStream(t.Context(), validSpec(t, row, keyService), func(execution.StreamEvent) error { return nil })
+
+	dirty := manager.DirtyPassiveQuotaObservations(1)
+	if len(dirty) != 1 || dirty[0].ObservedAtMS != observedAt.UnixMilli() || len(dirty[0].Windows) != 1 {
+		t.Fatalf("dirty observations = %#v", dirty)
+	}
 }
 
 func TestAdapterStopsBeforeDispatchWhenCredentialPreparationFails(t *testing.T) {

--- a/internal/execution/cpa/claude_provider.go
+++ b/internal/execution/cpa/claude_provider.go
@@ -109,6 +109,8 @@ func (bridge *claudeProviderBridge) Execute(
 	return providerResponse{
 		Payload: append([]byte(nil), response.Payload...), Headers: response.Headers.Clone(),
 		AppliedReasoningEffort: response.AppliedReasoningEffort,
+		QuotaObservedAt:        response.QuotaObservedAt,
+		QuotaWindows:           claude.NormalizePassiveQuotaWindows(response.QuotaSignals, response.QuotaObservedAt),
 	}, err
 }
 
@@ -133,6 +135,8 @@ func (bridge *claudeProviderBridge) ExecuteStream(
 	if err != nil {
 		return &providerStreamResponse{
 			Headers: response.Headers.Clone(), AppliedReasoningEffort: response.AppliedReasoningEffort,
+			QuotaObservedAt: response.QuotaObservedAt,
+			QuotaWindows:    claude.NormalizePassiveQuotaWindows(response.QuotaSignals, response.QuotaObservedAt),
 		}, err
 	}
 	chunks := make(chan providerStreamChunk)
@@ -150,6 +154,8 @@ func (bridge *claudeProviderBridge) ExecuteStream(
 	return &providerStreamResponse{
 		Headers: response.Headers.Clone(), Chunks: chunks,
 		AppliedReasoningEffort: response.AppliedReasoningEffort,
+		QuotaObservedAt:        response.QuotaObservedAt,
+		QuotaWindows:           claude.NormalizePassiveQuotaWindows(response.QuotaSignals, response.QuotaObservedAt),
 	}, nil
 }
 

--- a/internal/execution/cpa/codex_provider.go
+++ b/internal/execution/cpa/codex_provider.go
@@ -308,6 +308,8 @@ func (bridge *codexProviderBridge) Execute(
 		Payload: append([]byte(nil), response.Payload...), Headers: response.Headers.Clone(),
 		AppliedReasoningEffort: response.AppliedReasoningEffort,
 		UpstreamProtocol:       codexUpstreamProtocol(response.UpstreamRequestPath),
+		QuotaObservedAt:        response.QuotaObservedAt,
+		QuotaWindows:           codex.NormalizePassiveQuotaWindows(response.QuotaSignals, response.QuotaObservedAt),
 	}, err
 }
 
@@ -334,6 +336,8 @@ func (bridge *codexProviderBridge) ExecuteStream(
 		Headers:                response.Headers.Clone(),
 		AppliedReasoningEffort: response.AppliedReasoningEffort,
 		UpstreamProtocol:       codexUpstreamProtocol(response.UpstreamRequestPath),
+		QuotaObservedAt:        response.QuotaObservedAt,
+		QuotaWindows:           codex.NormalizePassiveQuotaWindows(response.QuotaSignals, response.QuotaObservedAt),
 	}
 	if err != nil {
 		if codexBootstrapCapacityRejection(err) {

--- a/internal/execution/cpa/provider.go
+++ b/internal/execution/cpa/provider.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"time"
 
 	"gpt-load/internal/channel"
 	"gpt-load/internal/execution"
 	"gpt-load/internal/outboundproxy"
 	"gpt-load/internal/protocol"
+	providerobservation "gpt-load/internal/subscription/providers/observation"
 )
 
 // providerCredential is deliberately opaque to the shared CPA adapter. Each
@@ -141,6 +143,8 @@ type providerResponse struct {
 	AppliedReasoningEffort string
 	UpstreamProtocol       protocol.Protocol
 	Local                  bool
+	QuotaObservedAt        time.Time
+	QuotaWindows           []providerobservation.QuotaWindow
 }
 
 type providerStreamResponse struct {
@@ -148,6 +152,8 @@ type providerStreamResponse struct {
 	Chunks                 <-chan providerStreamChunk
 	AppliedReasoningEffort string
 	UpstreamProtocol       protocol.Protocol
+	QuotaObservedAt        time.Time
+	QuotaWindows           []providerobservation.QuotaWindow
 }
 
 type providerStreamChunk struct {

--- a/internal/requestlog/passive_quota_checkpoint_test.go
+++ b/internal/requestlog/passive_quota_checkpoint_test.go
@@ -1,0 +1,130 @@
+package requestlog
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"gpt-load/internal/platform/redact"
+	"gpt-load/internal/storage/models"
+)
+
+type fakePassiveQuotaFlusher struct {
+	mu        sync.Mutex
+	calls     int
+	remaining []bool
+	errs      []error
+	notifier  func()
+}
+
+func (f *fakePassiveQuotaFlusher) FlushPassiveQuotaObservations(context.Context) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	index := f.calls
+	f.calls++
+	var remaining bool
+	if index < len(f.remaining) {
+		remaining = f.remaining[index]
+	}
+	var err error
+	if index < len(f.errs) {
+		err = f.errs[index]
+	}
+	return remaining, err
+}
+
+func (f *fakePassiveQuotaFlusher) SetPassiveQuotaDirtyNotifier(notifier func()) {
+	f.mu.Lock()
+	f.notifier = notifier
+	f.mu.Unlock()
+}
+
+func (f *fakePassiveQuotaFlusher) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func TestSetPassiveQuotaFlusherSharesQuotaWakeAndRegistersNotifier(t *testing.T) {
+	service := newService(
+		batchWriterFunc(func(context.Context, []models.RequestLog) error { return nil }),
+		redact.New(),
+		newManualTimerFactory().New,
+	)
+	if service.quotaWake != nil {
+		t.Fatal("quotaWake already exists before any quota source was installed")
+	}
+	flusher := &fakePassiveQuotaFlusher{}
+	service.SetPassiveQuotaFlusher(flusher)
+	if service.quotaWake == nil {
+		t.Fatal("SetPassiveQuotaFlusher() did not create quotaWake")
+	}
+	if flusher.notifier == nil {
+		t.Fatal("SetPassiveQuotaFlusher() did not register a dirty notifier")
+	}
+	flusher.notifier()
+	select {
+	case <-service.quotaWake:
+	default:
+		t.Fatal("dirty notifier did not wake quotaWake")
+	}
+}
+
+func TestWriteBatchFlushesPassiveQuotaWithoutAffectingItsOwnErrorOrCounters(t *testing.T) {
+	service := newService(
+		batchWriterFunc(func(context.Context, []models.RequestLog) error { return nil }),
+		redact.New(),
+		newManualTimerFactory().New,
+	)
+	flusher := &fakePassiveQuotaFlusher{errs: []error{errors.New("boom")}}
+	service.SetPassiveQuotaFlusher(flusher)
+
+	if err := service.writeBatch(t.Context(), nil); err != nil {
+		t.Fatalf("writeBatch() error = %v, want nil despite a passive quota failure", err)
+	}
+	if flusher.callCount() != 1 {
+		t.Fatalf("passive quota flush calls = %d, want 1", flusher.callCount())
+	}
+	stats := service.Stats()
+	if stats.WriteFailureTotal != 0 || stats.DroppedPersistFailedTotal != 0 {
+		t.Fatalf("RequestLog failure counters changed from a passive quota failure: %#v", stats)
+	}
+}
+
+func TestWriteBatchRewakesWhenPassiveQuotaHasRemainingPending(t *testing.T) {
+	service := newService(
+		batchWriterFunc(func(context.Context, []models.RequestLog) error { return nil }),
+		redact.New(),
+		newManualTimerFactory().New,
+	)
+	flusher := &fakePassiveQuotaFlusher{remaining: []bool{true}}
+	service.SetPassiveQuotaFlusher(flusher)
+
+	if err := service.writeBatch(t.Context(), nil); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-service.quotaWake:
+	default:
+		t.Fatal("writeBatch() did not re-wake for remaining passive quota pending")
+	}
+}
+
+func TestRequestLogWorkerStopSucceedsDespitePassiveQuotaDrainFailure(t *testing.T) {
+	timers := newManualTimerFactory()
+	service := newService(
+		batchWriterFunc(func(context.Context, []models.RequestLog) error { return nil }),
+		redact.New(),
+		timers.New,
+	)
+	flusher := &fakePassiveQuotaFlusher{remaining: []bool{true}, errs: []error{nil, errors.New("boom")}}
+	service.SetPassiveQuotaFlusher(flusher)
+	if err := service.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := service.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop() error = %v, want nil despite a passive quota drain failure", err)
+	}
+}

--- a/internal/requestlog/service.go
+++ b/internal/requestlog/service.go
@@ -29,6 +29,15 @@ type batchWriter interface {
 	WriteBatch(context.Context, []models.RequestLog) error
 }
 
+// passiveQuotaFlusher is the narrow, package-local view of
+// subscription.CredentialManager's passive quota pending store. RequestLog
+// depends on this shape only -- it never imports the subscription package or
+// its Provider, Observation, or window models.
+type passiveQuotaFlusher interface {
+	FlushPassiveQuotaObservations(ctx context.Context) (bool, error)
+	SetPassiveQuotaDirtyNotifier(notifier func())
+}
+
 type workerTimer interface {
 	C() <-chan time.Time
 	Stop() bool
@@ -51,6 +60,7 @@ type Service struct {
 	accessQuota     *accessquota.Runtime
 	quotaWriter     accessQuotaCheckpointWriter
 	quotaWake       chan struct{}
+	passiveQuota    passiveQuotaFlusher
 
 	stateMu       sync.Mutex
 	state         lifecycleState
@@ -79,6 +89,9 @@ type Service struct {
 
 	warningMu     sync.Mutex
 	lastWarningAt time.Time
+
+	passiveQuotaWarningMu     sync.Mutex
+	lastPassiveQuotaWarningAt time.Time
 }
 
 func NewService(
@@ -121,6 +134,45 @@ func (service *Service) wakeAccessQuotaCheckpoint() {
 	case service.quotaWake <- struct{}{}:
 	default:
 	}
+}
+
+// SetPassiveQuotaFlusher installs the passive credential-quota observation
+// flusher and shares this worker's existing quotaWake with it, so a dirty
+// passive observation and a dirty AccessQuota checkpoint wake the same
+// worker cycle. Call it before Start; a nil flusher is a no-op.
+func (service *Service) SetPassiveQuotaFlusher(flusher passiveQuotaFlusher) {
+	if service == nil || flusher == nil {
+		return
+	}
+	service.passiveQuota = flusher
+	if service.quotaWake == nil {
+		service.quotaWake = make(chan struct{}, 1)
+	}
+	flusher.SetPassiveQuotaDirtyNotifier(service.wakeAccessQuotaCheckpoint)
+}
+
+func (service *Service) warnPassiveQuotaFlushFailure(cause error) {
+	if service == nil || cause == nil {
+		return
+	}
+	now := service.now()
+	service.passiveQuotaWarningMu.Lock()
+	if !service.lastPassiveQuotaWarningAt.IsZero() && now.Before(service.lastPassiveQuotaWarningAt.Add(warningInterval)) {
+		service.passiveQuotaWarningMu.Unlock()
+		return
+	}
+	service.lastPassiveQuotaWarningAt = now
+	service.passiveQuotaWarningMu.Unlock()
+	utils.LogPlaneBestEffort(
+		service.logger,
+		logrus.WarnLevel,
+		utils.LogPlaneData,
+		logrus.Fields{
+			"event": "credential_observation.passive_persist_failed",
+			"error": cause.Error(),
+		},
+		"passive credential quota observation persistence failed",
+	)
 }
 
 func newService(

--- a/internal/requestlog/worker.go
+++ b/internal/requestlog/worker.go
@@ -863,6 +863,7 @@ func (service *Service) drain(ctx context.Context, batch []queuedEvent) {
 					return
 				}
 			}
+			service.drainPassiveQuotaObservations(ctx)
 			return
 		}
 	}
@@ -889,7 +890,49 @@ func (service *Service) writeBatch(ctx context.Context, events []queuedEvent) er
 			service.persistedTotal.Add(uint64(len(rows)))
 		}
 	}
-	return service.flushAccessQuotaCheckpoints(ctx)
+	err := service.flushAccessQuotaCheckpoints(ctx)
+	service.flushPassiveQuotaCheckpoint(ctx)
+	return err
+}
+
+// flushPassiveQuotaCheckpoint writes one bounded passive quota observation
+// batch after the log and AccessQuota checkpoint batches. It never returns
+// an error to writeBatch: a persistence failure here must not affect
+// RequestLog's own failure counters, dropped-event accounting, or Stop
+// result, and pending observations simply retry on the next wake.
+func (service *Service) flushPassiveQuotaCheckpoint(ctx context.Context) {
+	if service == nil || service.passiveQuota == nil {
+		return
+	}
+	remaining, err := service.passiveQuota.FlushPassiveQuotaObservations(ctx)
+	if err != nil {
+		service.warnPassiveQuotaFlushFailure(err)
+		service.wakeAccessQuotaCheckpoint()
+		return
+	}
+	if remaining {
+		service.wakeAccessQuotaCheckpoint()
+	}
+}
+
+// drainPassiveQuotaObservations makes a best-effort attempt to persist
+// remaining passive quota pending within the shutdown context. It stops on
+// an empty pending set, a canceled context, or the first write failure --
+// never retrying without bound -- and never marks RequestLog Stop as failed.
+func (service *Service) drainPassiveQuotaObservations(ctx context.Context) {
+	if service == nil || service.passiveQuota == nil {
+		return
+	}
+	for ctx.Err() == nil {
+		remaining, err := service.passiveQuota.FlushPassiveQuotaObservations(ctx)
+		if err != nil {
+			service.warnPassiveQuotaFlushFailure(err)
+			return
+		}
+		if !remaining {
+			return
+		}
+	}
 }
 
 func (service *Service) flushAccessQuotaCheckpoints(ctx context.Context) error {

--- a/internal/state/registry.go
+++ b/internal/state/registry.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	providerobservation "gpt-load/internal/subscription/providers/observation"
 )
 
 type CredentialStatus string
@@ -698,6 +700,53 @@ func (r *CredentialRegistry) SetCredentialQuotaObservation(
 	}
 	entry.quotaResetAt = resetAt
 	return true
+}
+
+// ApplyQuotaWindows publishes the tightest account-scope remaining ratio
+// derived from windows to the management-plane health display, or clears it
+// when no account-scope window carries both a usable ratio and a reset time.
+// It is shared by the active and passive credential observation writers so
+// both pick the same bottleneck window using one rule.
+func (r *CredentialRegistry) ApplyQuotaWindows(credentialID uint, windows []providerobservation.QuotaWindow) bool {
+	if r == nil || credentialID == 0 {
+		return false
+	}
+	var remaining *float64
+	var resetAtMS int64
+	for _, window := range windows {
+		if window.Scope != "account" || window.ResetAtMS == nil {
+			continue
+		}
+		value, known := quotaWindowRemainingRatio(window)
+		if !known {
+			continue
+		}
+		if remaining == nil || value < *remaining {
+			cloned := value
+			remaining = &cloned
+			resetAtMS = *window.ResetAtMS
+		} else if value == *remaining && *window.ResetAtMS > resetAtMS {
+			// Equal bottlenecks must all recover before this credential is usable.
+			resetAtMS = *window.ResetAtMS
+		}
+	}
+	if remaining == nil || resetAtMS == 0 {
+		return r.SetCredentialQuotaObservation(credentialID, nil, time.Time{})
+	}
+	return r.SetCredentialQuotaObservation(credentialID, remaining, time.UnixMilli(resetAtMS).UTC())
+}
+
+func quotaWindowRemainingRatio(window providerobservation.QuotaWindow) (float64, bool) {
+	if window.State == "exhausted" {
+		return 0, true
+	}
+	if window.Utilization != nil {
+		return math.Max(0, math.Min(1, 1-*window.Utilization)), true
+	}
+	if window.Remaining != nil && window.Limit != nil && *window.Limit > 0 {
+		return math.Max(0, math.Min(1, *window.Remaining / *window.Limit)), true
+	}
+	return 0, false
 }
 
 func (r *CredentialRegistry) SetCooldown(credentialID uint, until time.Time) bool {

--- a/internal/state/registry_test.go
+++ b/internal/state/registry_test.go
@@ -2,11 +2,14 @@ package state
 
 import (
 	"fmt"
+	"math"
 	"reflect"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	providerobservation "gpt-load/internal/subscription/providers/observation"
 )
 
 func TestKeyRegistryReplaceAndEncryptedValue(t *testing.T) {
@@ -156,6 +159,49 @@ func TestCredentialRegistryQuotaObservationDoesNotAffectCandidates(t *testing.T)
 	got := registry.CollectCredentialCandidates([]uint{10}, nil, now)
 	if len(got) != 1 {
 		t.Fatalf("available quota candidates = %#v", got)
+	}
+}
+
+func TestCredentialRegistryApplyQuotaWindowsPublishesTightestAccountBottleneck(t *testing.T) {
+	registry := NewCredentialRegistry()
+	mustReplaceKeyEntries(t, registry, []CredentialEntry{{
+		ID: 1, GroupID: 10, Status: CredentialStatusActive,
+		Version: 1, IdentityGeneration: 1, Fingerprint: "test-fingerprint", EncryptedValue: "cipher-one",
+	}})
+	resetAt := int64(1800000000000)
+	utilizationTight := 0.9
+	utilizationLoose := 0.1
+	if !registry.ApplyQuotaWindows(1, []providerobservation.QuotaWindow{
+		{ID: "primary", Scope: "account", State: "available", Utilization: &utilizationTight, ResetAtMS: &resetAt},
+		{ID: "secondary", Scope: "account", State: "available", Utilization: &utilizationLoose, ResetAtMS: &resetAt},
+		{ID: "extra", Scope: "extra_usage", State: "available", Utilization: &utilizationLoose, ResetAtMS: &resetAt},
+	}) {
+		t.Fatal("ApplyQuotaWindows() = false")
+	}
+	views := registry.Snapshot()
+	if len(views) != 1 || views[0].ObservedQuotaRemaining() == nil ||
+		math.Abs(*views[0].ObservedQuotaRemaining()-0.1) > 1e-9 {
+		t.Fatalf("observed quota remaining = %#v, want the tighter account-scope bottleneck 0.1", views)
+	}
+}
+
+func TestCredentialRegistryApplyQuotaWindowsClearsWhenNoUsableWindow(t *testing.T) {
+	registry := NewCredentialRegistry()
+	mustReplaceKeyEntries(t, registry, []CredentialEntry{{
+		ID: 1, GroupID: 10, Status: CredentialStatusActive,
+		Version: 1, IdentityGeneration: 1, Fingerprint: "test-fingerprint", EncryptedValue: "cipher-one",
+	}})
+	remaining := 0.5
+	registry.SetCredentialQuotaObservation(1, &remaining, time.Date(2026, 8, 28, 9, 0, 0, 0, time.UTC))
+
+	if !registry.ApplyQuotaWindows(1, []providerobservation.QuotaWindow{
+		{ID: "model-scope", Scope: "model", State: "available"},
+	}) {
+		t.Fatal("ApplyQuotaWindows() = false")
+	}
+	views := registry.Snapshot()
+	if len(views) != 1 || views[0].ObservedQuotaRemaining() != nil {
+		t.Fatalf("observed quota remaining = %#v, want cleared", views)
 	}
 }
 

--- a/internal/subscription/credential_manager.go
+++ b/internal/subscription/credential_manager.go
@@ -37,6 +37,7 @@ type CredentialManager struct {
 	replaceSecret  func(uint, uint64, uint64, string, string) bool
 	reconcileGroup func(uint, []state.CredentialEntry) (bool, error)
 	now            func() time.Time
+	passiveQuota   *passiveQuotaPending
 }
 
 // Runtime returns the immutable capability registry used by this manager.
@@ -61,7 +62,7 @@ func NewCredentialManager(
 	}
 	return &CredentialManager{
 		db: db, encryption: encryptionService, registry: registry, mutations: mutations,
-		runtime: runtime,
+		runtime: runtime, passiveQuota: newPassiveQuotaPending(),
 		refresh: func(ctx context.Context, driver subscriptionruntime.Driver, credential subscriptionruntime.Credential) (subscriptionruntime.Credential, error) {
 			return driver.Refresh(ctx, credential)
 		},

--- a/internal/subscription/passive_quota.go
+++ b/internal/subscription/passive_quota.go
@@ -7,8 +7,8 @@ import (
 	providerobservation "gpt-load/internal/subscription/providers/observation"
 )
 
-// PassiveQuotaObservation is one credential's merged, not-yet-persisted
-// passive quota snapshot, captured from upstream response headers.
+// PassiveQuotaObservation is one credential's not-yet-persisted passive quota
+// snapshot, captured from a single upstream response's headers.
 type PassiveQuotaObservation struct {
 	CredentialID       uint
 	IdentityGeneration uint64
@@ -40,12 +40,19 @@ func newPassiveQuotaPending() *passiveQuotaPending {
 	return &passiveQuotaPending{entries: make(map[uint]*passiveQuotaEntry)}
 }
 
-// RecordPassiveQuotaObservation merges one response's passive quota windows
-// into the pending snapshot for credentialID. A response with no windows is
-// a no-op: it must not advance the pending observation time. An
-// identityGeneration different from the currently pending entry replaces it
-// instead of merging, since the windows would belong to a different secret.
-// An observedAtMS older than the pending entry is dropped.
+// RecordPassiveQuotaObservation stores one response's passive quota windows
+// as the pending snapshot for credentialID, replacing whatever the previous
+// response left there.
+//
+// Responses are deliberately never combined. A pending entry carries a single
+// observation time, so mixing fields captured at different instants would let
+// an older value be persisted under a newer timestamp and outrank an active
+// refresh committed in between. Dropping the older response loses nothing:
+// the stored snapshot keeps its current value for any window this response
+// omits, and the next response carrying that window refreshes it.
+//
+// A response with no windows is a no-op: it must not advance the pending
+// observation time. An observedAtMS older than the pending entry is dropped.
 func (manager *CredentialManager) RecordPassiveQuotaObservation(
 	credentialID uint,
 	identityGeneration uint64,
@@ -103,7 +110,7 @@ func (pending *passiveQuotaPending) record(
 		pending.mu.Unlock()
 		return
 	}
-	entry.windows = mergeQuotaWindowsByID(entry.windows, windows)
+	entry.windows = append([]providerobservation.QuotaWindow(nil), windows...)
 	entry.observedAtMS = observedAtMS
 	pending.nextVersion++
 	entry.version = pending.nextVersion
@@ -146,10 +153,7 @@ func (pending *passiveQuotaPending) dirtyObservations(limit int) []PassiveQuotaO
 	return result
 }
 
-// ack clears the dirty flag and drops the cached windows for an exactly
-// matching version. The cache must not survive its own flush: once a field
-// has been persisted, a future response that omits it must not have that
-// stale value merged back in and rewritten over a newer active refresh.
+// ack clears the dirty flag for an exactly matching version.
 func (pending *passiveQuotaPending) ack(credentialID uint, version uint64) {
 	pending.mu.Lock()
 	defer pending.mu.Unlock()
@@ -158,27 +162,4 @@ func (pending *passiveQuotaPending) ack(credentialID uint, version uint64) {
 		return
 	}
 	entry.dirty = false
-	entry.windows = nil
-}
-
-// mergeQuotaWindowsByID overlays patches onto previous by window ID, keeping
-// any previous window a patch did not touch.
-func mergeQuotaWindowsByID(
-	previous []providerobservation.QuotaWindow,
-	patches []providerobservation.QuotaWindow,
-) []providerobservation.QuotaWindow {
-	merged := append([]providerobservation.QuotaWindow(nil), previous...)
-	index := make(map[string]int, len(merged))
-	for position, window := range merged {
-		index[window.ID] = position
-	}
-	for _, patch := range patches {
-		if position, ok := index[patch.ID]; ok {
-			merged[position] = providerobservation.MergeQuotaWindow(merged[position], patch)
-			continue
-		}
-		index[patch.ID] = len(merged)
-		merged = append(merged, patch)
-	}
-	return merged
 }

--- a/internal/subscription/passive_quota.go
+++ b/internal/subscription/passive_quota.go
@@ -110,7 +110,7 @@ func (pending *passiveQuotaPending) record(
 		pending.mu.Unlock()
 		return
 	}
-	entry.windows = append([]providerobservation.QuotaWindow(nil), windows...)
+	entry.windows = cloneQuotaWindows(windows)
 	entry.observedAtMS = observedAtMS
 	pending.nextVersion++
 	entry.version = pending.nextVersion
@@ -143,7 +143,7 @@ func (pending *passiveQuotaPending) dirtyObservations(limit int) []PassiveQuotaO
 			CredentialID:       credentialID,
 			IdentityGeneration: entry.identityGeneration,
 			ObservedAtMS:       entry.observedAtMS,
-			Windows:            append([]providerobservation.QuotaWindow(nil), entry.windows...),
+			Windows:            cloneQuotaWindows(entry.windows),
 			Version:            entry.version,
 		})
 		if len(result) >= limit {
@@ -151,6 +151,44 @@ func (pending *passiveQuotaPending) dirtyObservations(limit int) []PassiveQuotaO
 		}
 	}
 	return result
+}
+
+// cloneQuotaWindows detaches a window slice from its caller, including the
+// values behind its optional numeric fields. Sharing those pointers would let
+// a later mutation change what is about to be persisted, under an observation
+// time captured before that change.
+func cloneQuotaWindows(windows []providerobservation.QuotaWindow) []providerobservation.QuotaWindow {
+	if len(windows) == 0 {
+		return nil
+	}
+	cloned := make([]providerobservation.QuotaWindow, 0, len(windows))
+	for _, window := range windows {
+		window.Used = cloneFloat(window.Used)
+		window.Limit = cloneFloat(window.Limit)
+		window.Remaining = cloneFloat(window.Remaining)
+		window.Utilization = cloneFloat(window.Utilization)
+		window.ResetAtMS = cloneInt64(window.ResetAtMS)
+		window.WindowSeconds = cloneInt64(window.WindowSeconds)
+		window.ModelIDs = append([]string(nil), window.ModelIDs...)
+		cloned = append(cloned, window)
+	}
+	return cloned
+}
+
+func cloneFloat(value *float64) *float64 {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func cloneInt64(value *int64) *int64 {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
 }
 
 // ack clears the dirty flag for an exactly matching version.

--- a/internal/subscription/passive_quota.go
+++ b/internal/subscription/passive_quota.go
@@ -74,16 +74,6 @@ func (manager *CredentialManager) DirtyPassiveQuotaObservations(limit int) []Pas
 	return manager.passiveQuota.dirtyObservations(limit)
 }
 
-// AckPassiveQuotaObservation clears the dirty flag for credentialID only when
-// version exactly matches the currently pending version, so a write that
-// landed after this version was read is never dropped by a stale ACK.
-func (manager *CredentialManager) AckPassiveQuotaObservation(credentialID uint, version uint64) {
-	if manager == nil || manager.passiveQuota == nil {
-		return
-	}
-	manager.passiveQuota.ack(credentialID, version)
-}
-
 // SetPassiveQuotaDirtyNotifier installs the process-owned non-blocking wake-up
 // invoked after a record introduces a new dirty version.
 func (manager *CredentialManager) SetPassiveQuotaDirtyNotifier(notifier func()) {
@@ -191,7 +181,12 @@ func cloneInt64(value *int64) *int64 {
 	return &cloned
 }
 
-// ack clears the dirty flag for an exactly matching version.
+// ack drops the pending entry for an exactly matching version. Evicting
+// rather than just clearing a flag is what keeps the map bounded: a
+// credential that is deleted after producing quota headers would otherwise
+// retain its cloned windows for the life of the process, so an instance with
+// credential churn would grow without bound. A version mismatch means a newer
+// response arrived while this one was being written, so that entry stays.
 func (pending *passiveQuotaPending) ack(credentialID uint, version uint64) {
 	pending.mu.Lock()
 	defer pending.mu.Unlock()
@@ -199,5 +194,5 @@ func (pending *passiveQuotaPending) ack(credentialID uint, version uint64) {
 	if !ok || entry.version != version {
 		return
 	}
-	entry.dirty = false
+	delete(pending.entries, credentialID)
 }

--- a/internal/subscription/passive_quota.go
+++ b/internal/subscription/passive_quota.go
@@ -1,0 +1,179 @@
+package subscription
+
+import (
+	"sort"
+	"sync"
+
+	providerobservation "gpt-load/internal/subscription/providers/observation"
+)
+
+// PassiveQuotaObservation is one credential's merged, not-yet-persisted
+// passive quota snapshot, captured from upstream response headers.
+type PassiveQuotaObservation struct {
+	CredentialID       uint
+	IdentityGeneration uint64
+	ObservedAtMS       int64
+	Windows            []providerobservation.QuotaWindow
+	Version            uint64
+}
+
+type passiveQuotaEntry struct {
+	identityGeneration uint64
+	observedAtMS       int64
+	windows            []providerobservation.QuotaWindow
+	version            uint64
+	dirty              bool
+}
+
+// passiveQuotaPending is the process-local, credential-keyed dirty set for
+// passive quota observations. It holds at most one entry per credential and
+// never grows with request volume, only with the number of accounts that
+// have produced a valid quota signal.
+type passiveQuotaPending struct {
+	mu            sync.Mutex
+	entries       map[uint]*passiveQuotaEntry
+	nextVersion   uint64
+	dirtyNotifier func()
+}
+
+func newPassiveQuotaPending() *passiveQuotaPending {
+	return &passiveQuotaPending{entries: make(map[uint]*passiveQuotaEntry)}
+}
+
+// RecordPassiveQuotaObservation merges one response's passive quota windows
+// into the pending snapshot for credentialID. A response with no windows is
+// a no-op: it must not advance the pending observation time. An
+// identityGeneration different from the currently pending entry replaces it
+// instead of merging, since the windows would belong to a different secret.
+// An observedAtMS older than the pending entry is dropped.
+func (manager *CredentialManager) RecordPassiveQuotaObservation(
+	credentialID uint,
+	identityGeneration uint64,
+	observedAtMS int64,
+	windows []providerobservation.QuotaWindow,
+) {
+	if manager == nil || manager.passiveQuota == nil || credentialID == 0 || len(windows) == 0 {
+		return
+	}
+	manager.passiveQuota.record(credentialID, identityGeneration, observedAtMS, windows)
+}
+
+// DirtyPassiveQuotaObservations returns up to limit pending observations that
+// have not yet been acknowledged, ordered by credential ID for determinism.
+func (manager *CredentialManager) DirtyPassiveQuotaObservations(limit int) []PassiveQuotaObservation {
+	if manager == nil || manager.passiveQuota == nil {
+		return nil
+	}
+	return manager.passiveQuota.dirtyObservations(limit)
+}
+
+// AckPassiveQuotaObservation clears the dirty flag for credentialID only when
+// version exactly matches the currently pending version, so a write that
+// landed after this version was read is never dropped by a stale ACK.
+func (manager *CredentialManager) AckPassiveQuotaObservation(credentialID uint, version uint64) {
+	if manager == nil || manager.passiveQuota == nil {
+		return
+	}
+	manager.passiveQuota.ack(credentialID, version)
+}
+
+// SetPassiveQuotaDirtyNotifier installs the process-owned non-blocking wake-up
+// invoked after a record introduces a new dirty version.
+func (manager *CredentialManager) SetPassiveQuotaDirtyNotifier(notifier func()) {
+	if manager == nil || manager.passiveQuota == nil {
+		return
+	}
+	manager.passiveQuota.mu.Lock()
+	manager.passiveQuota.dirtyNotifier = notifier
+	manager.passiveQuota.mu.Unlock()
+}
+
+func (pending *passiveQuotaPending) record(
+	credentialID uint,
+	identityGeneration uint64,
+	observedAtMS int64,
+	windows []providerobservation.QuotaWindow,
+) {
+	pending.mu.Lock()
+	entry, exists := pending.entries[credentialID]
+	if !exists || entry.identityGeneration != identityGeneration {
+		entry = &passiveQuotaEntry{identityGeneration: identityGeneration}
+		pending.entries[credentialID] = entry
+	} else if observedAtMS < entry.observedAtMS {
+		pending.mu.Unlock()
+		return
+	}
+	entry.windows = mergeQuotaWindowsByID(entry.windows, windows)
+	entry.observedAtMS = observedAtMS
+	pending.nextVersion++
+	entry.version = pending.nextVersion
+	entry.dirty = true
+	notifier := pending.dirtyNotifier
+	pending.mu.Unlock()
+	if notifier != nil {
+		notifier()
+	}
+}
+
+func (pending *passiveQuotaPending) dirtyObservations(limit int) []PassiveQuotaObservation {
+	if pending == nil || limit <= 0 {
+		return nil
+	}
+	pending.mu.Lock()
+	defer pending.mu.Unlock()
+	ids := make([]uint, 0, len(pending.entries))
+	for credentialID := range pending.entries {
+		ids = append(ids, credentialID)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	result := make([]PassiveQuotaObservation, 0, limit)
+	for _, credentialID := range ids {
+		entry := pending.entries[credentialID]
+		if entry == nil || !entry.dirty {
+			continue
+		}
+		result = append(result, PassiveQuotaObservation{
+			CredentialID:       credentialID,
+			IdentityGeneration: entry.identityGeneration,
+			ObservedAtMS:       entry.observedAtMS,
+			Windows:            append([]providerobservation.QuotaWindow(nil), entry.windows...),
+			Version:            entry.version,
+		})
+		if len(result) >= limit {
+			break
+		}
+	}
+	return result
+}
+
+func (pending *passiveQuotaPending) ack(credentialID uint, version uint64) {
+	pending.mu.Lock()
+	defer pending.mu.Unlock()
+	entry, ok := pending.entries[credentialID]
+	if !ok || entry.version != version {
+		return
+	}
+	entry.dirty = false
+}
+
+// mergeQuotaWindowsByID overlays patches onto previous by window ID, keeping
+// any previous window a patch did not touch.
+func mergeQuotaWindowsByID(
+	previous []providerobservation.QuotaWindow,
+	patches []providerobservation.QuotaWindow,
+) []providerobservation.QuotaWindow {
+	merged := append([]providerobservation.QuotaWindow(nil), previous...)
+	index := make(map[string]int, len(merged))
+	for position, window := range merged {
+		index[window.ID] = position
+	}
+	for _, patch := range patches {
+		if position, ok := index[patch.ID]; ok {
+			merged[position] = providerobservation.MergeQuotaWindow(merged[position], patch)
+			continue
+		}
+		index[patch.ID] = len(merged)
+		merged = append(merged, patch)
+	}
+	return merged
+}

--- a/internal/subscription/passive_quota.go
+++ b/internal/subscription/passive_quota.go
@@ -146,6 +146,10 @@ func (pending *passiveQuotaPending) dirtyObservations(limit int) []PassiveQuotaO
 	return result
 }
 
+// ack clears the dirty flag and drops the cached windows for an exactly
+// matching version. The cache must not survive its own flush: once a field
+// has been persisted, a future response that omits it must not have that
+// stale value merged back in and rewritten over a newer active refresh.
 func (pending *passiveQuotaPending) ack(credentialID uint, version uint64) {
 	pending.mu.Lock()
 	defer pending.mu.Unlock()
@@ -154,6 +158,7 @@ func (pending *passiveQuotaPending) ack(credentialID uint, version uint64) {
 		return
 	}
 	entry.dirty = false
+	entry.windows = nil
 }
 
 // mergeQuotaWindowsByID overlays patches onto previous by window ID, keeping

--- a/internal/subscription/passive_quota_flush.go
+++ b/internal/subscription/passive_quota_flush.go
@@ -63,12 +63,15 @@ func (manager *CredentialManager) flushOnePassiveQuotaObservation(
 			}
 			return fmt.Errorf("read credential observation %d: %w", observation.CredentialID, err)
 		}
-		if row.ObservedAtMS != nil && observation.ObservedAtMS < *row.ObservedAtMS {
-			// A newer observation -- typically a manual refresh -- was persisted
-			// while this sample sat in the pending map. Writing it now would both
+		if row.ObservedAtMS != nil && observation.ObservedAtMS <= *row.ObservedAtMS {
+			// An observation at least as new -- typically a manual refresh --
+			// was persisted while this sample sat pending. Writing it now would
 			// rewind observed_at_ms and overwrite newer quota values with older
-			// ones, so the sample is dropped instead. The updated_at_ms guard
-			// below only catches writes that land after this read.
+			// ones. The tie is included on purpose: a passive header captured
+			// just before an active refresh that finished within the same
+			// millisecond truncates to the same value, and the active result is
+			// the authoritative one. The CAS below only catches writes that land
+			// after this read.
 			manager.passiveQuota.ack(observation.CredentialID, observation.Version)
 			return nil
 		}
@@ -79,11 +82,10 @@ func (manager *CredentialManager) flushOnePassiveQuotaObservation(
 			manager.passiveQuota.ack(observation.CredentialID, observation.Version)
 			return nil
 		}
-		alreadyObservedAt := row.ObservedAtMS != nil && *row.ObservedAtMS == observation.ObservedAtMS
-		if !merge.Matched || (!merge.Changed && alreadyObservedAt) {
-			// Nothing this response says is new: either it named no window the
-			// snapshot tracks, or it repeated values already stored at this
-			// very instant.
+		if !merge.Matched {
+			// The response named no window this snapshot tracks, so it is no
+			// observation of this credential's quota at all. Creating windows
+			// is the active observation's job.
 			manager.passiveQuota.ack(observation.CredentialID, observation.Version)
 			return nil
 		}

--- a/internal/subscription/passive_quota_flush.go
+++ b/internal/subscription/passive_quota_flush.go
@@ -97,8 +97,17 @@ func (manager *CredentialManager) flushOnePassiveQuotaObservation(
 		if merge.Changed {
 			updates["snapshot_json"] = models.JSON(merge.Encoded)
 		}
+		// observation_version is the concurrency token: every successful active
+		// observation increments it. A timestamp cannot serve here because two
+		// writes can land in the same millisecond, leaving updated_at_ms
+		// numerically unchanged and letting this update slip past. updated_at_ms
+		// stays in the predicate to also catch the metadata-only writes from the
+		// active failure and reset paths, which do not move the version.
 		result := manager.db.WithContext(ctx).Model(&models.CredentialObservation{}).
-			Where("credential_id = ? AND updated_at_ms = ?", observation.CredentialID, row.UpdatedAtMS).
+			Where(
+				"credential_id = ? AND observation_version = ? AND updated_at_ms = ?",
+				observation.CredentialID, row.ObservationVersion, row.UpdatedAtMS,
+			).
 			Updates(updates)
 		if result.Error != nil {
 			return fmt.Errorf("update credential observation %d: %w", observation.CredentialID, result.Error)

--- a/internal/subscription/passive_quota_flush.go
+++ b/internal/subscription/passive_quota_flush.go
@@ -63,6 +63,15 @@ func (manager *CredentialManager) flushOnePassiveQuotaObservation(
 			}
 			return fmt.Errorf("read credential observation %d: %w", observation.CredentialID, err)
 		}
+		if row.ObservedAtMS != nil && observation.ObservedAtMS < *row.ObservedAtMS {
+			// A newer observation -- typically a manual refresh -- was persisted
+			// while this sample sat in the pending map. Writing it now would both
+			// rewind observed_at_ms and overwrite newer quota values with older
+			// ones, so the sample is dropped instead. The updated_at_ms guard
+			// below only catches writes that land after this read.
+			manager.passiveQuota.ack(observation.CredentialID, observation.Version)
+			return nil
+		}
 		encoded, merged, changed, mergeErr := mergePassiveQuotaSnapshot(row.SnapshotJSON, observation.Windows)
 		if mergeErr != nil {
 			// A snapshot this malformed cannot be repaired by retrying the
@@ -98,9 +107,11 @@ func (manager *CredentialManager) flushOnePassiveQuotaObservation(
 }
 
 // mergePassiveQuotaSnapshot overlays patches onto the quota_windows array
-// inside a stored snapshot, leaving every other field byte-identical. Only
-// window IDs the snapshot already tracks are updated; an unmatched patch ID
-// is silently ignored so a passive signal never creates a window.
+// inside a stored snapshot, carrying every other field through unchanged by
+// value. The snapshot is decoded and re-encoded, so key order and formatting
+// are not preserved byte-for-byte. Only window IDs the snapshot already
+// tracks are updated; an unmatched patch ID is silently ignored so a passive
+// signal never creates a window.
 func mergePassiveQuotaSnapshot(
 	raw []byte,
 	patches []providerobservation.QuotaWindow,

--- a/internal/subscription/passive_quota_flush.go
+++ b/internal/subscription/passive_quota_flush.go
@@ -1,0 +1,150 @@
+package subscription
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"gorm.io/gorm"
+
+	"gpt-load/internal/storage/models"
+	providerobservation "gpt-load/internal/subscription/providers/observation"
+)
+
+// passiveQuotaFlushBatchSize bounds how many credentials one
+// FlushPassiveQuotaObservations call processes, matching the "one bounded
+// batch per worker cycle" contract shared with RequestLog's own checkpoints.
+const passiveQuotaFlushBatchSize = 20
+
+// FlushPassiveQuotaObservations persists up to one bounded batch of pending
+// passive quota observations into credential_observations and reports
+// whether pending observations still remain for another wake-up. Each
+// credential is its own independent transaction-free conditional update: it
+// only ever touches snapshot_json, observed_at_ms, and updated_at_ms. State,
+// plan/account summaries, reset credits, and the most recent active
+// attempt/error metadata are always left untouched. A credential with no
+// existing observation row, a stale identity generation, or no window ID
+// the row already tracks is discarded without writing anything, since manual
+// or automatic active observation remains the sole owner of window creation.
+func (manager *CredentialManager) FlushPassiveQuotaObservations(ctx context.Context) (bool, error) {
+	if manager == nil || manager.passiveQuota == nil || manager.db == nil {
+		return false, nil
+	}
+	batch := manager.passiveQuota.dirtyObservations(passiveQuotaFlushBatchSize)
+	for _, observation := range batch {
+		if err := manager.flushOnePassiveQuotaObservation(ctx, observation); err != nil {
+			return true, err
+		}
+	}
+	return len(manager.passiveQuota.dirtyObservations(1)) > 0, nil
+}
+
+func (manager *CredentialManager) flushOnePassiveQuotaObservation(
+	ctx context.Context,
+	observation PassiveQuotaObservation,
+) error {
+	if manager.registry == nil {
+		return nil
+	}
+	ref, ok := manager.registry.CredentialRef(observation.CredentialID)
+	if !ok || ref.IdentityGeneration != observation.IdentityGeneration {
+		manager.passiveQuota.ack(observation.CredentialID, observation.Version)
+		return nil
+	}
+	for attempt := 0; attempt < 2; attempt++ {
+		var row models.CredentialObservation
+		err := manager.db.WithContext(ctx).Take(&row, "credential_id = ?", observation.CredentialID).Error
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				manager.passiveQuota.ack(observation.CredentialID, observation.Version)
+				return nil
+			}
+			return fmt.Errorf("read credential observation %d: %w", observation.CredentialID, err)
+		}
+		encoded, merged, changed, mergeErr := mergePassiveQuotaSnapshot(row.SnapshotJSON, observation.Windows)
+		if mergeErr != nil {
+			// A snapshot this malformed cannot be repaired by retrying the
+			// same merge; drop the observation instead of retrying forever.
+			manager.passiveQuota.ack(observation.CredentialID, observation.Version)
+			return nil
+		}
+		if !changed {
+			manager.passiveQuota.ack(observation.CredentialID, observation.Version)
+			return nil
+		}
+		result := manager.db.WithContext(ctx).Model(&models.CredentialObservation{}).
+			Where("credential_id = ? AND updated_at_ms = ?", observation.CredentialID, row.UpdatedAtMS).
+			Updates(map[string]any{
+				"snapshot_json":  models.JSON(encoded),
+				"observed_at_ms": observation.ObservedAtMS,
+				"updated_at_ms":  manager.now().UnixMilli(),
+			})
+		if result.Error != nil {
+			return fmt.Errorf("update credential observation %d: %w", observation.CredentialID, result.Error)
+		}
+		if result.RowsAffected == 1 {
+			manager.passiveQuota.ack(observation.CredentialID, observation.Version)
+			if row.State == models.CredentialObservationFresh {
+				manager.registry.ApplyQuotaWindows(observation.CredentialID, merged)
+			}
+			return nil
+		}
+		// An active refresh or a reset committed between our read and our
+		// write. Retry once against the row it left behind.
+	}
+	return fmt.Errorf("passive quota observation for credential %d conflicted with a concurrent write", observation.CredentialID)
+}
+
+// mergePassiveQuotaSnapshot overlays patches onto the quota_windows array
+// inside a stored snapshot, leaving every other field byte-identical. Only
+// window IDs the snapshot already tracks are updated; an unmatched patch ID
+// is silently ignored so a passive signal never creates a window.
+func mergePassiveQuotaSnapshot(
+	raw []byte,
+	patches []providerobservation.QuotaWindow,
+) (encoded []byte, windows []providerobservation.QuotaWindow, changed bool, err error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return nil, nil, false, fmt.Errorf("decode credential observation snapshot: %w", err)
+	}
+	windowsRaw, ok := fields["quota_windows"]
+	if !ok {
+		return nil, nil, false, errors.New("credential observation snapshot has no quota_windows field")
+	}
+	var existing []providerobservation.QuotaWindow
+	if err := json.Unmarshal(windowsRaw, &existing); err != nil {
+		return nil, nil, false, fmt.Errorf("decode credential observation quota windows: %w", err)
+	}
+	merged := append([]providerobservation.QuotaWindow(nil), existing...)
+	index := make(map[string]int, len(merged))
+	for position, window := range merged {
+		index[window.ID] = position
+	}
+	changedAny := false
+	for _, patch := range patches {
+		position, exists := index[patch.ID]
+		if !exists {
+			continue
+		}
+		next := providerobservation.MergeQuotaWindow(merged[position], patch)
+		if !reflect.DeepEqual(next, merged[position]) {
+			changedAny = true
+		}
+		merged[position] = next
+	}
+	if !changedAny {
+		return raw, existing, false, nil
+	}
+	encodedWindows, err := json.Marshal(merged)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("encode credential observation quota windows: %w", err)
+	}
+	fields["quota_windows"] = encodedWindows
+	result, err := json.Marshal(fields)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("encode credential observation snapshot: %w", err)
+	}
+	return result, merged, true, nil
+}

--- a/internal/subscription/passive_quota_flush.go
+++ b/internal/subscription/passive_quota_flush.go
@@ -72,31 +72,41 @@ func (manager *CredentialManager) flushOnePassiveQuotaObservation(
 			manager.passiveQuota.ack(observation.CredentialID, observation.Version)
 			return nil
 		}
-		encoded, merged, changed, mergeErr := mergePassiveQuotaSnapshot(row.SnapshotJSON, observation.Windows)
+		merge, mergeErr := mergePassiveQuotaSnapshot(row.SnapshotJSON, observation.Windows)
 		if mergeErr != nil {
 			// A snapshot this malformed cannot be repaired by retrying the
 			// same merge; drop the observation instead of retrying forever.
 			manager.passiveQuota.ack(observation.CredentialID, observation.Version)
 			return nil
 		}
-		if !changed {
+		alreadyObservedAt := row.ObservedAtMS != nil && *row.ObservedAtMS == observation.ObservedAtMS
+		if !merge.Matched || (!merge.Changed && alreadyObservedAt) {
+			// Nothing this response says is new: either it named no window the
+			// snapshot tracks, or it repeated values already stored at this
+			// very instant.
 			manager.passiveQuota.ack(observation.CredentialID, observation.Version)
 			return nil
 		}
+		// A matched window whose values did not move is still evidence the
+		// credential was observed just now, so the sync time advances even
+		// when the snapshot itself stays byte-identical.
+		updates := map[string]any{
+			"observed_at_ms": observation.ObservedAtMS,
+			"updated_at_ms":  manager.now().UnixMilli(),
+		}
+		if merge.Changed {
+			updates["snapshot_json"] = models.JSON(merge.Encoded)
+		}
 		result := manager.db.WithContext(ctx).Model(&models.CredentialObservation{}).
 			Where("credential_id = ? AND updated_at_ms = ?", observation.CredentialID, row.UpdatedAtMS).
-			Updates(map[string]any{
-				"snapshot_json":  models.JSON(encoded),
-				"observed_at_ms": observation.ObservedAtMS,
-				"updated_at_ms":  manager.now().UnixMilli(),
-			})
+			Updates(updates)
 		if result.Error != nil {
 			return fmt.Errorf("update credential observation %d: %w", observation.CredentialID, result.Error)
 		}
 		if result.RowsAffected == 1 {
 			manager.passiveQuota.ack(observation.CredentialID, observation.Version)
 			if row.State == models.CredentialObservationFresh {
-				manager.registry.ApplyQuotaWindows(observation.CredentialID, merged)
+				manager.registry.ApplyQuotaWindows(observation.CredentialID, merge.Windows)
 			}
 			return nil
 		}
@@ -104,6 +114,18 @@ func (manager *CredentialManager) flushOnePassiveQuotaObservation(
 		// write. Retry once against the row it left behind.
 	}
 	return fmt.Errorf("passive quota observation for credential %d conflicted with a concurrent write", observation.CredentialID)
+}
+
+// passiveQuotaMerge is the outcome of overlaying one response's windows onto
+// a stored snapshot. Matched and Changed are distinct on purpose: a response
+// that names a tracked window but repeats its values is still a fresh
+// observation of that credential, while a response naming no tracked window
+// is no observation of this snapshot at all.
+type passiveQuotaMerge struct {
+	Encoded []byte
+	Windows []providerobservation.QuotaWindow
+	Matched bool
+	Changed bool
 }
 
 // mergePassiveQuotaSnapshot overlays patches onto the quota_windows array
@@ -115,47 +137,49 @@ func (manager *CredentialManager) flushOnePassiveQuotaObservation(
 func mergePassiveQuotaSnapshot(
 	raw []byte,
 	patches []providerobservation.QuotaWindow,
-) (encoded []byte, windows []providerobservation.QuotaWindow, changed bool, err error) {
+) (result passiveQuotaMerge, err error) {
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &fields); err != nil {
-		return nil, nil, false, fmt.Errorf("decode credential observation snapshot: %w", err)
+		return passiveQuotaMerge{}, fmt.Errorf("decode credential observation snapshot: %w", err)
 	}
 	windowsRaw, ok := fields["quota_windows"]
 	if !ok {
-		return nil, nil, false, errors.New("credential observation snapshot has no quota_windows field")
+		return passiveQuotaMerge{}, errors.New("credential observation snapshot has no quota_windows field")
 	}
 	var existing []providerobservation.QuotaWindow
 	if err := json.Unmarshal(windowsRaw, &existing); err != nil {
-		return nil, nil, false, fmt.Errorf("decode credential observation quota windows: %w", err)
+		return passiveQuotaMerge{}, fmt.Errorf("decode credential observation quota windows: %w", err)
 	}
 	merged := append([]providerobservation.QuotaWindow(nil), existing...)
 	index := make(map[string]int, len(merged))
 	for position, window := range merged {
 		index[window.ID] = position
 	}
-	changedAny := false
+	outcome := passiveQuotaMerge{Encoded: raw, Windows: existing}
 	for _, patch := range patches {
 		position, exists := index[patch.ID]
 		if !exists {
 			continue
 		}
+		outcome.Matched = true
 		next := providerobservation.MergeQuotaWindow(merged[position], patch)
 		if !reflect.DeepEqual(next, merged[position]) {
-			changedAny = true
+			outcome.Changed = true
 		}
 		merged[position] = next
 	}
-	if !changedAny {
-		return raw, existing, false, nil
+	if !outcome.Changed {
+		return outcome, nil
 	}
 	encodedWindows, err := json.Marshal(merged)
 	if err != nil {
-		return nil, nil, false, fmt.Errorf("encode credential observation quota windows: %w", err)
+		return passiveQuotaMerge{}, fmt.Errorf("encode credential observation quota windows: %w", err)
 	}
 	fields["quota_windows"] = encodedWindows
-	result, err := json.Marshal(fields)
+	encoded, err := json.Marshal(fields)
 	if err != nil {
-		return nil, nil, false, fmt.Errorf("encode credential observation snapshot: %w", err)
+		return passiveQuotaMerge{}, fmt.Errorf("encode credential observation snapshot: %w", err)
 	}
-	return result, merged, true, nil
+	outcome.Encoded, outcome.Windows = encoded, merged
+	return outcome, nil
 }

--- a/internal/subscription/passive_quota_flush_test.go
+++ b/internal/subscription/passive_quota_flush_test.go
@@ -198,6 +198,35 @@ func TestFlushPassiveQuotaObservationsAppliesSampleAtSameObservationTime(t *test
 	}
 }
 
+func TestFlushPassiveQuotaObservationsAdvancesObservedAtWhenValuesAreUnchanged(t *testing.T) {
+	manager, db, registry, _, row := newCredentialManagerFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
+	newFlushableCredentialObservation(t, manager, row.ID, models.CredentialObservationFresh,
+		`{"plan_summary":{},"quota_windows":[{"id":"primary","label":"5h","scope":"account","unit":"percent","state":"available","used":50,"limit":100,"remaining":50,"utilization":0.5,"reset_at_ms":1800000000000}]}`,
+	)
+	ref, _ := registry.CredentialRef(row.ID)
+	// A quota percentage that has not moved is still proof the credential was
+	// observed just now, which is what the account card's sync time shows.
+	used, limit, remaining, utilization := 50.0, 100.0, 50.0, 0.5
+	manager.RecordPassiveQuotaObservation(row.ID, ref.IdentityGeneration, 99999, []providerobservation.QuotaWindow{
+		{ID: "primary", Scope: "account", Unit: "percent", State: "available",
+			Used: &used, Limit: &limit, Remaining: &remaining, Utilization: &utilization},
+	})
+
+	if _, err := manager.FlushPassiveQuotaObservations(t.Context()); err != nil {
+		t.Fatalf("FlushPassiveQuotaObservations() error = %v", err)
+	}
+	if dirty := manager.DirtyPassiveQuotaObservations(1); len(dirty) != 0 {
+		t.Fatalf("unchanged sample was not acknowledged: %#v", dirty)
+	}
+	var persisted models.CredentialObservation
+	if err := db.Take(&persisted, "credential_id = ?", row.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if persisted.ObservedAtMS == nil || *persisted.ObservedAtMS != 99999 {
+		t.Fatalf("observed_at_ms = %#v, want it advanced to 99999 even though the values did not change", persisted.ObservedAtMS)
+	}
+}
+
 func TestFlushPassiveQuotaObservationsSkipsUnknownWindowID(t *testing.T) {
 	manager, db, registry, _, row := newCredentialManagerFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
 	newFlushableCredentialObservation(t, manager, row.ID, models.CredentialObservationFresh,

--- a/internal/subscription/passive_quota_flush_test.go
+++ b/internal/subscription/passive_quota_flush_test.go
@@ -77,6 +77,75 @@ func TestFlushPassiveQuotaObservationsUpdatesExistingWindowAndProjectsFreshToReg
 	}
 }
 
+func TestFlushPassiveQuotaObservationsDiscardsSampleOlderThanStoredObservation(t *testing.T) {
+	manager, db, registry, _, row := newCredentialManagerFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
+	// A newer active observation is already stored: observed at 5000, used 90.
+	if err := manager.db.AutoMigrate(&models.CredentialObservation{}); err != nil {
+		t.Fatal(err)
+	}
+	newer := int64(5000)
+	stored := models.CredentialObservation{
+		CredentialID: row.ID, IdentityFingerprint: "identity", SchemaVersion: 1, ObservationVersion: 2,
+		SnapshotJSON: models.JSON(
+			`{"plan_summary":{},"quota_windows":[{"id":"primary","label":"5h","scope":"account","unit":"percent","state":"available","used":90,"utilization":0.9,"reset_at_ms":1800000000000}]}`,
+		),
+		State: models.CredentialObservationFresh, ObservedAtMS: &newer, UpdatedAtMS: 5000,
+	}
+	if err := manager.db.Create(&stored).Error; err != nil {
+		t.Fatal(err)
+	}
+	ref, _ := registry.CredentialRef(row.ID)
+	// A passive sample captured before that active refresh completed.
+	oldUsed, oldUtilization := 10.0, 0.1
+	manager.RecordPassiveQuotaObservation(row.ID, ref.IdentityGeneration, 2000, []providerobservation.QuotaWindow{
+		{ID: "primary", Label: "5h", Scope: "account", Unit: "percent", State: "available",
+			Used: &oldUsed, Utilization: &oldUtilization},
+	})
+
+	if _, err := manager.FlushPassiveQuotaObservations(t.Context()); err != nil {
+		t.Fatalf("FlushPassiveQuotaObservations() error = %v", err)
+	}
+	if dirty := manager.DirtyPassiveQuotaObservations(1); len(dirty) != 0 {
+		t.Fatalf("stale sample was not acknowledged and will retry forever: %#v", dirty)
+	}
+
+	var persisted models.CredentialObservation
+	if err := db.Take(&persisted, "credential_id = ?", row.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if persisted.ObservedAtMS == nil || *persisted.ObservedAtMS != 5000 {
+		t.Fatalf("observed_at_ms = %#v, want the newer 5000 preserved", persisted.ObservedAtMS)
+	}
+	if !strings.Contains(string(persisted.SnapshotJSON), `"used":90`) {
+		t.Fatalf("snapshot_json = %s, want the newer used:90 preserved", persisted.SnapshotJSON)
+	}
+}
+
+func TestFlushPassiveQuotaObservationsAppliesSampleAtSameObservationTime(t *testing.T) {
+	manager, db, registry, _, row := newCredentialManagerFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
+	newFlushableCredentialObservation(t, manager, row.ID, models.CredentialObservationFresh,
+		`{"plan_summary":{},"quota_windows":[{"id":"primary","label":"5h","scope":"account","unit":"percent","state":"available","reset_at_ms":1800000000000}]}`,
+	)
+	ref, _ := registry.CredentialRef(row.ID)
+	used, utilization := 42.0, 0.42
+	// newFlushableCredentialObservation stores observed_at_ms = 1000.
+	manager.RecordPassiveQuotaObservation(row.ID, ref.IdentityGeneration, 1000, []providerobservation.QuotaWindow{
+		{ID: "primary", Label: "5h", Scope: "account", Unit: "percent", State: "available",
+			Used: &used, Utilization: &utilization},
+	})
+
+	if _, err := manager.FlushPassiveQuotaObservations(t.Context()); err != nil {
+		t.Fatalf("FlushPassiveQuotaObservations() error = %v", err)
+	}
+	var persisted models.CredentialObservation
+	if err := db.Take(&persisted, "credential_id = ?", row.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(persisted.SnapshotJSON), `"used":42`) {
+		t.Fatalf("snapshot_json = %s, want an equally-timed sample to still merge", persisted.SnapshotJSON)
+	}
+}
+
 func TestFlushPassiveQuotaObservationsSkipsUnknownWindowID(t *testing.T) {
 	manager, db, registry, _, row := newCredentialManagerFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
 	newFlushableCredentialObservation(t, manager, row.ID, models.CredentialObservationFresh,

--- a/internal/subscription/passive_quota_flush_test.go
+++ b/internal/subscription/passive_quota_flush_test.go
@@ -176,17 +176,19 @@ func TestFlushPassiveQuotaObservationsDoesNotResurrectStaleCachedFieldsAfterAck(
 	}
 }
 
-func TestFlushPassiveQuotaObservationsAppliesSampleAtSameObservationTime(t *testing.T) {
+func TestFlushPassiveQuotaObservationsYieldsToStoredObservationAtTheSameMillisecond(t *testing.T) {
 	manager, db, registry, _, row := newCredentialManagerFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
 	newFlushableCredentialObservation(t, manager, row.ID, models.CredentialObservationFresh,
-		`{"plan_summary":{},"quota_windows":[{"id":"primary","label":"5h","scope":"account","unit":"percent","state":"available","reset_at_ms":1800000000000}]}`,
+		`{"plan_summary":{},"quota_windows":[{"id":"primary","label":"5h","scope":"account","unit":"percent","state":"available","used":90,"utilization":0.9,"reset_at_ms":1800000000000}]}`,
 	)
 	ref, _ := registry.CredentialRef(row.ID)
 	used, utilization := 42.0, 0.42
-	// newFlushableCredentialObservation stores observed_at_ms = 1000.
+	// newFlushableCredentialObservation stores observed_at_ms = 1000. A passive
+	// header captured just before an active refresh that completed within the
+	// same millisecond truncates to the same value; the active result is the
+	// authoritative one, so the tie goes to what is already stored.
 	manager.RecordPassiveQuotaObservation(row.ID, ref.IdentityGeneration, 1000, []providerobservation.QuotaWindow{
-		{ID: "primary", Label: "5h", Scope: "account", Unit: "percent", State: "available",
-			Used: &used, Utilization: &utilization},
+		{ID: "primary", Used: &used, Utilization: &utilization},
 	})
 
 	if _, err := manager.FlushPassiveQuotaObservations(t.Context()); err != nil {
@@ -196,8 +198,8 @@ func TestFlushPassiveQuotaObservationsAppliesSampleAtSameObservationTime(t *test
 	if err := db.Take(&persisted, "credential_id = ?", row.ID).Error; err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(persisted.SnapshotJSON), `"used":42`) {
-		t.Fatalf("snapshot_json = %s, want an equally-timed sample to still merge", persisted.SnapshotJSON)
+	if !strings.Contains(string(persisted.SnapshotJSON), `"used":90`) {
+		t.Fatalf("snapshot_json = %s, want the stored observation to win the tie", persisted.SnapshotJSON)
 	}
 }
 

--- a/internal/subscription/passive_quota_flush_test.go
+++ b/internal/subscription/passive_quota_flush_test.go
@@ -121,6 +121,58 @@ func TestFlushPassiveQuotaObservationsDiscardsSampleOlderThanStoredObservation(t
 	}
 }
 
+func TestFlushPassiveQuotaObservationsDoesNotResurrectStaleCachedFieldsAfterAck(t *testing.T) {
+	manager, db, registry, _, row := newCredentialManagerFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
+	newFlushableCredentialObservation(t, manager, row.ID, models.CredentialObservationFresh,
+		`{"plan_summary":{},"quota_windows":[{"id":"primary","label":"5h","scope":"account","unit":"percent","state":"available","used":5,"utilization":0.05,"reset_at_ms":1000}]}`,
+	)
+	ref, _ := registry.CredentialRef(row.ID)
+
+	// A first passive response carries a usage percentage and is flushed.
+	firstUsed, firstUtilization := 10.0, 0.10
+	manager.RecordPassiveQuotaObservation(row.ID, ref.IdentityGeneration, 2000, []providerobservation.QuotaWindow{
+		{ID: "primary", Label: "5h", Scope: "account", Unit: "percent", State: "available",
+			Used: &firstUsed, Utilization: &firstUtilization},
+	})
+	if _, err := manager.FlushPassiveQuotaObservations(t.Context()); err != nil {
+		t.Fatalf("first FlushPassiveQuotaObservations() error = %v", err)
+	}
+
+	// An active refresh independently overwrites the same window with a newer value.
+	if err := manager.db.Model(&models.CredentialObservation{}).Where("credential_id = ?", row.ID).
+		Updates(map[string]any{
+			"snapshot_json": models.JSON(
+				`{"plan_summary":{},"quota_windows":[{"id":"primary","label":"5h","scope":"account","unit":"percent","state":"available","used":90,"utilization":0.9,"reset_at_ms":1000}]}`,
+			),
+			"observed_at_ms": int64(3000), "updated_at_ms": int64(3000),
+		}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	// A second passive response carries only a reset time -- no usage percentage.
+	resetAt := int64(9999)
+	manager.RecordPassiveQuotaObservation(row.ID, ref.IdentityGeneration, 4000, []providerobservation.QuotaWindow{
+		{ID: "primary", ResetAtMS: &resetAt},
+	})
+	if _, err := manager.FlushPassiveQuotaObservations(t.Context()); err != nil {
+		t.Fatalf("second FlushPassiveQuotaObservations() error = %v", err)
+	}
+
+	var persisted models.CredentialObservation
+	if err := db.Take(&persisted, "credential_id = ?", row.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(persisted.SnapshotJSON), `"used":10`) {
+		t.Fatalf("snapshot_json = %s, stale acknowledged usage (10) resurrected over the active refresh's 90", persisted.SnapshotJSON)
+	}
+	if !strings.Contains(string(persisted.SnapshotJSON), `"used":90`) {
+		t.Fatalf("snapshot_json = %s, want the active refresh's used:90 preserved", persisted.SnapshotJSON)
+	}
+	if !strings.Contains(string(persisted.SnapshotJSON), `"reset_at_ms":9999`) {
+		t.Fatalf("snapshot_json = %s, want the new reset_at_ms applied", persisted.SnapshotJSON)
+	}
+}
+
 func TestFlushPassiveQuotaObservationsAppliesSampleAtSameObservationTime(t *testing.T) {
 	manager, db, registry, _, row := newCredentialManagerFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
 	newFlushableCredentialObservation(t, manager, row.ID, models.CredentialObservationFresh,

--- a/internal/subscription/passive_quota_flush_test.go
+++ b/internal/subscription/passive_quota_flush_test.go
@@ -198,6 +198,56 @@ func TestFlushPassiveQuotaObservationsAppliesSampleAtSameObservationTime(t *test
 	}
 }
 
+func TestFlushPassiveQuotaObservationsDoesNotCarryFieldsAcrossCoalescedResponses(t *testing.T) {
+	manager, db, registry, _, row := newCredentialManagerFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
+	newFlushableCredentialObservation(t, manager, row.ID, models.CredentialObservationFresh,
+		`{"plan_summary":{},"quota_windows":[{"id":"primary","label":"5h","scope":"account","unit":"percent","state":"available","used":5,"utilization":0.05,"reset_at_ms":1000}]}`,
+	)
+	ref, _ := registry.CredentialRef(row.ID)
+
+	// t1: a utilization-only response is recorded but not yet flushed.
+	staleUsed, staleUtilization := 10.0, 0.10
+	manager.RecordPassiveQuotaObservation(row.ID, ref.IdentityGeneration, 1000, []providerobservation.QuotaWindow{
+		{ID: "primary", Scope: "account", Unit: "percent", State: "available",
+			Used: &staleUsed, Utilization: &staleUtilization},
+	})
+
+	// t2: an active refresh commits a newer utilization.
+	if err := manager.db.Model(&models.CredentialObservation{}).Where("credential_id = ?", row.ID).
+		Updates(map[string]any{
+			"snapshot_json": models.JSON(
+				`{"plan_summary":{},"quota_windows":[{"id":"primary","label":"5h","scope":"account","unit":"percent","state":"available","used":90,"utilization":0.9,"reset_at_ms":1000}]}`,
+			),
+			"observed_at_ms": int64(2000), "updated_at_ms": int64(2000),
+		}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	// t3: a reset-only response arrives before the t1 entry was ever flushed.
+	resetAt := int64(9999)
+	manager.RecordPassiveQuotaObservation(row.ID, ref.IdentityGeneration, 3000, []providerobservation.QuotaWindow{
+		{ID: "primary", ResetAtMS: &resetAt},
+	})
+
+	if _, err := manager.FlushPassiveQuotaObservations(t.Context()); err != nil {
+		t.Fatalf("FlushPassiveQuotaObservations() error = %v", err)
+	}
+	var persisted models.CredentialObservation
+	if err := db.Take(&persisted, "credential_id = ?", row.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(persisted.SnapshotJSON), `"used":10`) {
+		t.Fatalf("snapshot_json = %s, the t1 utilization was carried into the t3 entry and overwrote the active refresh",
+			persisted.SnapshotJSON)
+	}
+	if !strings.Contains(string(persisted.SnapshotJSON), `"used":90`) {
+		t.Fatalf("snapshot_json = %s, want the active refresh's used:90 preserved", persisted.SnapshotJSON)
+	}
+	if !strings.Contains(string(persisted.SnapshotJSON), `"reset_at_ms":9999`) {
+		t.Fatalf("snapshot_json = %s, want the t3 reset applied", persisted.SnapshotJSON)
+	}
+}
+
 func TestFlushPassiveQuotaObservationsAdvancesObservedAtWhenValuesAreUnchanged(t *testing.T) {
 	manager, db, registry, _, row := newCredentialManagerFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
 	newFlushableCredentialObservation(t, manager, row.ID, models.CredentialObservationFresh,

--- a/internal/subscription/passive_quota_flush_test.go
+++ b/internal/subscription/passive_quota_flush_test.go
@@ -2,8 +2,11 @@ package subscription
 
 import (
 	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	"gorm.io/gorm"
 
 	"gpt-load/internal/storage/models"
 	providerobservation "gpt-load/internal/subscription/providers/observation"
@@ -195,6 +198,76 @@ func TestFlushPassiveQuotaObservationsAppliesSampleAtSameObservationTime(t *test
 	}
 	if !strings.Contains(string(persisted.SnapshotJSON), `"used":42`) {
 		t.Fatalf("snapshot_json = %s, want an equally-timed sample to still merge", persisted.SnapshotJSON)
+	}
+}
+
+func TestFlushPassiveQuotaObservationsDetectsActiveWriteSharingTheSameMillisecond(t *testing.T) {
+	manager, db, registry, _, row := newCredentialManagerFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
+	if err := manager.db.AutoMigrate(&models.CredentialObservation{}); err != nil {
+		t.Fatal(err)
+	}
+	observedAt := int64(5000)
+	if err := manager.db.Create(&models.CredentialObservation{
+		CredentialID: row.ID, IdentityFingerprint: "identity", SchemaVersion: 1, ObservationVersion: 1,
+		SnapshotJSON: models.JSON(
+			`{"plan_summary":{},"quota_windows":[{"id":"primary","label":"5h","scope":"account","unit":"percent","state":"available","used":5,"utilization":0.05,"reset_at_ms":1000}]}`,
+		),
+		State: models.CredentialObservationFresh, ObservedAtMS: &observedAt, UpdatedAtMS: 5000,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	ref, _ := registry.CredentialRef(row.ID)
+	staleUsed, staleUtilization := 10.0, 0.10
+	manager.RecordPassiveQuotaObservation(row.ID, ref.IdentityGeneration, 6000, []providerobservation.QuotaWindow{
+		{ID: "primary", Scope: "account", Unit: "percent", State: "available",
+			Used: &staleUsed, Utilization: &staleUtilization},
+	})
+	// Pin the passive writer's clock to the row's existing updated_at_ms so a
+	// timestamp cannot serve as the concurrency token.
+	manager.now = func() time.Time { return time.UnixMilli(5000) }
+
+	// An active refresh commits after the flusher has read the row but before
+	// it writes: it observes at 7000, bumps observation_version, and lands in
+	// the same millisecond so updated_at_ms stays numerically unchanged.
+	var injectActiveRefresh sync.Once
+	if err := manager.db.Callback().Query().After("gorm:query").
+		Register("test:inject_active_refresh", func(tx *gorm.DB) {
+			if tx.Statement == nil || tx.Statement.Table != "credential_observations" {
+				return
+			}
+			injectActiveRefresh.Do(func() {
+				if err := db.Model(&models.CredentialObservation{}).Where("credential_id = ?", row.ID).
+					Updates(map[string]any{
+						"snapshot_json": models.JSON(
+							`{"plan_summary":{},"quota_windows":[{"id":"primary","label":"5h","scope":"account","unit":"percent","state":"available","used":90,"utilization":0.9,"reset_at_ms":1000}]}`,
+						),
+						"observation_version": 2,
+						"observed_at_ms":      int64(7000),
+						"updated_at_ms":       int64(5000),
+					}).Error; err != nil {
+					t.Error(err)
+				}
+			})
+		}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = manager.db.Callback().Query().Remove("test:inject_active_refresh")
+	})
+
+	if _, err := manager.FlushPassiveQuotaObservations(t.Context()); err != nil {
+		t.Fatalf("FlushPassiveQuotaObservations() error = %v", err)
+	}
+	var persisted models.CredentialObservation
+	if err := db.Take(&persisted, "credential_id = ?", row.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(persisted.SnapshotJSON), `"used":10`) {
+		t.Fatalf("snapshot_json = %s, the passive write slipped past the CAS and overwrote the active refresh",
+			persisted.SnapshotJSON)
+	}
+	if !strings.Contains(string(persisted.SnapshotJSON), `"used":90`) {
+		t.Fatalf("snapshot_json = %s, want the active refresh's used:90 preserved", persisted.SnapshotJSON)
 	}
 }
 

--- a/internal/subscription/passive_quota_flush_test.go
+++ b/internal/subscription/passive_quota_flush_test.go
@@ -1,0 +1,206 @@
+package subscription
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"gpt-load/internal/storage/models"
+	providerobservation "gpt-load/internal/subscription/providers/observation"
+)
+
+func newFlushableCredentialObservation(
+	t *testing.T,
+	manager *CredentialManager,
+	credentialID uint,
+	state models.CredentialObservationState,
+	snapshotJSON string,
+) models.CredentialObservation {
+	t.Helper()
+	if err := manager.db.AutoMigrate(&models.CredentialObservation{}); err != nil {
+		t.Fatal(err)
+	}
+	observedAt := int64(1000)
+	row := models.CredentialObservation{
+		CredentialID: credentialID, IdentityFingerprint: "identity", SchemaVersion: 1,
+		ObservationVersion: 1, SnapshotJSON: models.JSON(snapshotJSON), State: state,
+		ObservedAtMS: &observedAt, UpdatedAtMS: 1000,
+	}
+	if err := manager.db.Create(&row).Error; err != nil {
+		t.Fatal(err)
+	}
+	return row
+}
+
+func TestFlushPassiveQuotaObservationsUpdatesExistingWindowAndProjectsFreshToRegistry(t *testing.T) {
+	manager, db, registry, _, row := newCredentialManagerFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
+	newFlushableCredentialObservation(t, manager, row.ID, models.CredentialObservationFresh,
+		`{"plan_summary":{"name":"Pro 20x"},"quota_windows":[{"id":"primary","label":"Session","scope":"account","unit":"percent","state":"available","window_seconds":300,"reset_at_ms":1800000000000}],"reset_credits_available":3}`,
+	)
+	ref, ok := registry.CredentialRef(row.ID)
+	if !ok {
+		t.Fatal("credential ref is unavailable")
+	}
+	used := 55.0
+	utilization := 0.55
+	manager.RecordPassiveQuotaObservation(row.ID, ref.IdentityGeneration, 2000, []providerobservation.QuotaWindow{
+		{ID: "primary", Label: "Session", Scope: "account", Unit: "percent", State: "available", Used: &used, Utilization: &utilization},
+	})
+
+	remaining, err := manager.FlushPassiveQuotaObservations(t.Context())
+	if err != nil {
+		t.Fatalf("FlushPassiveQuotaObservations() error = %v", err)
+	}
+	if remaining {
+		t.Fatal("FlushPassiveQuotaObservations() reported remaining pending after flushing everything")
+	}
+	if dirty := manager.DirtyPassiveQuotaObservations(1); len(dirty) != 0 {
+		t.Fatalf("pending observation was not acknowledged: %#v", dirty)
+	}
+
+	var stored models.CredentialObservation
+	if err := db.Take(&stored, "credential_id = ?", row.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if stored.ObservedAtMS == nil || *stored.ObservedAtMS != 2000 {
+		t.Fatalf("stored observed_at_ms = %#v, want 2000", stored.ObservedAtMS)
+	}
+	snapshot := string(stored.SnapshotJSON)
+	if !strings.Contains(snapshot, `"used":55`) || !strings.Contains(snapshot, `"window_seconds":300`) ||
+		!strings.Contains(snapshot, `"Pro 20x"`) || !strings.Contains(snapshot, `"reset_credits_available":3`) {
+		t.Fatalf("stored snapshot_json = %s", snapshot)
+	}
+
+	views := registry.Snapshot()
+	if len(views) != 1 || views[0].ObservedQuotaRemaining() == nil {
+		t.Fatalf("registry was not projected from the fresh flush: %#v", views)
+	}
+}
+
+func TestFlushPassiveQuotaObservationsSkipsUnknownWindowID(t *testing.T) {
+	manager, db, registry, _, row := newCredentialManagerFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
+	newFlushableCredentialObservation(t, manager, row.ID, models.CredentialObservationFresh,
+		`{"plan_summary":{},"quota_windows":[{"id":"primary","scope":"account","unit":"percent","state":"available"}]}`,
+	)
+	ref, _ := registry.CredentialRef(row.ID)
+	used := 10.0
+	manager.RecordPassiveQuotaObservation(row.ID, ref.IdentityGeneration, 2000, []providerobservation.QuotaWindow{
+		{ID: "secondary", Scope: "account", State: "available", Used: &used},
+	})
+
+	if _, err := manager.FlushPassiveQuotaObservations(t.Context()); err != nil {
+		t.Fatalf("FlushPassiveQuotaObservations() error = %v", err)
+	}
+	if dirty := manager.DirtyPassiveQuotaObservations(1); len(dirty) != 0 {
+		t.Fatalf("pending observation with no matching window was not acknowledged: %#v", dirty)
+	}
+
+	var stored models.CredentialObservation
+	if err := db.Take(&stored, "credential_id = ?", row.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if stored.ObservedAtMS == nil || *stored.ObservedAtMS != 1000 {
+		t.Fatalf("stored observed_at_ms = %#v, want unchanged 1000", stored.ObservedAtMS)
+	}
+	if strings.Contains(string(stored.SnapshotJSON), `"secondary"`) {
+		t.Fatalf("an unknown window ID was created: %s", stored.SnapshotJSON)
+	}
+}
+
+func TestFlushPassiveQuotaObservationsDiscardsWithoutExistingRow(t *testing.T) {
+	manager, _, registry, _, row := newCredentialManagerFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
+	if err := manager.db.AutoMigrate(&models.CredentialObservation{}); err != nil {
+		t.Fatal(err)
+	}
+	ref, _ := registry.CredentialRef(row.ID)
+	used := 10.0
+	manager.RecordPassiveQuotaObservation(row.ID, ref.IdentityGeneration, 2000, []providerobservation.QuotaWindow{
+		{ID: "primary", Scope: "account", State: "available", Used: &used},
+	})
+
+	if _, err := manager.FlushPassiveQuotaObservations(t.Context()); err != nil {
+		t.Fatalf("FlushPassiveQuotaObservations() error = %v", err)
+	}
+	if dirty := manager.DirtyPassiveQuotaObservations(1); len(dirty) != 0 {
+		t.Fatalf("pending observation for a credential with no observation row was not acknowledged: %#v", dirty)
+	}
+	var count int64
+	if err := manager.db.Model(&models.CredentialObservation{}).Where("credential_id = ?", row.ID).Count(&count).Error; err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("a new observation row was created, want none: count=%d", count)
+	}
+}
+
+func TestFlushPassiveQuotaObservationsDiscardsOnIdentityGenerationMismatch(t *testing.T) {
+	manager, db, _, _, row := newCredentialManagerFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
+	newFlushableCredentialObservation(t, manager, row.ID, models.CredentialObservationFresh,
+		`{"plan_summary":{},"quota_windows":[{"id":"primary","scope":"account","unit":"percent","state":"available"}]}`,
+	)
+	used := 10.0
+	manager.RecordPassiveQuotaObservation(row.ID, 999999, 2000, []providerobservation.QuotaWindow{
+		{ID: "primary", Scope: "account", State: "available", Used: &used},
+	})
+
+	if _, err := manager.FlushPassiveQuotaObservations(t.Context()); err != nil {
+		t.Fatalf("FlushPassiveQuotaObservations() error = %v", err)
+	}
+	if dirty := manager.DirtyPassiveQuotaObservations(1); len(dirty) != 0 {
+		t.Fatalf("pending observation with a stale identity generation was not acknowledged: %#v", dirty)
+	}
+	var stored models.CredentialObservation
+	if err := db.Take(&stored, "credential_id = ?", row.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if stored.ObservedAtMS == nil || *stored.ObservedAtMS != 1000 {
+		t.Fatalf("stored observed_at_ms = %#v, want unchanged 1000", stored.ObservedAtMS)
+	}
+}
+
+func TestFlushPassiveQuotaObservationsDoesNotProjectStaleStateToRegistry(t *testing.T) {
+	manager, _, registry, _, row := newCredentialManagerFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
+	newFlushableCredentialObservation(t, manager, row.ID, models.CredentialObservationStale,
+		`{"plan_summary":{},"quota_windows":[{"id":"primary","scope":"account","unit":"percent","state":"available"}]}`,
+	)
+	ref, _ := registry.CredentialRef(row.ID)
+	used := 10.0
+	manager.RecordPassiveQuotaObservation(row.ID, ref.IdentityGeneration, 2000, []providerobservation.QuotaWindow{
+		{ID: "primary", Scope: "account", State: "available", Used: &used},
+	})
+
+	if _, err := manager.FlushPassiveQuotaObservations(t.Context()); err != nil {
+		t.Fatalf("FlushPassiveQuotaObservations() error = %v", err)
+	}
+	views := registry.Snapshot()
+	if len(views) != 1 || views[0].ObservedQuotaRemaining() != nil {
+		t.Fatalf("a stale row's passive update was projected to the registry: %#v", views)
+	}
+}
+
+func TestFlushPassiveQuotaObservationsPreservesUntouchedStateAndMetadata(t *testing.T) {
+	manager, db, registry, _, row := newCredentialManagerFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
+	existing := newFlushableCredentialObservation(t, manager, row.ID, models.CredentialObservationError,
+		`{"plan_summary":{},"quota_windows":[{"id":"primary","scope":"account","unit":"percent","state":"available"}]}`,
+	)
+	existing.LastErrorCode = "observation_upstream_failed"
+	if err := db.Save(&existing).Error; err != nil {
+		t.Fatal(err)
+	}
+	ref, _ := registry.CredentialRef(row.ID)
+	used := 10.0
+	manager.RecordPassiveQuotaObservation(row.ID, ref.IdentityGeneration, 2000, []providerobservation.QuotaWindow{
+		{ID: "primary", Scope: "account", State: "available", Used: &used},
+	})
+
+	if _, err := manager.FlushPassiveQuotaObservations(t.Context()); err != nil {
+		t.Fatalf("FlushPassiveQuotaObservations() error = %v", err)
+	}
+	var stored models.CredentialObservation
+	if err := db.Take(&stored, "credential_id = ?", row.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if stored.State != models.CredentialObservationError || stored.LastErrorCode != "observation_upstream_failed" {
+		t.Fatalf("stored observation = %#v, want state/last_error_code preserved", stored)
+	}
+}

--- a/internal/subscription/passive_quota_test.go
+++ b/internal/subscription/passive_quota_test.go
@@ -50,13 +50,29 @@ func TestRecordPassiveQuotaObservationReplacesRatherThanCombiningResponses(t *te
 
 func TestRecordPassiveQuotaObservationCopiesCallerWindows(t *testing.T) {
 	manager := testCredentialManagerForPassiveQuota()
-	windows := []providerobservation.QuotaWindow{{ID: "primary", Used: floatPointer(10)}}
+	resetAt := int64(4242)
+	windows := []providerobservation.QuotaWindow{
+		{ID: "primary", Used: floatPointer(10), Utilization: floatPointer(0.1), ResetAtMS: &resetAt},
+	}
 	manager.RecordPassiveQuotaObservation(7, 100, 1000, windows)
+
+	// Both the struct fields and the values behind its pointers must be
+	// detached: sharing them would let a caller change what is about to be
+	// persisted, under an observation time captured before the change.
 	windows[0].ID = "mutated"
+	*windows[0].Used = 999
+	*windows[0].Utilization = 9.99
+	*windows[0].ResetAtMS = 999999
 
 	dirty := manager.DirtyPassiveQuotaObservations(10)
-	if len(dirty) != 1 || dirty[0].Windows[0].ID != "primary" {
-		t.Fatalf("dirty observations = %#v, want the pending entry unaffected by caller mutation", dirty)
+	if len(dirty) != 1 {
+		t.Fatalf("dirty observations = %#v", dirty)
+	}
+	stored := dirty[0].Windows[0]
+	if stored.ID != "primary" || stored.Used == nil || *stored.Used != 10 ||
+		stored.Utilization == nil || *stored.Utilization != 0.1 ||
+		stored.ResetAtMS == nil || *stored.ResetAtMS != 4242 {
+		t.Fatalf("pending window = %#v, want it unaffected by caller mutation", stored)
 	}
 }
 

--- a/internal/subscription/passive_quota_test.go
+++ b/internal/subscription/passive_quota_test.go
@@ -26,7 +26,7 @@ func TestRecordPassiveQuotaObservationIsVisibleAsDirty(t *testing.T) {
 	}
 }
 
-func TestRecordPassiveQuotaObservationMergesByWindowID(t *testing.T) {
+func TestRecordPassiveQuotaObservationReplacesRatherThanCombiningResponses(t *testing.T) {
 	manager := testCredentialManagerForPassiveQuota()
 	manager.RecordPassiveQuotaObservation(7, 100, 1000, []providerobservation.QuotaWindow{
 		{ID: "primary", Used: floatPointer(10)},
@@ -35,9 +35,28 @@ func TestRecordPassiveQuotaObservationMergesByWindowID(t *testing.T) {
 		{ID: "secondary", Used: floatPointer(20)},
 	})
 
+	// A pending entry carries exactly one response, so its windows and its
+	// observation time always describe the same instant. Combining responses
+	// would let a field observed at 1000 be persisted stamped as 2000, which
+	// can then outrank -- and overwrite -- an active refresh committed in
+	// between. The window dropped here is not lost data: the stored snapshot
+	// keeps its current value and the next full response refreshes it.
 	dirty := manager.DirtyPassiveQuotaObservations(10)
-	if len(dirty) != 1 || len(dirty[0].Windows) != 2 || dirty[0].ObservedAtMS != 2000 {
-		t.Fatalf("dirty observations = %#v, want both windows merged", dirty)
+	if len(dirty) != 1 || len(dirty[0].Windows) != 1 ||
+		dirty[0].Windows[0].ID != "secondary" || dirty[0].ObservedAtMS != 2000 {
+		t.Fatalf("dirty observations = %#v, want only the newest response's window", dirty)
+	}
+}
+
+func TestRecordPassiveQuotaObservationCopiesCallerWindows(t *testing.T) {
+	manager := testCredentialManagerForPassiveQuota()
+	windows := []providerobservation.QuotaWindow{{ID: "primary", Used: floatPointer(10)}}
+	manager.RecordPassiveQuotaObservation(7, 100, 1000, windows)
+	windows[0].ID = "mutated"
+
+	dirty := manager.DirtyPassiveQuotaObservations(10)
+	if len(dirty) != 1 || dirty[0].Windows[0].ID != "primary" {
+		t.Fatalf("dirty observations = %#v, want the pending entry unaffected by caller mutation", dirty)
 	}
 }
 

--- a/internal/subscription/passive_quota_test.go
+++ b/internal/subscription/passive_quota_test.go
@@ -116,6 +116,30 @@ func TestRecordPassiveQuotaObservationReplacesOnIdentityGenerationChange(t *test
 	}
 }
 
+func TestAckPassiveQuotaObservationEvictsTheEntry(t *testing.T) {
+	manager := testCredentialManagerForPassiveQuota()
+	manager.RecordPassiveQuotaObservation(7, 100, 1000, []providerobservation.QuotaWindow{
+		{ID: "primary", Used: floatPointer(10)},
+	})
+	dirty := manager.DirtyPassiveQuotaObservations(10)
+	if len(dirty) != 1 {
+		t.Fatalf("dirty observations = %#v", dirty)
+	}
+
+	manager.passiveQuota.ack(7, dirty[0].Version)
+
+	// Keeping an acknowledged entry around would retain its cloned windows for
+	// the life of the process; a credential that is later deleted would never
+	// release them, so a long-running instance with credential churn grows
+	// without bound.
+	manager.passiveQuota.mu.Lock()
+	remaining := len(manager.passiveQuota.entries)
+	manager.passiveQuota.mu.Unlock()
+	if remaining != 0 {
+		t.Fatalf("pending entries after ack = %d, want the entry evicted", remaining)
+	}
+}
+
 func TestAckPassiveQuotaObservationClearsOnlyMatchingVersion(t *testing.T) {
 	manager := testCredentialManagerForPassiveQuota()
 	manager.RecordPassiveQuotaObservation(7, 100, 1000, []providerobservation.QuotaWindow{
@@ -130,13 +154,13 @@ func TestAckPassiveQuotaObservationClearsOnlyMatchingVersion(t *testing.T) {
 	manager.RecordPassiveQuotaObservation(7, 100, 2000, []providerobservation.QuotaWindow{
 		{ID: "primary", Used: floatPointer(20)},
 	})
-	manager.AckPassiveQuotaObservation(7, staleVersion)
+	manager.passiveQuota.ack(7, staleVersion)
 	if stillDirty := manager.DirtyPassiveQuotaObservations(10); len(stillDirty) != 1 {
 		t.Fatalf("a stale ACK cleared a newer pending version: %#v", stillDirty)
 	}
 
 	current := manager.DirtyPassiveQuotaObservations(10)[0].Version
-	manager.AckPassiveQuotaObservation(7, current)
+	manager.passiveQuota.ack(7, current)
 	if stillDirty := manager.DirtyPassiveQuotaObservations(10); len(stillDirty) != 0 {
 		t.Fatalf("matching ACK did not clear the pending entry: %#v", stillDirty)
 	}

--- a/internal/subscription/passive_quota_test.go
+++ b/internal/subscription/passive_quota_test.go
@@ -1,0 +1,127 @@
+package subscription
+
+import (
+	"testing"
+
+	providerobservation "gpt-load/internal/subscription/providers/observation"
+)
+
+func testCredentialManagerForPassiveQuota() *CredentialManager {
+	return NewCredentialManager(nil, nil, nil, nil, nil)
+}
+
+func floatPointer(value float64) *float64 { return &value }
+
+func TestRecordPassiveQuotaObservationIsVisibleAsDirty(t *testing.T) {
+	manager := testCredentialManagerForPassiveQuota()
+	windows := []providerobservation.QuotaWindow{
+		{ID: "primary", Scope: "account", Unit: "percent", State: "available", Used: floatPointer(10)},
+	}
+	manager.RecordPassiveQuotaObservation(7, 100, 1000, windows)
+
+	dirty := manager.DirtyPassiveQuotaObservations(10)
+	if len(dirty) != 1 || dirty[0].CredentialID != 7 || dirty[0].IdentityGeneration != 100 ||
+		dirty[0].ObservedAtMS != 1000 || len(dirty[0].Windows) != 1 || dirty[0].Windows[0].ID != "primary" {
+		t.Fatalf("dirty observations = %#v", dirty)
+	}
+}
+
+func TestRecordPassiveQuotaObservationMergesByWindowID(t *testing.T) {
+	manager := testCredentialManagerForPassiveQuota()
+	manager.RecordPassiveQuotaObservation(7, 100, 1000, []providerobservation.QuotaWindow{
+		{ID: "primary", Used: floatPointer(10)},
+	})
+	manager.RecordPassiveQuotaObservation(7, 100, 2000, []providerobservation.QuotaWindow{
+		{ID: "secondary", Used: floatPointer(20)},
+	})
+
+	dirty := manager.DirtyPassiveQuotaObservations(10)
+	if len(dirty) != 1 || len(dirty[0].Windows) != 2 || dirty[0].ObservedAtMS != 2000 {
+		t.Fatalf("dirty observations = %#v, want both windows merged", dirty)
+	}
+}
+
+func TestRecordPassiveQuotaObservationDropsOlderObservedAt(t *testing.T) {
+	manager := testCredentialManagerForPassiveQuota()
+	manager.RecordPassiveQuotaObservation(7, 100, 2000, []providerobservation.QuotaWindow{
+		{ID: "primary", Used: floatPointer(90)},
+	})
+	manager.RecordPassiveQuotaObservation(7, 100, 1000, []providerobservation.QuotaWindow{
+		{ID: "primary", Used: floatPointer(10)},
+	})
+
+	dirty := manager.DirtyPassiveQuotaObservations(10)
+	if len(dirty) != 1 || dirty[0].ObservedAtMS != 2000 || *dirty[0].Windows[0].Used != 90 {
+		t.Fatalf("dirty observations = %#v, want the newer 2000ms observation preserved", dirty)
+	}
+}
+
+func TestRecordPassiveQuotaObservationIgnoresEmptyWindows(t *testing.T) {
+	manager := testCredentialManagerForPassiveQuota()
+	manager.RecordPassiveQuotaObservation(7, 100, 1000, nil)
+
+	if dirty := manager.DirtyPassiveQuotaObservations(10); len(dirty) != 0 {
+		t.Fatalf("dirty observations = %#v, want none for an empty-window record", dirty)
+	}
+}
+
+func TestRecordPassiveQuotaObservationReplacesOnIdentityGenerationChange(t *testing.T) {
+	manager := testCredentialManagerForPassiveQuota()
+	manager.RecordPassiveQuotaObservation(7, 100, 1000, []providerobservation.QuotaWindow{
+		{ID: "primary", Used: floatPointer(10)},
+	})
+	manager.RecordPassiveQuotaObservation(7, 200, 2000, []providerobservation.QuotaWindow{
+		{ID: "secondary", Used: floatPointer(20)},
+	})
+
+	dirty := manager.DirtyPassiveQuotaObservations(10)
+	if len(dirty) != 1 || dirty[0].IdentityGeneration != 200 || len(dirty[0].Windows) != 1 ||
+		dirty[0].Windows[0].ID != "secondary" {
+		t.Fatalf("dirty observations = %#v, want replaced (not merged) after identity change", dirty)
+	}
+}
+
+func TestAckPassiveQuotaObservationClearsOnlyMatchingVersion(t *testing.T) {
+	manager := testCredentialManagerForPassiveQuota()
+	manager.RecordPassiveQuotaObservation(7, 100, 1000, []providerobservation.QuotaWindow{
+		{ID: "primary", Used: floatPointer(10)},
+	})
+	dirty := manager.DirtyPassiveQuotaObservations(10)
+	if len(dirty) != 1 {
+		t.Fatalf("dirty observations = %#v", dirty)
+	}
+	staleVersion := dirty[0].Version
+
+	manager.RecordPassiveQuotaObservation(7, 100, 2000, []providerobservation.QuotaWindow{
+		{ID: "primary", Used: floatPointer(20)},
+	})
+	manager.AckPassiveQuotaObservation(7, staleVersion)
+	if stillDirty := manager.DirtyPassiveQuotaObservations(10); len(stillDirty) != 1 {
+		t.Fatalf("a stale ACK cleared a newer pending version: %#v", stillDirty)
+	}
+
+	current := manager.DirtyPassiveQuotaObservations(10)[0].Version
+	manager.AckPassiveQuotaObservation(7, current)
+	if stillDirty := manager.DirtyPassiveQuotaObservations(10); len(stillDirty) != 0 {
+		t.Fatalf("matching ACK did not clear the pending entry: %#v", stillDirty)
+	}
+}
+
+func TestSetPassiveQuotaDirtyNotifierFiresOnRecord(t *testing.T) {
+	manager := testCredentialManagerForPassiveQuota()
+	fired := make(chan struct{}, 1)
+	manager.SetPassiveQuotaDirtyNotifier(func() {
+		select {
+		case fired <- struct{}{}:
+		default:
+		}
+	})
+	manager.RecordPassiveQuotaObservation(7, 100, 1000, []providerobservation.QuotaWindow{
+		{ID: "primary", Used: floatPointer(10)},
+	})
+	select {
+	case <-fired:
+	default:
+		t.Fatal("dirty notifier was not called after a record")
+	}
+}

--- a/internal/subscription/providers/claude/claude_test.go
+++ b/internal/subscription/providers/claude/claude_test.go
@@ -120,9 +120,14 @@ func TestExecutorMapsResponsesAndPreservesBoundedClassification(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	observedAt := time.Date(2026, 8, 28, 9, 0, 0, 0, time.UTC)
 	bridge := &fakeClaudeBridgeExecutor{response: cpaembedded.ExecuteResponse{
 		Payload: []byte(`{"ok":true}`), Headers: http.Header{"X-Request-Id": {"request-one"}},
 		AppliedReasoningEffort: "high",
+		QuotaSignals: cpaembedded.QuotaSignalObservation{
+			ObservedAt: observedAt,
+			Signals:    map[string]string{"Anthropic-Ratelimit-Unified-5h-Utilization": "0.4"},
+		},
 	}}
 	executor := &executor{bridge: bridge}
 	response, err := executor.Execute(t.Context(), "1", credential, ExecuteRequest{
@@ -131,6 +136,10 @@ func TestExecutorMapsResponsesAndPreservesBoundedClassification(t *testing.T) {
 	if err != nil || string(response.Payload) != `{"ok":true}` ||
 		response.Headers.Get("X-Request-Id") != "request-one" || response.AppliedReasoningEffort != "high" {
 		t.Fatalf("response/error = %#v / %v", response, err)
+	}
+	if !response.QuotaObservedAt.Equal(observedAt) ||
+		response.QuotaSignals["Anthropic-Ratelimit-Unified-5h-Utilization"] != "0.4" {
+		t.Fatalf("response quota signals = %#v", response)
 	}
 
 	bridge.err = &fakeBridgeExecutionError{

--- a/internal/subscription/providers/claude/executor.go
+++ b/internal/subscription/providers/claude/executor.go
@@ -29,6 +29,8 @@ type ExecuteResponse struct {
 	Payload                []byte
 	Headers                http.Header
 	AppliedReasoningEffort string
+	QuotaObservedAt        time.Time
+	QuotaSignals           map[string]string
 }
 
 // ExecuteStreamResponse contains converted streaming chunks and metadata.
@@ -36,6 +38,8 @@ type ExecuteStreamResponse struct {
 	Headers                http.Header
 	Chunks                 <-chan ExecuteStreamChunk
 	AppliedReasoningEffort string
+	QuotaObservedAt        time.Time
+	QuotaSignals           map[string]string
 }
 
 // ExecuteStreamChunk contains one converted payload or terminal bridge error.
@@ -142,6 +146,8 @@ func (e *executor) Execute(
 	return ExecuteResponse{
 		Payload: append([]byte(nil), response.Payload...), Headers: response.Headers.Clone(),
 		AppliedReasoningEffort: response.AppliedReasoningEffort,
+		QuotaObservedAt:        response.QuotaSignals.ObservedAt,
+		QuotaSignals:           response.QuotaSignals.Signals,
 	}, normalizeExecutionError(err)
 }
 
@@ -183,6 +189,7 @@ func (e *executor) ExecuteStream(
 	if err != nil {
 		return &ExecuteStreamResponse{
 			Headers: response.Headers.Clone(), AppliedReasoningEffort: response.AppliedReasoningEffort,
+			QuotaObservedAt: response.QuotaSignals.ObservedAt, QuotaSignals: response.QuotaSignals.Signals,
 		}, normalizeExecutionError(err)
 	}
 	chunks := make(chan ExecuteStreamChunk)
@@ -202,6 +209,8 @@ func (e *executor) ExecuteStream(
 	return &ExecuteStreamResponse{
 		Headers: response.Headers.Clone(), Chunks: chunks,
 		AppliedReasoningEffort: response.AppliedReasoningEffort,
+		QuotaObservedAt:        response.QuotaSignals.ObservedAt,
+		QuotaSignals:           response.QuotaSignals.Signals,
 	}, nil
 }
 

--- a/internal/subscription/providers/claude/observation.go
+++ b/internal/subscription/providers/claude/observation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -345,6 +346,79 @@ func claudeScopedLimitLabel(group, displayName string) string {
 		return displayName
 	}
 	return providerobservation.DisplayName(group)
+}
+
+// NormalizePassiveQuotaWindows converts one response's passive quota Header
+// signals into the same account-scope windows NormalizeObservation produces
+// from the active usage payload, reusing normalizeClaudePercentageWindow so
+// Label, LabelKey, and the numeric fields follow one rule regardless of
+// source. observedAt is accepted for symmetry with the Codex normalizer;
+// Claude's reset header is always an absolute timestamp.
+func NormalizePassiveQuotaWindows(signals map[string]string, observedAt time.Time) []quotaWindow {
+	windows := make([]quotaWindow, 0, 2)
+	for _, entry := range []struct {
+		id, label, statusKey, utilizationKey, resetKey string
+		windowSeconds                                  int64
+		primary                                        bool
+	}{
+		{
+			id: "five_hour", label: "Session", windowSeconds: 5 * 60 * 60, primary: true,
+			statusKey: "Anthropic-Ratelimit-Unified-5h-Status", utilizationKey: "Anthropic-Ratelimit-Unified-5h-Utilization",
+			resetKey: "Anthropic-Ratelimit-Unified-5h-Reset",
+		},
+		{
+			id: "seven_day", label: "Weekly", windowSeconds: 7 * 24 * 60 * 60,
+			statusKey: "Anthropic-Ratelimit-Unified-7d-Status", utilizationKey: "Anthropic-Ratelimit-Unified-7d-Utilization",
+			resetKey: "Anthropic-Ratelimit-Unified-7d-Reset",
+		},
+	} {
+		status, hasStatus := signals[entry.statusKey]
+		percent, hasUtilization := passiveClaudeUtilizationPercent(signals[entry.utilizationKey])
+		reset, hasReset := passiveClaudeResetRFC3339(signals[entry.resetKey])
+		if !hasStatus && !hasUtilization && !hasReset {
+			continue
+		}
+		window, err := normalizeClaudePercentageWindow(entry.id, entry.label, "account", entry.windowSeconds, entry.primary, percent, reset)
+		if err != nil {
+			continue
+		}
+		if hasStatus {
+			switch strings.ToLower(strings.TrimSpace(status)) {
+			case "allowed":
+				if window.State != "exhausted" {
+					window.State = "available"
+				}
+			case "rejected":
+				window.State = "exhausted"
+			}
+		}
+		windows = append(windows, window)
+	}
+	return windows
+}
+
+func passiveClaudeUtilizationPercent(raw string) (*float64, bool) {
+	if raw == "" {
+		return nil, false
+	}
+	parsed, err := strconv.ParseFloat(strings.TrimSpace(raw), 64)
+	if err != nil || math.IsNaN(parsed) || math.IsInf(parsed, 0) || parsed < 0 || parsed > 1 {
+		return nil, false
+	}
+	percent := parsed * 100
+	return &percent, true
+}
+
+func passiveClaudeResetRFC3339(raw string) (*string, bool) {
+	if raw == "" {
+		return nil, false
+	}
+	seconds, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
+	if err != nil || seconds <= 0 {
+		return nil, false
+	}
+	formatted := time.Unix(seconds, 0).UTC().Format(time.RFC3339)
+	return &formatted, true
 }
 
 func claudeOptionalResetMilliseconds(field string, value *string) (*int64, error) {

--- a/internal/subscription/providers/claude/observation.go
+++ b/internal/subscription/providers/claude/observation.go
@@ -392,6 +392,11 @@ func NormalizePassiveQuotaWindows(signals map[string]string, observedAt time.Tim
 				window.State = "exhausted"
 			}
 		}
+		// Identity and display metadata stay owned by the active observation:
+		// this output only ever updates windows it already created, and only
+		// their quota numbers and state.
+		window.Label, window.LabelKey, window.Scope, window.Unit = "", "", "", ""
+		window.IsPrimary = false
 		windows = append(windows, window)
 	}
 	return windows

--- a/internal/subscription/providers/claude/observation_test.go
+++ b/internal/subscription/providers/claude/observation_test.go
@@ -92,10 +92,16 @@ func TestNormalizePassiveQuotaWindowsMapsFiveHourAndSevenDay(t *testing.T) {
 	for _, window := range windows {
 		byID[window.ID] = window
 	}
+	// Display metadata is deliberately empty: a passive response only updates
+	// quota numbers and state on windows the active observation already owns.
 	fiveHour, ok := byID["five_hour"]
-	if !ok || fiveHour.Scope != "account" || fiveHour.Utilization == nil || *fiveHour.Utilization != 0.4 ||
+	if !ok || fiveHour.Utilization == nil || *fiveHour.Utilization != 0.4 ||
 		fiveHour.State != "available" || fiveHour.ResetAtMS == nil || *fiveHour.ResetAtMS != 1787296800*1000 {
 		t.Fatalf("five_hour window = %#v", fiveHour)
+	}
+	if fiveHour.Label != "" || fiveHour.LabelKey != "" || fiveHour.Scope != "" ||
+		fiveHour.Unit != "" || fiveHour.IsPrimary {
+		t.Fatalf("five_hour window = %#v, want empty display metadata", fiveHour)
 	}
 	sevenDay, ok := byID["seven_day"]
 	if !ok || sevenDay.Utilization == nil || *sevenDay.Utilization != 0.1 || sevenDay.State != "exhausted" {

--- a/internal/subscription/providers/claude/observation_test.go
+++ b/internal/subscription/providers/claude/observation_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func floatPointer(value float64) *float64 { return &value }
@@ -73,6 +74,71 @@ func TestNormalizeObservationIncludesAccountAndQuotaWindows(t *testing.T) {
 		byID["weekly_opus"].Label != "Opus · 7d" ||
 		byID["weekly_opus"].Utilization == nil || *byID["weekly_opus"].Utilization != 0.8 {
 		t.Fatalf("quota windows = %#v", byID)
+	}
+}
+
+func TestNormalizePassiveQuotaWindowsMapsFiveHourAndSevenDay(t *testing.T) {
+	windows := NormalizePassiveQuotaWindows(map[string]string{
+		"Anthropic-Ratelimit-Unified-5h-Status":      "allowed",
+		"Anthropic-Ratelimit-Unified-5h-Utilization": "0.4",
+		"Anthropic-Ratelimit-Unified-5h-Reset":       "1787296800",
+		"Anthropic-Ratelimit-Unified-7d-Status":      "rejected",
+		"Anthropic-Ratelimit-Unified-7d-Utilization": "0.1",
+	}, time.Now())
+	if len(windows) != 2 {
+		t.Fatalf("windows = %#v, want 2 entries", windows)
+	}
+	byID := map[string]quotaWindow{}
+	for _, window := range windows {
+		byID[window.ID] = window
+	}
+	fiveHour, ok := byID["five_hour"]
+	if !ok || fiveHour.Scope != "account" || fiveHour.Utilization == nil || *fiveHour.Utilization != 0.4 ||
+		fiveHour.State != "available" || fiveHour.ResetAtMS == nil || *fiveHour.ResetAtMS != 1787296800*1000 {
+		t.Fatalf("five_hour window = %#v", fiveHour)
+	}
+	sevenDay, ok := byID["seven_day"]
+	if !ok || sevenDay.Utilization == nil || *sevenDay.Utilization != 0.1 || sevenDay.State != "exhausted" {
+		t.Fatalf("seven_day window = %#v, want rejected status forcing exhausted", sevenDay)
+	}
+}
+
+func TestNormalizePassiveQuotaWindowsIgnoresUnknownStatusAndOutOfRangeUtilization(t *testing.T) {
+	windows := NormalizePassiveQuotaWindows(map[string]string{
+		"Anthropic-Ratelimit-Unified-5h-Status":      "unknown",
+		"Anthropic-Ratelimit-Unified-5h-Utilization": "1.5",
+	}, time.Now())
+	if len(windows) != 1 || windows[0].Utilization != nil || windows[0].State != "unknown" {
+		t.Fatalf("windows = %#v, want state unknown and no utilization", windows)
+	}
+}
+
+func TestNormalizePassiveQuotaWindowsRejectsNaNUtilization(t *testing.T) {
+	windows := NormalizePassiveQuotaWindows(map[string]string{
+		"Anthropic-Ratelimit-Unified-5h-Status":      "allowed",
+		"Anthropic-Ratelimit-Unified-5h-Utilization": "NaN",
+	}, time.Now())
+	if len(windows) != 1 || windows[0].Utilization != nil || windows[0].State != "available" {
+		t.Fatalf("windows = %#v, want status-derived state without a NaN utilization", windows)
+	}
+}
+
+func TestNormalizePassiveQuotaWindowsOmitsWindowWithNoValidEvidence(t *testing.T) {
+	windows := NormalizePassiveQuotaWindows(map[string]string{
+		"Anthropic-Ratelimit-Unified-5h-Utilization": "NaN",
+	}, time.Now())
+	if len(windows) != 0 {
+		t.Fatalf("windows = %#v, want none when the only signal is invalid", windows)
+	}
+}
+
+func TestNormalizePassiveQuotaWindowsIgnoresUnrelatedHeaders(t *testing.T) {
+	windows := NormalizePassiveQuotaWindows(map[string]string{
+		"Anthropic-Ratelimit-Unified-Overage-Status": "rejected",
+		"Retry-After": "30",
+	}, time.Now())
+	if len(windows) != 0 {
+		t.Fatalf("windows = %#v, want none", windows)
 	}
 }
 

--- a/internal/subscription/providers/codex/codex.go
+++ b/internal/subscription/providers/codex/codex.go
@@ -266,6 +266,8 @@ type ExecuteResponse struct {
 	Headers                http.Header
 	AppliedReasoningEffort string
 	UpstreamRequestPath    string
+	QuotaObservedAt        time.Time
+	QuotaSignals           map[string]string
 }
 
 // ExecuteStreamResponse contains converted streaming chunks and response metadata.
@@ -274,6 +276,8 @@ type ExecuteStreamResponse struct {
 	Chunks                 <-chan ExecuteStreamChunk
 	AppliedReasoningEffort string
 	UpstreamRequestPath    string
+	QuotaObservedAt        time.Time
+	QuotaSignals           map[string]string
 }
 
 // ExecuteStreamChunk contains one converted payload or terminal bridge error.
@@ -315,6 +319,8 @@ func (e *executor) Execute(
 		Headers:                response.Headers.Clone(),
 		AppliedReasoningEffort: response.AppliedReasoningEffort,
 		UpstreamRequestPath:    response.UpstreamRequestPath,
+		QuotaObservedAt:        response.QuotaSignals.ObservedAt,
+		QuotaSignals:           response.QuotaSignals.Signals,
 	}, err
 }
 
@@ -357,6 +363,8 @@ func (e *executor) ExecuteStream(
 		Headers:                response.Headers.Clone(),
 		AppliedReasoningEffort: response.AppliedReasoningEffort,
 		UpstreamRequestPath:    response.UpstreamRequestPath,
+		QuotaObservedAt:        response.QuotaSignals.ObservedAt,
+		QuotaSignals:           response.QuotaSignals.Signals,
 	}
 	if err != nil {
 		return convertedResponse, err

--- a/internal/subscription/providers/codex/codex_test.go
+++ b/internal/subscription/providers/codex/codex_test.go
@@ -7,9 +7,42 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+	"time"
 
 	cpaembedded "github.com/router-for-me/CLIProxyAPI/v7/gptload-embedded/embedded"
 )
+
+type fakeQuotaBridge struct {
+	unary  cpaembedded.ExecuteResponse
+	stream *cpaembedded.ExecuteStreamResponse
+}
+
+func (bridge fakeQuotaBridge) ExecuteCanonical(
+	context.Context,
+	string,
+	cpaembedded.CodexCredential,
+	cpaembedded.ExecuteRequest,
+) (cpaembedded.ExecuteResponse, error) {
+	return bridge.unary, nil
+}
+
+func (bridge fakeQuotaBridge) CountTokensCanonical(
+	context.Context,
+	string,
+	cpaembedded.CodexCredential,
+	cpaembedded.ExecuteRequest,
+) (cpaembedded.ExecuteResponse, error) {
+	return bridge.unary, nil
+}
+
+func (bridge fakeQuotaBridge) ExecuteStreamCanonical(
+	context.Context,
+	string,
+	cpaembedded.CodexCredential,
+	cpaembedded.ExecuteRequest,
+) (*cpaembedded.ExecuteStreamResponse, error) {
+	return bridge.stream, nil
+}
 
 type streamErrorBridge struct {
 	response *cpaembedded.ExecuteStreamResponse
@@ -112,6 +145,47 @@ func TestExecutorDoesNotFanOutNilChunksAfterSynchronousStreamError(t *testing.T)
 	if !errors.Is(err, wantErr) || response == nil || response.Chunks != nil ||
 		response.UpstreamRequestPath != "/backend-api/codex/responses" {
 		t.Fatalf("ExecuteStream() = %#v, %v", response, err)
+	}
+}
+
+func TestExecutorPropagatesQuotaSignalsButNotForCountTokens(t *testing.T) {
+	observedAt := time.Date(2026, 8, 28, 9, 0, 0, 0, time.UTC)
+	bridge := fakeQuotaBridge{unary: cpaembedded.ExecuteResponse{
+		QuotaSignals: cpaembedded.QuotaSignalObservation{
+			ObservedAt: observedAt,
+			Signals:    map[string]string{"X-Codex-Primary-Used-Percent": "55"},
+		},
+	}}
+	executor := &executor{bridge: bridge}
+
+	execResponse, err := executor.Execute(t.Context(), "credential-1", Credential{}, ExecuteRequest{})
+	if err != nil || !execResponse.QuotaObservedAt.Equal(observedAt) ||
+		execResponse.QuotaSignals["X-Codex-Primary-Used-Percent"] != "55" {
+		t.Fatalf("Execute() quota propagation = %#v, %v", execResponse, err)
+	}
+
+	countResponse, err := executor.CountTokens(t.Context(), "credential-1", Credential{}, ExecuteRequest{})
+	if err != nil || !countResponse.QuotaObservedAt.IsZero() || countResponse.QuotaSignals != nil {
+		t.Fatalf("CountTokens() unexpectedly propagated quota = %#v, %v", countResponse, err)
+	}
+}
+
+func TestExecutorStreamPropagatesQuotaSignals(t *testing.T) {
+	observedAt := time.Date(2026, 8, 28, 9, 0, 0, 0, time.UTC)
+	chunks := make(chan cpaembedded.ExecuteStreamChunk)
+	close(chunks)
+	bridge := fakeQuotaBridge{stream: &cpaembedded.ExecuteStreamResponse{
+		Chunks: chunks,
+		QuotaSignals: cpaembedded.QuotaSignalObservation{
+			ObservedAt: observedAt,
+			Signals:    map[string]string{"X-Codex-Primary-Used-Percent": "55"},
+		},
+	}}
+	executor := &executor{bridge: bridge}
+	response, err := executor.ExecuteStream(t.Context(), "credential-1", Credential{}, ExecuteRequest{})
+	if err != nil || response == nil || !response.QuotaObservedAt.Equal(observedAt) ||
+		response.QuotaSignals["X-Codex-Primary-Used-Percent"] != "55" {
+		t.Fatalf("ExecuteStream() quota propagation = %#v, %v", response, err)
 	}
 }
 

--- a/internal/subscription/providers/codex/observation.go
+++ b/internal/subscription/providers/codex/observation.go
@@ -101,60 +101,212 @@ func NormalizeQuota(primary, details []byte) ([]byte, error) {
 	return json.Marshal(result)
 }
 
-// NormalizePassiveQuotaWindows converts one response's passive quota Header
-// signals into the same account-scope windows NormalizeQuota produces from
-// the active JSON payload, reusing normalizeRateWindows so Label, LabelKey,
-// and State follow one rule regardless of source. Only window IDs with at
-// least one recognized Header are returned; the Header not mentioning a
-// window is not evidence that window disappeared.
+// passiveQuotaMaxResetAtSeconds bounds a reset timestamp before it is scaled
+// to milliseconds, so a malformed header cannot overflow int64 into a
+// nonsensical past instant.
+const passiveQuotaMaxResetAtSeconds = math.MaxInt64 / 1000
+
+// passiveQuotaNamespaceFields are the header suffixes that belong to a limit
+// namespace as a whole rather than to one of its windows.
+var passiveQuotaNamespaceFields = []string{"limit-reached", "limit-name", "allowed"}
+
+// passiveQuotaNamespace holds one Codex limit namespace parsed out of the
+// response headers. The empty namespace is the credential's own rate limit;
+// any other namespace is an additional limit identified by its Limit-Name.
+type passiveQuotaNamespace struct {
+	rateLevel map[string]string
+	windows   map[string]map[string]string
+}
+
+// NormalizePassiveQuotaWindows converts one response's passive quota headers
+// into the same windows NormalizeQuota produces from the active JSON payload,
+// reusing normalizeRateWindows so Scope, Unit, and State follow one rule
+// regardless of source.
+//
+// Namespaces are discovered from the headers rather than enumerated, so a
+// limit Codex introduces later is picked up without a code change as long as
+// it follows the same X-Codex-<namespace>-<window>-<field> shape and carries
+// an X-Codex-<namespace>-Limit-Name. An additional namespace without that
+// name is skipped: its ID could not be made to match the active JSON path.
+//
+// Label and LabelKey are deliberately left empty. They are derived from the
+// window period, which a partial response may omit, and this output only ever
+// updates windows an active observation already created -- that observation
+// stays the owner of the display metadata.
 func NormalizePassiveQuotaWindows(signals map[string]string, observedAt time.Time) []quotaWindow {
 	if len(signals) == 0 {
 		return nil
 	}
+	result := make([]quotaWindow, 0, 2)
+	namespaces := parsePassiveQuotaNamespaces(signals)
+	for _, key := range sortedNamespaceKeys(namespaces) {
+		namespace := namespaces[key]
+		prefix, scope := "", "account"
+		if key != "" {
+			limitName := strings.TrimSpace(namespace.rateLevel["limit-name"])
+			if limitName == "" || providerobservation.SafeID(limitName) == "" {
+				continue
+			}
+			scope = limitName
+			prefix = providerobservation.SafeID(limitName) + "-"
+		}
+		rate := passiveQuotaRate(namespace, observedAt)
+		if rate == nil {
+			continue
+		}
+		for _, window := range normalizeRateWindows(rate, prefix, scope) {
+			window.Label, window.LabelKey = "", ""
+			result = append(result, window)
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+// parsePassiveQuotaNamespaces groups X-Codex-* headers by limit namespace.
+// The first path segment equal to "primary" or "secondary" separates the
+// namespace from the field name, so a field that merely mentions a window
+// (X-Codex-Primary-Over-Secondary-Limit-Percent) stays attached to the window
+// that owns it.
+func parsePassiveQuotaNamespaces(signals map[string]string) map[string]*passiveQuotaNamespace {
+	namespaces := make(map[string]*passiveQuotaNamespace)
+	ensure := func(key string) *passiveQuotaNamespace {
+		if existing, ok := namespaces[key]; ok {
+			return existing
+		}
+		created := &passiveQuotaNamespace{
+			rateLevel: map[string]string{},
+			windows:   map[string]map[string]string{},
+		}
+		namespaces[key] = created
+		return created
+	}
+	for rawKey, value := range signals {
+		key := strings.ToLower(strings.TrimSpace(rawKey))
+		suffix, found := strings.CutPrefix(key, "x-codex-")
+		if !found || suffix == "" {
+			continue
+		}
+		segments := strings.Split(suffix, "-")
+		windowIndex := -1
+		for index, segment := range segments {
+			if segment == "primary" || segment == "secondary" {
+				windowIndex = index
+				break
+			}
+		}
+		if windowIndex < 0 {
+			// No window segment: this is either a namespace-wide field or a
+			// header this normalizer has no meaning for (plan type, credits).
+			for _, field := range passiveQuotaNamespaceFields {
+				if suffix == field {
+					ensure("").rateLevel[field] = value
+					break
+				}
+				if owner, trimmed := strings.CutSuffix(suffix, "-"+field); trimmed && owner != "" {
+					ensure(owner).rateLevel[field] = value
+					break
+				}
+			}
+			continue
+		}
+		namespaceKey := strings.Join(segments[:windowIndex], "-")
+		field := strings.Join(segments[windowIndex+1:], "-")
+		if field == "" {
+			continue
+		}
+		namespace := ensure(namespaceKey)
+		window := namespace.windows[segments[windowIndex]]
+		if window == nil {
+			window = map[string]string{}
+			namespace.windows[segments[windowIndex]] = window
+		}
+		window[field] = value
+	}
+	return namespaces
+}
+
+func sortedNamespaceKeys(namespaces map[string]*passiveQuotaNamespace) []string {
+	keys := make([]string, 0, len(namespaces))
+	for key := range namespaces {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// passiveQuotaRate rebuilds the rate-limit object shape normalizeRateWindows
+// already consumes from the active JSON payload. It returns nil when the
+// namespace carries no usable window field.
+func passiveQuotaRate(namespace *passiveQuotaNamespace, observedAt time.Time) map[string]any {
 	rate := map[string]any{}
-	if allowed, ok := passiveQuotaBool(signals, "X-Codex-Allowed"); ok {
+	if allowed, ok := passiveQuotaBool(namespace.rateLevel["allowed"]); ok {
 		rate["allowed"] = allowed
 	}
-	if reached, ok := passiveQuotaBool(signals, "X-Codex-Limit-Reached"); ok {
+	if reached, ok := passiveQuotaBool(namespace.rateLevel["limit-reached"]); ok {
 		rate["limit_reached"] = reached
 	}
-	windowPresent := false
-	for _, entry := range []struct{ name, prefix string }{
-		{"primary", "X-Codex-Primary-"},
-		{"secondary", "X-Codex-Secondary-"},
-	} {
-		window := passiveQuotaWindowFields(signals, entry.prefix, observedAt)
+	present := false
+	for _, name := range []string{"primary", "secondary"} {
+		fields := namespace.windows[name]
+		if len(fields) == 0 {
+			continue
+		}
+		window := passiveQuotaWindowFields(fields, observedAt)
 		if len(window) == 0 {
 			continue
 		}
-		rate[entry.name+"_window"] = window
-		windowPresent = true
+		rate[name+"_window"] = window
+		present = true
 	}
-	if !windowPresent {
+	if !present {
 		return nil
 	}
-	return normalizeRateWindows(rate, "", "account")
+	return rate
 }
 
-func passiveQuotaWindowFields(signals map[string]string, prefix string, observedAt time.Time) map[string]any {
+func passiveQuotaWindowFields(fields map[string]string, observedAt time.Time) map[string]any {
 	window := map[string]any{}
-	if used, ok := passiveQuotaFloat(signals, prefix+"Used-Percent"); ok {
+	// A percentage outside 0..100 is not a value to clamp: it means the header
+	// was not the quota reading it claims to be, so it is dropped entirely.
+	if used, ok := passiveQuotaFloat(fields["used-percent"]); ok && used >= 0 && used <= 100 {
 		window["used_percent"] = used
 	}
-	if minutes, ok := passiveQuotaInt(signals, prefix+"Window-Minutes"); ok {
+	if minutes, ok := passiveQuotaInt(fields["window-minutes"]); ok && minutes > 0 &&
+		minutes <= passiveQuotaMaxResetAtSeconds/60 {
 		window["limit_window_seconds"] = float64(minutes * 60)
 	}
-	if resetAt, ok := passiveQuotaInt(signals, prefix+"Reset-At"); ok {
+	if resetAt, ok := passiveQuotaResetAt(fields, observedAt); ok {
 		window["reset_at"] = float64(resetAt)
-	} else if resetAfter, ok := passiveQuotaInt(signals, prefix+"Reset-After-Seconds"); ok {
-		window["reset_at"] = float64(observedAt.Unix() + resetAfter)
 	}
 	return window
 }
 
-func passiveQuotaFloat(signals map[string]string, key string) (float64, bool) {
-	value, ok := signals[key]
-	if !ok {
+// passiveQuotaResetAt prefers the absolute reset instant and falls back to the
+// relative one. Both must land on a positive, non-overflowing second so the
+// stored window keeps a usable timestamp.
+func passiveQuotaResetAt(fields map[string]string, observedAt time.Time) (int64, bool) {
+	if absolute, ok := passiveQuotaInt(fields["reset-at"]); ok {
+		if absolute <= 0 || absolute > passiveQuotaMaxResetAtSeconds {
+			return 0, false
+		}
+		return absolute, true
+	}
+	relative, ok := passiveQuotaInt(fields["reset-after-seconds"])
+	if !ok || relative <= 0 {
+		return 0, false
+	}
+	base := observedAt.Unix()
+	if base < 0 || relative > passiveQuotaMaxResetAtSeconds-base {
+		return 0, false
+	}
+	return base + relative, true
+}
+
+func passiveQuotaFloat(value string) (float64, bool) {
+	if value == "" {
 		return 0, false
 	}
 	parsed, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
@@ -164,9 +316,8 @@ func passiveQuotaFloat(signals map[string]string, key string) (float64, bool) {
 	return parsed, true
 }
 
-func passiveQuotaInt(signals map[string]string, key string) (int64, bool) {
-	value, ok := signals[key]
-	if !ok {
+func passiveQuotaInt(value string) (int64, bool) {
+	if value == "" {
 		return 0, false
 	}
 	parsed, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
@@ -176,9 +327,8 @@ func passiveQuotaInt(signals map[string]string, key string) (int64, bool) {
 	return parsed, true
 }
 
-func passiveQuotaBool(signals map[string]string, key string) (bool, bool) {
-	value, ok := signals[key]
-	if !ok {
+func passiveQuotaBool(value string) (bool, bool) {
+	if value == "" {
 		return false, false
 	}
 	parsed, err := strconv.ParseBool(strings.TrimSpace(value))

--- a/internal/subscription/providers/codex/observation.go
+++ b/internal/subscription/providers/codex/observation.go
@@ -101,6 +101,93 @@ func NormalizeQuota(primary, details []byte) ([]byte, error) {
 	return json.Marshal(result)
 }
 
+// NormalizePassiveQuotaWindows converts one response's passive quota Header
+// signals into the same account-scope windows NormalizeQuota produces from
+// the active JSON payload, reusing normalizeRateWindows so Label, LabelKey,
+// and State follow one rule regardless of source. Only window IDs with at
+// least one recognized Header are returned; the Header not mentioning a
+// window is not evidence that window disappeared.
+func NormalizePassiveQuotaWindows(signals map[string]string, observedAt time.Time) []quotaWindow {
+	if len(signals) == 0 {
+		return nil
+	}
+	rate := map[string]any{}
+	if allowed, ok := passiveQuotaBool(signals, "X-Codex-Allowed"); ok {
+		rate["allowed"] = allowed
+	}
+	if reached, ok := passiveQuotaBool(signals, "X-Codex-Limit-Reached"); ok {
+		rate["limit_reached"] = reached
+	}
+	windowPresent := false
+	for _, entry := range []struct{ name, prefix string }{
+		{"primary", "X-Codex-Primary-"},
+		{"secondary", "X-Codex-Secondary-"},
+	} {
+		window := passiveQuotaWindowFields(signals, entry.prefix, observedAt)
+		if len(window) == 0 {
+			continue
+		}
+		rate[entry.name+"_window"] = window
+		windowPresent = true
+	}
+	if !windowPresent {
+		return nil
+	}
+	return normalizeRateWindows(rate, "", "account")
+}
+
+func passiveQuotaWindowFields(signals map[string]string, prefix string, observedAt time.Time) map[string]any {
+	window := map[string]any{}
+	if used, ok := passiveQuotaFloat(signals, prefix+"Used-Percent"); ok {
+		window["used_percent"] = used
+	}
+	if minutes, ok := passiveQuotaInt(signals, prefix+"Window-Minutes"); ok {
+		window["limit_window_seconds"] = float64(minutes * 60)
+	}
+	if resetAt, ok := passiveQuotaInt(signals, prefix+"Reset-At"); ok {
+		window["reset_at"] = float64(resetAt)
+	} else if resetAfter, ok := passiveQuotaInt(signals, prefix+"Reset-After-Seconds"); ok {
+		window["reset_at"] = float64(observedAt.Unix() + resetAfter)
+	}
+	return window
+}
+
+func passiveQuotaFloat(signals map[string]string, key string) (float64, bool) {
+	value, ok := signals[key]
+	if !ok {
+		return 0, false
+	}
+	parsed, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+	if err != nil || math.IsNaN(parsed) || math.IsInf(parsed, 0) {
+		return 0, false
+	}
+	return parsed, true
+}
+
+func passiveQuotaInt(signals map[string]string, key string) (int64, bool) {
+	value, ok := signals[key]
+	if !ok {
+		return 0, false
+	}
+	parsed, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return parsed, true
+}
+
+func passiveQuotaBool(signals map[string]string, key string) (bool, bool) {
+	value, ok := signals[key]
+	if !ok {
+		return false, false
+	}
+	parsed, err := strconv.ParseBool(strings.TrimSpace(value))
+	if err != nil {
+		return false, false
+	}
+	return parsed, true
+}
+
 func normalizeRateWindows(rate map[string]any, prefix, scope string) []quotaWindow {
 	result := make([]quotaWindow, 0, 2)
 	for _, name := range []string{"primary", "secondary"} {

--- a/internal/subscription/providers/codex/observation.go
+++ b/internal/subscription/providers/codex/observation.go
@@ -155,7 +155,10 @@ func NormalizePassiveQuotaWindows(signals map[string]string, observedAt time.Tim
 			continue
 		}
 		for _, window := range normalizeRateWindows(rate, prefix, scope) {
-			window.Label, window.LabelKey = "", ""
+			// Scope and Unit only served to build the ID and pick the label
+			// rules above; they are cleared, like Label, so the merge updates
+			// nothing but the quota numbers and state.
+			window.Label, window.LabelKey, window.Scope, window.Unit = "", "", "", ""
 			result = append(result, window)
 		}
 	}
@@ -285,13 +288,13 @@ func passiveQuotaWindowFields(fields map[string]string, observedAt time.Time) ma
 }
 
 // passiveQuotaResetAt prefers the absolute reset instant and falls back to the
-// relative one. Both must land on a positive, non-overflowing second so the
+// relative one, including when the absolute value is present but unusable --
+// a broken header should not suppress a valid alternative in the same
+// response. Both must land on a positive, non-overflowing second so the
 // stored window keeps a usable timestamp.
 func passiveQuotaResetAt(fields map[string]string, observedAt time.Time) (int64, bool) {
-	if absolute, ok := passiveQuotaInt(fields["reset-at"]); ok {
-		if absolute <= 0 || absolute > passiveQuotaMaxResetAtSeconds {
-			return 0, false
-		}
+	if absolute, ok := passiveQuotaInt(fields["reset-at"]); ok &&
+		absolute > 0 && absolute <= passiveQuotaMaxResetAtSeconds {
 		return absolute, true
 	}
 	relative, ok := passiveQuotaInt(fields["reset-after-seconds"])

--- a/internal/subscription/providers/codex/observation_test.go
+++ b/internal/subscription/providers/codex/observation_test.go
@@ -71,9 +71,10 @@ func TestNormalizePassiveQuotaWindowsMapsAdditionalLimitNamespaces(t *testing.T)
 	if _, ok := byID["primary"]; !ok {
 		t.Fatalf("windows = %#v, want the account-scope primary window", windows)
 	}
+	// The Limit-Name only has to produce the matching window ID; Scope, like
+	// the other display metadata, stays owned by the active observation.
 	spark, ok := byID["gpt-5-3-codex-spark-primary"]
-	if !ok || spark.Scope != "GPT 5.3 Codex Spark" ||
-		spark.Used == nil || *spark.Used != 33 {
+	if !ok || spark.Used == nil || *spark.Used != 33 {
 		t.Fatalf("additional primary window = %#v (all=%#v)", spark, windows)
 	}
 	sparkWeekly, ok := byID["gpt-5-3-codex-spark-secondary"]
@@ -125,14 +126,37 @@ func TestNormalizePassiveQuotaWindowsSkipsNamespaceWithoutLimitName(t *testing.T
 	}
 }
 
-func TestNormalizePassiveQuotaWindowsOmitsLabelMetadata(t *testing.T) {
-	// Labels are derived from the window period, which a partial response may
-	// not carry. Leaving them empty keeps the active observation's metadata.
+func TestNormalizePassiveQuotaWindowsOmitsAllDisplayMetadata(t *testing.T) {
+	// A passive response only ever updates quota numbers and state on windows
+	// an active observation already created. Every identity/display field is
+	// left empty so the merge cannot overwrite what that observation owns --
+	// Label in particular is derived from the window period, which a partial
+	// response may not carry.
 	windows := NormalizePassiveQuotaWindows(map[string]string{
 		"X-Codex-Primary-Used-Percent": "50",
 	}, time.Now())
-	if len(windows) != 1 || windows[0].Label != "" || windows[0].LabelKey != "" {
-		t.Fatalf("windows = %#v, want empty Label/LabelKey", windows)
+	if len(windows) != 1 {
+		t.Fatalf("windows = %#v, want one", windows)
+	}
+	window := windows[0]
+	if window.Label != "" || window.LabelKey != "" || window.Scope != "" || window.Unit != "" {
+		t.Fatalf("window = %#v, want empty Label/LabelKey/Scope/Unit", window)
+	}
+	if window.ID != "primary" || window.Used == nil || *window.Used != 50 || window.State != "available" {
+		t.Fatalf("window = %#v, want the ID, usage and state still populated", window)
+	}
+}
+
+func TestNormalizePassiveQuotaWindowsFallsBackToRelativeResetWhenAbsoluteIsInvalid(t *testing.T) {
+	// A response carrying a broken absolute reset plus a usable relative one
+	// should still refresh the reset time rather than dropping both.
+	windows := NormalizePassiveQuotaWindows(map[string]string{
+		"X-Codex-Primary-Used-Percent":        "50",
+		"X-Codex-Primary-Reset-At":            "0",
+		"X-Codex-Primary-Reset-After-Seconds": "60",
+	}, time.Unix(1000, 0).UTC())
+	if len(windows) != 1 || windows[0].ResetAtMS == nil || *windows[0].ResetAtMS != 1060*1000 {
+		t.Fatalf("windows = %#v, want the relative reset applied as 1060000", windows)
 	}
 }
 
@@ -197,7 +221,7 @@ func TestNormalizePassiveQuotaWindowsMapsPrimaryAndSecondary(t *testing.T) {
 		byID[window.ID] = window
 	}
 	primary, ok := byID["primary"]
-	if !ok || primary.Scope != "account" || primary.Used == nil || *primary.Used != 55 ||
+	if !ok || primary.Used == nil || *primary.Used != 55 ||
 		primary.Utilization == nil || *primary.Utilization != 0.55 || primary.State != "available" ||
 		primary.WindowSeconds == nil || *primary.WindowSeconds != 300*60 ||
 		primary.ResetAtMS == nil || *primary.ResetAtMS != 1800000000*1000 {

--- a/internal/subscription/providers/codex/observation_test.go
+++ b/internal/subscription/providers/codex/observation_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestNormalizeQuotaNormalizesPlanAndStandardWindows(t *testing.T) {
@@ -41,6 +42,78 @@ func TestNormalizeQuotaNormalizesPlanAndStandardWindows(t *testing.T) {
 	if !reflect.DeepEqual(labels, []string{"7d", "5h"}) ||
 		!reflect.DeepEqual(labelKeys, []string{"weekly", "session"}) {
 		t.Fatalf("window labels = %q, keys = %q", labels, labelKeys)
+	}
+}
+
+func TestNormalizePassiveQuotaWindowsMapsPrimaryAndSecondary(t *testing.T) {
+	observedAt := time.Date(2026, 8, 28, 9, 0, 0, 0, time.UTC)
+	windows := NormalizePassiveQuotaWindows(map[string]string{
+		"X-Codex-Primary-Used-Percent":     "55",
+		"X-Codex-Primary-Window-Minutes":   "300",
+		"X-Codex-Primary-Reset-At":         "1800000000",
+		"X-Codex-Secondary-Used-Percent":   "10",
+		"X-Codex-Secondary-Window-Minutes": "10080",
+	}, observedAt)
+	if len(windows) != 2 {
+		t.Fatalf("windows = %#v, want 2 entries", windows)
+	}
+	byID := map[string]quotaWindow{}
+	for _, window := range windows {
+		byID[window.ID] = window
+	}
+	primary, ok := byID["primary"]
+	if !ok || primary.Scope != "account" || primary.Used == nil || *primary.Used != 55 ||
+		primary.Utilization == nil || *primary.Utilization != 0.55 || primary.State != "available" ||
+		primary.WindowSeconds == nil || *primary.WindowSeconds != 300*60 ||
+		primary.ResetAtMS == nil || *primary.ResetAtMS != 1800000000*1000 {
+		t.Fatalf("primary window = %#v", primary)
+	}
+	secondary, ok := byID["secondary"]
+	if !ok || secondary.Used == nil || *secondary.Used != 10 || secondary.ResetAtMS != nil {
+		t.Fatalf("secondary window = %#v", secondary)
+	}
+}
+
+func TestNormalizePassiveQuotaWindowsAppliesAllowedFalseAsExhausted(t *testing.T) {
+	windows := NormalizePassiveQuotaWindows(map[string]string{
+		"X-Codex-Primary-Used-Percent": "10",
+		"X-Codex-Allowed":              "false",
+	}, time.Now())
+	if len(windows) != 1 || windows[0].State != "exhausted" {
+		t.Fatalf("windows = %#v, want exhausted primary", windows)
+	}
+}
+
+func TestNormalizePassiveQuotaWindowsComputesResetFromRelativeSeconds(t *testing.T) {
+	observedAt := time.Unix(1000, 0).UTC()
+	windows := NormalizePassiveQuotaWindows(map[string]string{
+		"X-Codex-Primary-Used-Percent":        "5",
+		"X-Codex-Primary-Reset-After-Seconds": "60",
+	}, observedAt)
+	if len(windows) != 1 || windows[0].ResetAtMS == nil || *windows[0].ResetAtMS != 1060*1000 {
+		t.Fatalf("windows = %#v, want reset_at_ms 1060000", windows)
+	}
+}
+
+func TestNormalizePassiveQuotaWindowsRejectsNaNAndInf(t *testing.T) {
+	for _, value := range []string{"NaN", "Inf", "-Inf", "not-a-number"} {
+		windows := NormalizePassiveQuotaWindows(map[string]string{
+			"X-Codex-Primary-Used-Percent": value,
+		}, time.Now())
+		if len(windows) != 0 {
+			t.Fatalf("value %q produced windows = %#v, want none", value, windows)
+		}
+	}
+}
+
+func TestNormalizePassiveQuotaWindowsIgnoresUnrelatedHeaders(t *testing.T) {
+	windows := NormalizePassiveQuotaWindows(map[string]string{
+		"X-Codex-Plan-Type":       "pro",
+		"X-Codex-Credits-Balance": "10",
+		"Retry-After":             "30",
+	}, time.Now())
+	if len(windows) != 0 {
+		t.Fatalf("windows = %#v, want none", windows)
 	}
 }
 

--- a/internal/subscription/providers/codex/observation_test.go
+++ b/internal/subscription/providers/codex/observation_test.go
@@ -45,6 +45,141 @@ func TestNormalizeQuotaNormalizesPlanAndStandardWindows(t *testing.T) {
 	}
 }
 
+func passiveWindowsByID(windows []quotaWindow) map[string]quotaWindow {
+	result := make(map[string]quotaWindow, len(windows))
+	for _, window := range windows {
+		result[window.ID] = window
+	}
+	return result
+}
+
+func TestNormalizePassiveQuotaWindowsMapsAdditionalLimitNamespaces(t *testing.T) {
+	// The same additional limit the active JSON payload reports as
+	// limit_name "GPT 5.3 Codex Spark" arrives on the HTTP path under a short
+	// namespace plus an X-Codex-<ns>-Limit-Name header.
+	windows := NormalizePassiveQuotaWindows(map[string]string{
+		"X-Codex-Primary-Used-Percent":               "20",
+		"X-Codex-Bengalfox-Limit-Name":               "GPT 5.3 Codex Spark",
+		"X-Codex-Bengalfox-Primary-Used-Percent":     "33",
+		"X-Codex-Bengalfox-Primary-Window-Minutes":   "300",
+		"X-Codex-Bengalfox-Secondary-Used-Percent":   "44",
+		"X-Codex-Bengalfox-Secondary-Window-Minutes": "10080",
+	}, time.Now())
+
+	byID := passiveWindowsByID(windows)
+	// Account-scope windows keep working alongside the additional namespace.
+	if _, ok := byID["primary"]; !ok {
+		t.Fatalf("windows = %#v, want the account-scope primary window", windows)
+	}
+	spark, ok := byID["gpt-5-3-codex-spark-primary"]
+	if !ok || spark.Scope != "GPT 5.3 Codex Spark" ||
+		spark.Used == nil || *spark.Used != 33 {
+		t.Fatalf("additional primary window = %#v (all=%#v)", spark, windows)
+	}
+	sparkWeekly, ok := byID["gpt-5-3-codex-spark-secondary"]
+	if !ok || sparkWeekly.Used == nil || *sparkWeekly.Used != 44 {
+		t.Fatalf("additional secondary window = %#v", sparkWeekly)
+	}
+}
+
+func TestNormalizePassiveQuotaWindowsAdditionalIDMatchesActiveJSON(t *testing.T) {
+	// The passive namespace ID must equal the ID the active JSON path builds
+	// for the same limit_name, otherwise the merge silently never applies.
+	raw, err := NormalizeQuota([]byte(`{
+		"plan_type":"pro",
+		"additional_rate_limits":[{
+			"limit_name":"GPT 5.3 Codex Spark",
+			"rate_limit":{"primary_window":{"used_percent":10,"limit_window_seconds":18000}}
+		}]
+	}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var snapshot quotaSnapshot
+	if err := json.Unmarshal(raw, &snapshot); err != nil {
+		t.Fatal(err)
+	}
+	activeIDs := passiveWindowsByID(snapshot.QuotaWindows)
+
+	passive := NormalizePassiveQuotaWindows(map[string]string{
+		"X-Codex-Bengalfox-Limit-Name":           "GPT 5.3 Codex Spark",
+		"X-Codex-Bengalfox-Primary-Used-Percent": "33",
+	}, time.Now())
+	if len(passive) != 1 {
+		t.Fatalf("passive windows = %#v, want exactly one", passive)
+	}
+	if _, ok := activeIDs[passive[0].ID]; !ok {
+		t.Fatalf("passive ID %q not produced by the active JSON path (active=%v)",
+			passive[0].ID, mapKeys(activeIDs))
+	}
+}
+
+func TestNormalizePassiveQuotaWindowsSkipsNamespaceWithoutLimitName(t *testing.T) {
+	// Without a Limit-Name there is no way to build the same stable ID the
+	// active path uses, so the namespace must be ignored entirely.
+	windows := NormalizePassiveQuotaWindows(map[string]string{
+		"X-Codex-Mysteryns-Primary-Used-Percent": "33",
+	}, time.Now())
+	if len(windows) != 0 {
+		t.Fatalf("windows = %#v, want none without a Limit-Name", windows)
+	}
+}
+
+func TestNormalizePassiveQuotaWindowsOmitsLabelMetadata(t *testing.T) {
+	// Labels are derived from the window period, which a partial response may
+	// not carry. Leaving them empty keeps the active observation's metadata.
+	windows := NormalizePassiveQuotaWindows(map[string]string{
+		"X-Codex-Primary-Used-Percent": "50",
+	}, time.Now())
+	if len(windows) != 1 || windows[0].Label != "" || windows[0].LabelKey != "" {
+		t.Fatalf("windows = %#v, want empty Label/LabelKey", windows)
+	}
+}
+
+func TestNormalizePassiveQuotaWindowsRejectsNonPositivePeriodAndReset(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		signal map[string]string
+	}{
+		{"zero reset", map[string]string{"X-Codex-Primary-Used-Percent": "50", "X-Codex-Primary-Reset-At": "0"}},
+		{"zero window", map[string]string{"X-Codex-Primary-Used-Percent": "50", "X-Codex-Primary-Window-Minutes": "0"}},
+		{"overflowing reset", map[string]string{"X-Codex-Primary-Used-Percent": "50", "X-Codex-Primary-Reset-At": "92233720368547758"}},
+		{"negative reset-after", map[string]string{"X-Codex-Primary-Used-Percent": "50", "X-Codex-Primary-Reset-After-Seconds": "-999"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			windows := NormalizePassiveQuotaWindows(test.signal, time.Unix(1000, 0).UTC())
+			if len(windows) != 1 {
+				t.Fatalf("windows = %#v, want one usage-only window", windows)
+			}
+			if windows[0].ResetAtMS != nil {
+				t.Fatalf("reset_at_ms = %d, want nil so a valid stored value is not overwritten", *windows[0].ResetAtMS)
+			}
+			if windows[0].WindowSeconds != nil {
+				t.Fatalf("window_seconds = %d, want nil so a valid stored value is not overwritten", *windows[0].WindowSeconds)
+			}
+		})
+	}
+}
+
+func TestNormalizePassiveQuotaWindowsRejectsOutOfRangeUsedPercent(t *testing.T) {
+	for _, value := range []string{"-1", "101"} {
+		windows := NormalizePassiveQuotaWindows(map[string]string{
+			"X-Codex-Primary-Used-Percent": value,
+		}, time.Now())
+		if len(windows) != 0 {
+			t.Fatalf("used-percent %q produced %#v, want none", value, windows)
+		}
+	}
+}
+
+func mapKeys(values map[string]quotaWindow) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
 func TestNormalizePassiveQuotaWindowsMapsPrimaryAndSecondary(t *testing.T) {
 	observedAt := time.Date(2026, 8, 28, 9, 0, 0, 0, time.UTC)
 	windows := NormalizePassiveQuotaWindows(map[string]string{

--- a/internal/subscription/providers/observation/merge.go
+++ b/internal/subscription/providers/observation/merge.go
@@ -3,13 +3,27 @@ package observation
 // MergeQuotaWindow overlays patch's Header-confirmed fields onto previous,
 // preserving whatever the patch left unset. Both must share the same ID;
 // callers are responsible for matching windows before calling this.
+//
+// Metadata strings are only overwritten when the patch actually carries one:
+// Label, Scope, Unit, and State are required by the stored snapshot, so an
+// empty patch value must never blank a window that already has them. The
+// usage numbers move as one group keyed on Utilization, so a partial patch
+// cannot leave Used and Remaining describing different observations.
 func MergeQuotaWindow(previous, patch QuotaWindow) QuotaWindow {
 	merged := previous
 	merged.ID = patch.ID
-	merged.Label = patch.Label
-	merged.LabelKey = patch.LabelKey
-	merged.Scope = patch.Scope
-	merged.Unit = patch.Unit
+	if patch.Label != "" {
+		merged.Label = patch.Label
+	}
+	if patch.LabelKey != "" {
+		merged.LabelKey = patch.LabelKey
+	}
+	if patch.Scope != "" {
+		merged.Scope = patch.Scope
+	}
+	if patch.Unit != "" {
+		merged.Unit = patch.Unit
+	}
 	if patch.Utilization != nil {
 		merged.Used, merged.Limit = patch.Used, patch.Limit
 		merged.Remaining, merged.Utilization = patch.Remaining, patch.Utilization

--- a/internal/subscription/providers/observation/merge.go
+++ b/internal/subscription/providers/observation/merge.go
@@ -1,0 +1,27 @@
+package observation
+
+// MergeQuotaWindow overlays patch's Header-confirmed fields onto previous,
+// preserving whatever the patch left unset. Both must share the same ID;
+// callers are responsible for matching windows before calling this.
+func MergeQuotaWindow(previous, patch QuotaWindow) QuotaWindow {
+	merged := previous
+	merged.ID = patch.ID
+	merged.Label = patch.Label
+	merged.LabelKey = patch.LabelKey
+	merged.Scope = patch.Scope
+	merged.Unit = patch.Unit
+	if patch.Utilization != nil {
+		merged.Used, merged.Limit = patch.Used, patch.Limit
+		merged.Remaining, merged.Utilization = patch.Remaining, patch.Utilization
+	}
+	if patch.ResetAtMS != nil {
+		merged.ResetAtMS = patch.ResetAtMS
+	}
+	if patch.WindowSeconds != nil {
+		merged.WindowSeconds = patch.WindowSeconds
+	}
+	if patch.State != "" && patch.State != "unknown" {
+		merged.State = patch.State
+	}
+	return merged
+}

--- a/internal/subscription/providers/observation/merge_test.go
+++ b/internal/subscription/providers/observation/merge_test.go
@@ -53,6 +53,36 @@ func TestMergeQuotaWindowAppliesPatchResetAndState(t *testing.T) {
 	}
 }
 
+func TestMergeQuotaWindowKeepsPreviousMetadataWhenPatchOmitsIt(t *testing.T) {
+	previous := QuotaWindow{
+		ID: "primary", Label: "5h", LabelKey: "session", Scope: "account", Unit: "percent",
+		State: "available",
+	}
+	patch := QuotaWindow{ID: "primary", Used: floatPtr(10), Utilization: floatPtr(0.1)}
+
+	merged := MergeQuotaWindow(previous, patch)
+
+	if merged.Label != "5h" || merged.LabelKey != "session" ||
+		merged.Scope != "account" || merged.Unit != "percent" {
+		t.Fatalf("merged metadata = %#v, want previous label/label_key/scope/unit preserved", merged)
+	}
+	if merged.Used == nil || *merged.Used != 10 {
+		t.Fatalf("merged usage = %#v, want the patch value applied", merged.Used)
+	}
+}
+
+func TestMergeQuotaWindowAppliesPatchMetadataWhenPresent(t *testing.T) {
+	previous := QuotaWindow{ID: "primary", Label: "old", LabelKey: "old-key", Scope: "model", Unit: "credits"}
+	patch := QuotaWindow{ID: "primary", Label: "5h", LabelKey: "session", Scope: "account", Unit: "percent"}
+
+	merged := MergeQuotaWindow(previous, patch)
+
+	if merged.Label != "5h" || merged.LabelKey != "session" ||
+		merged.Scope != "account" || merged.Unit != "percent" {
+		t.Fatalf("merged metadata = %#v, want the patch values applied", merged)
+	}
+}
+
 func TestMergeQuotaWindowIgnoresUnknownPatchState(t *testing.T) {
 	previous := QuotaWindow{ID: "primary", State: "exhausted"}
 	patch := QuotaWindow{ID: "primary", State: "unknown"}

--- a/internal/subscription/providers/observation/merge_test.go
+++ b/internal/subscription/providers/observation/merge_test.go
@@ -1,0 +1,65 @@
+package observation
+
+import "testing"
+
+func floatPtr(value float64) *float64 { return &value }
+func int64Ptr(value int64) *int64     { return &value }
+
+func TestMergeQuotaWindowKeepsUnsetFieldsFromPrevious(t *testing.T) {
+	previous := QuotaWindow{
+		ID: "primary", Label: "Session", Scope: "account", Unit: "percent",
+		Used: floatPtr(10), Limit: floatPtr(100), Remaining: floatPtr(90), Utilization: floatPtr(0.1),
+		ResetAtMS: int64Ptr(1000), WindowSeconds: int64Ptr(300), State: "available",
+	}
+	patch := QuotaWindow{
+		ID: "primary", Label: "Session", Scope: "account", Unit: "percent",
+		Used: floatPtr(55), Limit: floatPtr(100), Remaining: floatPtr(45), Utilization: floatPtr(0.55),
+		State: "available",
+	}
+
+	merged := MergeQuotaWindow(previous, patch)
+
+	if *merged.Used != 55 || *merged.Utilization != 0.55 {
+		t.Fatalf("merged usage = %#v", merged)
+	}
+	if merged.ResetAtMS == nil || *merged.ResetAtMS != 1000 {
+		t.Fatalf("merged reset_at_ms = %#v, want preserved 1000", merged.ResetAtMS)
+	}
+	if merged.WindowSeconds == nil || *merged.WindowSeconds != 300 {
+		t.Fatalf("merged window_seconds = %#v, want preserved 300", merged.WindowSeconds)
+	}
+}
+
+func TestMergeQuotaWindowAppliesPatchResetAndState(t *testing.T) {
+	previous := QuotaWindow{
+		ID: "primary", Scope: "account", Unit: "percent",
+		ResetAtMS: int64Ptr(1000), WindowSeconds: int64Ptr(300), State: "available",
+	}
+	patch := QuotaWindow{
+		ID: "primary", Scope: "account", Unit: "percent",
+		ResetAtMS: int64Ptr(2000), State: "exhausted",
+	}
+
+	merged := MergeQuotaWindow(previous, patch)
+
+	if merged.ResetAtMS == nil || *merged.ResetAtMS != 2000 {
+		t.Fatalf("merged reset_at_ms = %#v, want patch 2000", merged.ResetAtMS)
+	}
+	if merged.State != "exhausted" {
+		t.Fatalf("merged state = %q, want exhausted", merged.State)
+	}
+	if merged.WindowSeconds == nil || *merged.WindowSeconds != 300 {
+		t.Fatalf("merged window_seconds = %#v, want preserved 300", merged.WindowSeconds)
+	}
+}
+
+func TestMergeQuotaWindowIgnoresUnknownPatchState(t *testing.T) {
+	previous := QuotaWindow{ID: "primary", State: "exhausted"}
+	patch := QuotaWindow{ID: "primary", State: "unknown"}
+
+	merged := MergeQuotaWindow(previous, patch)
+
+	if merged.State != "exhausted" {
+		t.Fatalf("merged state = %q, want preserved exhausted", merged.State)
+	}
+}

--- a/third_party/cpaembedded/embedded/claude_executor.go
+++ b/third_party/cpaembedded/embedded/claude_executor.go
@@ -168,11 +168,15 @@ func (e *claudeHTTPExecutor) ExecuteCanonical(
 		SourceFormat: format, ResponseFormat: format,
 	})
 	if err != nil {
-		return ExecuteResponse{AppliedReasoningEffort: observation.reasoningEffort()}, normalizeClaudeExecutionError(err)
+		return ExecuteResponse{
+			AppliedReasoningEffort: observation.reasoningEffort(),
+			QuotaSignals:           observation.quotaSignalObservation(),
+		}, normalizeClaudeExecutionError(err)
 	}
 	return ExecuteResponse{
 		Payload: append([]byte(nil), response.Payload...), Headers: response.Headers.Clone(),
 		AppliedReasoningEffort: observation.reasoningEffort(),
+		QuotaSignals:           observation.quotaSignalObservation(),
 	}, nil
 }
 
@@ -231,7 +235,10 @@ func (e *claudeHTTPExecutor) ExecuteStreamCanonical(
 		SourceFormat: format, ResponseFormat: format,
 	})
 	if err != nil {
-		return &ExecuteStreamResponse{AppliedReasoningEffort: observation.reasoningEffort()}, normalizeClaudeExecutionError(err)
+		return &ExecuteStreamResponse{
+			AppliedReasoningEffort: observation.reasoningEffort(),
+			QuotaSignals:           observation.quotaSignalObservation(),
+		}, normalizeClaudeExecutionError(err)
 	}
 	chunks := make(chan ExecuteStreamChunk)
 	go func() {
@@ -251,6 +258,7 @@ func (e *claudeHTTPExecutor) ExecuteStreamCanonical(
 	return &ExecuteStreamResponse{
 		Headers: response.Headers.Clone(), Chunks: chunks,
 		AppliedReasoningEffort: observation.reasoningEffort(),
+		QuotaSignals:           observation.quotaSignalObservation(),
 	}, nil
 }
 

--- a/third_party/cpaembedded/embedded/claude_test.go
+++ b/third_party/cpaembedded/embedded/claude_test.go
@@ -189,6 +189,33 @@ func TestClaudeHTTPExecutorCountsTokensThroughAnthropicUpstream(t *testing.T) {
 	}
 }
 
+func TestClaudeHTTPExecutorStreamCanonicalFacadeCapturesQuotaSignalsOnHandshake(t *testing.T) {
+	transport := claudeRoundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"Content-Type": {"text/event-stream"},
+				"Anthropic-Ratelimit-Unified-5h-Utilization": {"0.4"},
+			},
+			Body:    io.NopCloser(strings.NewReader(claudeExecutionSSE)),
+			Request: request,
+		}, nil
+	})
+	ctx := context.WithValue(t.Context(), "cliproxy.roundtripper", http.RoundTripper(transport))
+	stream, err := NewClaudeHTTPExecutor().ExecuteStreamCanonical(ctx, "credential-one", testClaudeExecutionCredential(), ExecuteRequest{
+		Model: "claude-sonnet-4-5", Format: "claude",
+		Payload: []byte(`{"model":"claude-sonnet-4-5","max_tokens":32,"messages":[{"role":"user","content":"hello"}],"stream":true}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range stream.Chunks {
+	}
+	if stream.QuotaSignals.Signals["Anthropic-Ratelimit-Unified-5h-Utilization"] != "0.4" {
+		t.Fatalf("ExecuteStreamCanonical() QuotaSignals = %#v", stream.QuotaSignals)
+	}
+}
+
 func TestClaudeHTTPExecutorStreamsAllSupportedFormats(t *testing.T) {
 	tests := []struct {
 		format  string
@@ -385,6 +412,80 @@ func TestClaudeHTTPExecutorHonorsRequestCancellation(t *testing.T) {
 	}
 	if requests.Load() != 1 {
 		t.Fatalf("upstream requests = %d, want 1", requests.Load())
+	}
+}
+
+func TestClaudeHTTPExecutorCanonicalFacadeCapturesQuotaSignalsOnSuccessAndError(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantErr    bool
+	}{
+		{
+			name:       "success",
+			statusCode: http.StatusOK,
+			body:       `{"id":"msg-one","type":"message","role":"assistant","model":"claude-sonnet-4-5","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":2,"output_tokens":1}}`,
+		},
+		{
+			name:       "rate limited",
+			statusCode: http.StatusTooManyRequests,
+			body:       `{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}`,
+			wantErr:    true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			transport := claudeRoundTripperFunc(func(request *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: test.statusCode,
+					Header: http.Header{
+						"Content-Type":                               {"application/json"},
+						"Anthropic-Ratelimit-Unified-5h-Status":      {"allowed"},
+						"Anthropic-Ratelimit-Unified-5h-Utilization": {"0.4"},
+					},
+					Body:    io.NopCloser(strings.NewReader(test.body)),
+					Request: request,
+				}, nil
+			})
+			ctx := context.WithValue(t.Context(), "cliproxy.roundtripper", http.RoundTripper(transport))
+			response, err := NewClaudeHTTPExecutor().ExecuteCanonical(ctx, "credential-one", testClaudeExecutionCredential(), ExecuteRequest{
+				Model: "claude-sonnet-4-5", Format: "claude",
+				Payload: []byte(`{"model":"claude-sonnet-4-5","max_tokens":32,"messages":[{"role":"user","content":"hello"}]}`),
+			})
+			if (err != nil) != test.wantErr {
+				t.Fatalf("ExecuteCanonical() error = %v, wantErr %v", err, test.wantErr)
+			}
+			if response.QuotaSignals.Signals["Anthropic-Ratelimit-Unified-5h-Utilization"] != "0.4" ||
+				response.QuotaSignals.ObservedAt.IsZero() {
+				t.Fatalf("ExecuteCanonical() QuotaSignals = %#v", response.QuotaSignals)
+			}
+		})
+	}
+}
+
+func TestClaudeHTTPExecutorCanonicalFacadeSkipsQuotaSignalsForCountTokens(t *testing.T) {
+	transport := claudeRoundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"Content-Type": {"application/json"},
+				"Anthropic-Ratelimit-Unified-5h-Utilization": {"0.4"},
+			},
+			Body:    io.NopCloser(strings.NewReader(`{"input_tokens":7}`)),
+			Request: request,
+		}, nil
+	})
+	ctx := context.WithValue(t.Context(), "cliproxy.roundtripper", http.RoundTripper(transport))
+	response, err := NewClaudeHTTPExecutor().CountTokensCanonical(ctx, "credential-one", testClaudeExecutionCredential(), ExecuteRequest{
+		Model: "claude-sonnet-4-5", Format: "claude",
+		Payload: []byte(`{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"hello"}]}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.QuotaSignals.Signals != nil || !response.QuotaSignals.ObservedAt.IsZero() {
+		t.Fatalf("CountTokensCanonical() unexpectedly captured QuotaSignals = %#v", response.QuotaSignals)
 	}
 }
 

--- a/third_party/cpaembedded/embedded/embedded.go
+++ b/third_party/cpaembedded/embedded/embedded.go
@@ -153,11 +153,20 @@ type ExecuteRequest struct {
 	ProxyFromEnvironment bool
 }
 
+// QuotaSignalObservation is the bounded, provider-filtered quota watermark
+// captured from one execution's upstream response headers. Signals is nil
+// when no supported provider quota header was present.
+type QuotaSignalObservation struct {
+	ObservedAt time.Time
+	Signals    map[string]string
+}
+
 type ExecuteResponse struct {
 	Payload                []byte
 	Headers                http.Header
 	AppliedReasoningEffort string
 	UpstreamRequestPath    string
+	QuotaSignals           QuotaSignalObservation
 }
 
 type ExecuteStreamResponse struct {
@@ -165,6 +174,7 @@ type ExecuteStreamResponse struct {
 	Chunks                 <-chan ExecuteStreamChunk
 	AppliedReasoningEffort string
 	UpstreamRequestPath    string
+	QuotaSignals           QuotaSignalObservation
 }
 
 type ExecuteStreamChunk struct {
@@ -385,12 +395,14 @@ func (e *CodexHTTPExecutor) ExecuteCanonical(ctx context.Context, credentialID s
 		return ExecuteResponse{
 			AppliedReasoningEffort: observation.reasoningEffort(),
 			UpstreamRequestPath:    observation.upstreamRequestPath(),
+			QuotaSignals:           observation.quotaSignalObservation(),
 		}, err
 	}
 	return ExecuteResponse{
 		Payload: append([]byte(nil), response.Payload...), Headers: response.Headers.Clone(),
 		AppliedReasoningEffort: observation.reasoningEffort(),
 		UpstreamRequestPath:    observation.upstreamRequestPath(),
+		QuotaSignals:           observation.quotaSignalObservation(),
 	}, nil
 }
 
@@ -462,6 +474,7 @@ func (e *CodexHTTPExecutor) ExecuteStreamCanonical(ctx context.Context, credenti
 		return &ExecuteStreamResponse{
 			AppliedReasoningEffort: observation.reasoningEffort(),
 			UpstreamRequestPath:    observation.upstreamRequestPath(),
+			QuotaSignals:           observation.quotaSignalObservation(),
 		}, err
 	}
 	chunks := make(chan ExecuteStreamChunk)
@@ -479,6 +492,7 @@ func (e *CodexHTTPExecutor) ExecuteStreamCanonical(ctx context.Context, credenti
 		Headers: response.Headers.Clone(), Chunks: chunks,
 		AppliedReasoningEffort: observation.reasoningEffort(),
 		UpstreamRequestPath:    observation.upstreamRequestPath(),
+		QuotaSignals:           observation.quotaSignalObservation(),
 	}, nil
 }
 
@@ -739,6 +753,9 @@ func (t noRedirectRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 	if err != nil {
 		return nil, err
 	}
+	if t.observation != nil {
+		t.observation.observeQuotaSignals(resp.Header, time.Now())
+	}
 	if resp.StatusCode >= 300 && resp.StatusCode < 400 && resp.Header.Get("Location") != "" {
 		_ = resp.Body.Close()
 		return nil, ErrRedirectNotAllowed
@@ -753,6 +770,7 @@ type executionObservation struct {
 	mu                  sync.RWMutex
 	effort              string
 	observedRequestPath string
+	quota               cliproxyauth.QuotaState
 }
 
 func newExecutionObservation(request ExecuteRequest) *executionObservation {
@@ -824,6 +842,33 @@ func (o *executionObservation) upstreamRequestPath() string {
 	o.mu.RLock()
 	defer o.mu.RUnlock()
 	return o.observedRequestPath
+}
+
+// observeQuotaSignals replaces the captured quota snapshot with the signals
+// carried by one upstream response, using CPA SDK's own provider whitelist,
+// size limits, and control-character filter. A response with no quota signal
+// leaves the previous snapshot untouched, so the last non-empty response
+// within one execution always wins.
+func (o *executionObservation) observeQuotaSignals(header http.Header, observedAt time.Time) {
+	if o == nil {
+		return
+	}
+	o.mu.Lock()
+	o.quota.ObserveResponseHeadersForProvider(o.provider, header, observedAt)
+	o.mu.Unlock()
+}
+
+func (o *executionObservation) quotaSignalObservation() QuotaSignalObservation {
+	if o == nil {
+		return QuotaSignalObservation{}
+	}
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	if len(o.quota.Signals) == 0 {
+		return QuotaSignalObservation{}
+	}
+	clone := o.quota.Clone()
+	return QuotaSignalObservation{ObservedAt: clone.ObservedAt, Signals: clone.Signals}
 }
 
 func exchangeToken(ctx context.Context, values url.Values, options Options) (CodexCredential, error) {

--- a/third_party/cpaembedded/embedded/embedded_test.go
+++ b/third_party/cpaembedded/embedded/embedded_test.go
@@ -117,6 +117,49 @@ func TestExecutionObservationCapturesRequestPathWithoutReasoning(t *testing.T) {
 	}
 }
 
+func TestExecutionObservationCapturesCodexQuotaSignalsAndKeepsLastNonEmpty(t *testing.T) {
+	t.Parallel()
+
+	observation := newProviderExecutionObservation(ExecuteRequest{}, ProviderCodex)
+	first := time.Date(2026, 8, 28, 10, 0, 0, 0, time.UTC)
+	observation.observeQuotaSignals(http.Header{
+		"X-Codex-Primary-Used-Percent": {"42"},
+		"X-Ignored-Header":             {"anything"},
+	}, first)
+	got := observation.quotaSignalObservation()
+	if !got.ObservedAt.Equal(first) || got.Signals["X-Codex-Primary-Used-Percent"] != "42" {
+		t.Fatalf("quotaSignalObservation() = %#v", got)
+	}
+	if _, exists := got.Signals["X-Ignored-Header"]; exists {
+		t.Fatalf("quotaSignalObservation() leaked non-whitelisted header: %#v", got.Signals)
+	}
+
+	// A later response with no quota headers must not clear the prior observation.
+	observation.observeQuotaSignals(http.Header{"Content-Type": {"application/json"}}, first.Add(time.Minute))
+	unchanged := observation.quotaSignalObservation()
+	if !unchanged.ObservedAt.Equal(first) || unchanged.Signals["X-Codex-Primary-Used-Percent"] != "42" {
+		t.Fatalf("empty response cleared observation: %#v", unchanged)
+	}
+
+	// A later response with a fresh signal replaces the snapshot and advances the time.
+	second := first.Add(2 * time.Minute)
+	observation.observeQuotaSignals(http.Header{"X-Codex-Primary-Used-Percent": {"70"}}, second)
+	replaced := observation.quotaSignalObservation()
+	if !replaced.ObservedAt.Equal(second) || replaced.Signals["X-Codex-Primary-Used-Percent"] != "70" {
+		t.Fatalf("newer signal did not replace snapshot: %#v", replaced)
+	}
+}
+
+func TestExecutionObservationIgnoresQuotaSignalsForUnsupportedProvider(t *testing.T) {
+	t.Parallel()
+
+	observation := newProviderExecutionObservation(ExecuteRequest{}, "grok")
+	observation.observeQuotaSignals(http.Header{"X-Codex-Primary-Used-Percent": {"42"}}, time.Now())
+	if got := observation.quotaSignalObservation(); got.Signals != nil {
+		t.Fatalf("unsupported provider captured signals: %#v", got)
+	}
+}
+
 func TestParseCodexCredentialJSONRejectsInvalidOrDangerousInput(t *testing.T) {
 	t.Parallel()
 
@@ -470,6 +513,84 @@ func TestCodexHTTPExecutorKeepsOtherBootstrapErrorsInStream(t *testing.T) {
 	}
 	if streamErr == nil || !strings.Contains(streamErr.Error(), "bad_request") {
 		t.Fatalf("stream error = %v", streamErr)
+	}
+}
+
+func TestCodexHTTPExecutorCanonicalFacadeCapturesQuotaSignalsOnSuccessAndError(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantErr    bool
+	}{
+		{
+			name:       "success",
+			statusCode: http.StatusOK,
+			body:       "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.2\",\"output\":[]}}\n\n",
+		},
+		{
+			name:       "bootstrap error",
+			statusCode: http.StatusOK,
+			body: "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"status\":\"in_progress\"}}\n\n" +
+				"data: {\"type\":\"error\",\"error\":{\"type\":\"service_unavailable_error\",\"code\":\"server_is_overloaded\",\"message\":\"try another credential\"}}\n\n",
+			wantErr: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			transport := claudeRoundTripperFunc(func(request *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: test.statusCode,
+					Header: http.Header{
+						"Content-Type":                   {"text/event-stream"},
+						"X-Codex-Primary-Used-Percent":   {"55"},
+						"X-Codex-Primary-Window-Minutes": {"10080"},
+					},
+					Body:    io.NopCloser(strings.NewReader(test.body)),
+					Request: request,
+				}, nil
+			})
+			ctx := context.WithValue(t.Context(), "cliproxy.roundtripper", http.RoundTripper(transport))
+			response, err := NewCodexHTTPExecutor().ExecuteCanonical(ctx, "credential-one", CodexCredential{
+				Type: ProviderCodex, AccessToken: "access", RefreshToken: "refresh", AccountID: "account-123",
+			}, ExecuteRequest{
+				Model: "gpt-5.2", Payload: []byte(`{"model":"gpt-5.2","input":"hello"}`), Format: "openai-response",
+			})
+			if (err != nil) != test.wantErr {
+				t.Fatalf("ExecuteCanonical() error = %v, wantErr %v", err, test.wantErr)
+			}
+			if response.QuotaSignals.Signals["X-Codex-Primary-Used-Percent"] != "55" || response.QuotaSignals.ObservedAt.IsZero() {
+				t.Fatalf("ExecuteCanonical() QuotaSignals = %#v", response.QuotaSignals)
+			}
+		})
+	}
+}
+
+func TestCodexHTTPExecutorStreamCanonicalFacadeCapturesQuotaSignalsOnHandshake(t *testing.T) {
+	transport := claudeRoundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"Content-Type":                 {"text/event-stream"},
+				"X-Codex-Primary-Used-Percent": {"12"},
+			},
+			Body:    io.NopCloser(strings.NewReader("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5.2\",\"output\":[]}}\n\n")),
+			Request: request,
+		}, nil
+	})
+	ctx := context.WithValue(t.Context(), "cliproxy.roundtripper", http.RoundTripper(transport))
+	stream, err := NewCodexHTTPExecutor().ExecuteStreamCanonical(ctx, "credential-one", CodexCredential{
+		Type: ProviderCodex, AccessToken: "access", RefreshToken: "refresh", AccountID: "account-123",
+	}, ExecuteRequest{
+		Model: "gpt-5.2", Payload: []byte(`{"model":"gpt-5.2","input":"hello"}`), Format: "openai-response",
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStreamCanonical() error = %v", err)
+	}
+	for range stream.Chunks {
+	}
+	if stream.QuotaSignals.Signals["X-Codex-Primary-Used-Percent"] != "12" {
+		t.Fatalf("ExecuteStreamCanonical() QuotaSignals = %#v", stream.QuotaSignals)
 	}
 }
 


### PR DESCRIPTION
### 关联 Issue / Related Issue
Closes #

### 变更内容 / Change Content
- [ ] Bug 修复 / Bug fix
- [x] 新功能 / New feature
- [ ] 其他改动 / Other changes

利用 Codex、Claude 订阅请求已经返回的额度 Header，自动刷新已有账号卡的账号级额度窗口和额度观察时间。方案详见 `docs/plans/2026-08-28-sdk-stage3-passive-quota-observation.md`（本地文档，未入库）。

**数据流**：`third_party/cpaembedded` embedded 层在响应边界复用 CPA SDK 的 Provider 白名单过滤器捕获额度信号 → `internal/execution/cpa` 归一化为与主动观察完全一致的 `QuotaWindow`（复用 Codex/Claude 现有窗口构造器）→ 写入 `internal/subscription.CredentialManager` 的内存 pending map（按账号/窗口合并，版本化精确 ACK）→ `internal/requestlog` worker 复用现有 `quotaWake` 与批次节奏异步落库 → `internal/subscription` 完成字段级合并写入 `credential_observations`，并通过共享的 `state.CredentialRegistry.ApplyQuotaWindows` 投影到 `/api/health` 低额度提示。

**边界**：
- 只更新账号级（`scope=account`）窗口，且只更新目标记录中已存在的同 ID 窗口字段；不存在时忽略，不创建窗口，不新建记录。
- 手动刷新和完整主动观察仍是套餐、账号资料、重置卡及窗口增删的唯一权威；被动更新不改变 `state`、`last_attempt_at_ms`、`last_error_code` 等主动路径元数据。
- 额度仅用于管理面展示，不参与路由、调度、重试、健康判定、冷却、拉黑、权重或计价。
- 不采集 Codex 附加限额窗口（HTTP 短名与 JSON limit_name 恒等性无证据）、不支持 API Key/Antigravity/Grok。

**顺带修复**：`recordCredentialObservationFailure` 与 `invalidateCredentialObservationAfterReset` 此前使用整行 `Save`，会用读取时的旧 `snapshot_json` 覆盖并发落地的被动写入；已改为按列 `Updates`，新增回归测试复现并验证修复。

**架构复用**：pending map 的脏值/ACK/通知形状对齐现有 `accessquota.Runtime`；异步落库复用 RequestLog worker 生命周期与 `quotaWake`（不新增 channel）；额度→Registry 投影复用/收敛为 `state.CredentialRegistry.ApplyQuotaWindows`（`control` 侧同步重构为调用该共享方法，避免逻辑重复）。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。
- [x] 本 PR 范围聚焦，未包含无关改动。
- [x] 我已更新必要的公开文档或发布说明。（无需更新：不涉及 Schema/API/UI 变更）
- [x] 我已确认提交、日志和测试数据不包含敏感信息。
- [x] 如适用，我已说明兼容性或数据迁移影响。（无 Schema 变更，无迁移影响）

### 验证
- `make check` 全绿：gofmt、`go mod tidy -diff`、`go vet`、前端 lint/format/build、`go build`、`go test -count=1 . ./internal/...`（全仓）、`third_party/cpaembedded` 子模块测试、`git diff --check`。
- 本地未运行 `-race`；按仓库约定由远端分支 CI 负责 race 与数据库合同验证。
- 未做真实订阅账号联调（按方案约定不作为本阶段门禁）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增被动配额观测，可从成功、错误及流式响应中捕获配额信号。
  * 支持多种配额窗口、利用率和重置时间，并展示最紧张的账户级配额状态。
  * 支持观测结果合并、缓存及批量保存。

* **改进**
  * 配额观测失败不会影响请求日志保存或覆盖最新数据。
  * 服务关闭时自动排空待处理观测记录。
  * 增强并发写入、异常响应及无效配额数据场景的稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->