### PR TITLE
fix(subscription): 跳过并标记重复账号

### DIFF
--- a/internal/control/credential_connection_duplicates_test.go
+++ b/internal/control/credential_connection_duplicates_test.go
@@ -77,6 +77,108 @@ func TestConnectSubscriptionGroupSkipsExistingAndBatchDuplicateStages(t *testing
 	}
 }
 
+func TestConnectSubscriptionGroupReplacesCredentialThatNeedsReauthorization(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name           string
+		authState      models.CredentialAuthState
+		authErrorCode  string
+		idempotencyKey string
+	}{
+		{
+			name: "reauthorization required", authState: models.CredentialAuthStateReauthorizationRequired,
+			authErrorCode: "refresh_rejected", idempotencyKey: "00000000-0000-4000-8000-00000000d103",
+		},
+		{
+			name: "outcome unknown", authState: models.CredentialAuthStateOutcomeUnknown,
+			authErrorCode: "refresh_outcome_unknown", idempotencyKey: "00000000-0000-4000-8000-00000000d104",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			fixture, groupID, credentialID := newSubscriptionCredentialFixture(t)
+			var before models.Credential
+			if err := fixture.db.First(&before, credentialID).Error; err != nil {
+				t.Fatal(err)
+			}
+			const weight = 37
+			if err := fixture.db.Model(&models.Credential{}).Where("id = ?", credentialID).Updates(map[string]any{
+				"auth_state": test.authState, "auth_error_code": test.authErrorCode,
+				"status": models.CredentialStatusDisabled, "weight_manual": weight,
+			}).Error; err != nil {
+				t.Fatal(err)
+			}
+			stage, err := fixture.service.ImportCredentialStage(t.Context(), channel.Codex, []byte(fmt.Sprintf(
+				`{"type":"codex","access_token":"replacement-access-%s","refresh_token":"replacement-refresh-%s","account_id":"account-observation","email":%q}`,
+				test.authState,
+				test.authState,
+				fmt.Sprintf("replacement-%s@example.com", test.authState),
+			)))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			inspection, err := fixture.service.InspectGroupCredentialConnection(
+				t.Context(), groupID, []string{stage.StageID},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(inspection.DuplicatedStageIDs) != 0 {
+				t.Errorf("inspection duplicates = %v, want none", inspection.DuplicatedStageIDs)
+			}
+
+			result, err := fixture.service.ConnectGroupCredentialsIdempotent(
+				t.Context(), test.idempotencyKey, groupID, []string{stage.StageID},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.CredentialsAdded != 1 || result.CredentialsDuplicated != 0 {
+				t.Errorf("result = %#v", result)
+			}
+			var after models.Credential
+			if err := fixture.db.First(&after, credentialID).Error; err != nil {
+				t.Fatal(err)
+			}
+			if after.Fingerprint == before.Fingerprint || after.Data == before.Data ||
+				after.IdentityFingerprint != before.IdentityFingerprint ||
+				after.SecretVersion != before.SecretVersion+1 ||
+				after.AuthState != models.CredentialAuthStateReady || after.AuthErrorCode != "" {
+				t.Errorf(
+					"replacement state = fingerprint_changed:%t data_changed:%t identity_preserved:%t version:%d auth:%q error:%q",
+					after.Fingerprint != before.Fingerprint,
+					after.Data != before.Data,
+					after.IdentityFingerprint == before.IdentityFingerprint,
+					after.SecretVersion,
+					after.AuthState,
+					after.AuthErrorCode,
+				)
+			}
+			if after.Status != models.CredentialStatusDisabled ||
+				after.WeightManual == nil || *after.WeightManual != weight {
+				t.Errorf("operator settings changed: status=%q weight=%v", after.Status, after.WeightManual)
+			}
+			var credentialCount int64
+			if err := fixture.db.Model(&models.Credential{}).
+				Where("group_id = ?", groupID).Count(&credentialCount).Error; err != nil {
+				t.Fatal(err)
+			}
+			if credentialCount != 1 {
+				t.Errorf("credential count = %d, want 1", credentialCount)
+			}
+			var consumed models.CredentialStage
+			if err := fixture.db.Take(&consumed, "id = ?", stage.StageID).Error; err != nil {
+				t.Fatal(err)
+			}
+			if consumed.Status != models.CredentialStageConsumed || consumed.EncryptedPayload != "" {
+				t.Errorf("stage was not consumed after replacement: %#v", consumed)
+			}
+		})
+	}
+}
+
 func TestInspectSubscriptionConnectionIdentifiesExactDuplicateStages(t *testing.T) {
 	t.Parallel()
 	initControlI18n(t)

--- a/internal/control/credential_connection_duplicates_test.go
+++ b/internal/control/credential_connection_duplicates_test.go
@@ -1,0 +1,128 @@
+package control
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/platform/config"
+	"gpt-load/internal/storage/models"
+)
+
+func TestCreateSubscriptionGroupSkipsDuplicateReadyStageIdentity(t *testing.T) {
+	t.Parallel()
+	fixture := newServiceFixture(t)
+	first := mustImportSubscriptionStage(t, fixture, "create-duplicate", "first@example.com")
+	second := mustImportSubscriptionStage(t, fixture, "create-duplicate", "second@example.com")
+
+	created, err := fixture.service.CreateGroupIdempotent(
+		t.Context(),
+		"00000000-0000-4000-8000-00000000d101",
+		GroupCreateRequest{
+			Name: stringPointer("subscription duplicate create"), ChannelID: channel.Codex,
+			ConnectionType:      models.ConnectionTypeSubscription,
+			Models:              optionalGroupModels{Set: true},
+			StagedCredentialIDs: []string{first.StageID, second.StageID},
+		},
+	)
+	if err != nil {
+		t.Fatalf("CreateGroupIdempotent() error = %v", err)
+	}
+	if created.CredentialsAdded != 1 || created.CredentialsDuplicated != 1 {
+		t.Fatalf("created = %#v", created)
+	}
+}
+
+func TestConnectSubscriptionGroupSkipsExistingAndBatchDuplicateStages(t *testing.T) {
+	t.Parallel()
+	fixture, groupID, _ := newSubscriptionCredentialFixture(t)
+	existing := mustImportSubscriptionStage(t, fixture, "account-observation", "existing@example.com")
+	newFirst := mustImportSubscriptionStage(t, fixture, "connect-new", "new-first@example.com")
+	newSecond := mustImportSubscriptionStage(t, fixture, "connect-new", "new-second@example.com")
+
+	result, err := fixture.service.ConnectGroupCredentialsIdempotent(
+		t.Context(),
+		"00000000-0000-4000-8000-00000000d102",
+		groupID,
+		[]string{existing.StageID, newFirst.StageID, newSecond.StageID},
+	)
+	if err != nil {
+		t.Fatalf("ConnectGroupCredentialsIdempotent() error = %v", err)
+	}
+	if result.CredentialsAdded != 1 || result.CredentialsDuplicated != 2 {
+		t.Fatalf("result = %#v", result)
+	}
+	var credentialCount int64
+	if err := fixture.db.Model(&models.Credential{}).
+		Where("group_id = ?", groupID).Count(&credentialCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if credentialCount != 2 {
+		t.Fatalf("credential count = %d, want 2", credentialCount)
+	}
+	var consumedCount int64
+	if err := fixture.db.Model(&models.CredentialStage{}).
+		Where("id IN ? AND status = ?", []string{existing.StageID, newFirst.StageID, newSecond.StageID}, models.CredentialStageConsumed).
+		Count(&consumedCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if consumedCount != 3 {
+		t.Fatalf("consumed stage count = %d, want 3", consumedCount)
+	}
+}
+
+func TestInspectSubscriptionConnectionIdentifiesExactDuplicateStages(t *testing.T) {
+	t.Parallel()
+	initControlI18n(t)
+	fixture, groupID, _ := newSubscriptionCredentialFixture(t)
+	existing := mustImportSubscriptionStage(t, fixture, "account-observation", "existing@example.com")
+	newFirst := mustImportSubscriptionStage(t, fixture, "inspect-new", "new-first@example.com")
+	newSecond := mustImportSubscriptionStage(t, fixture, "inspect-new", "new-second@example.com")
+	stageIDs := []string{existing.StageID, newFirst.StageID, newSecond.StageID}
+
+	engine := gin.New()
+	const auth = "credential-duplicate-inspection-auth"
+	NewServer(&config.Config{AuthKey: auth}, fixture.service).RegisterRoutes(engine)
+	encoded, err := json.Marshal(CredentialConnectRequest{StagedCredentialIDs: stageIDs})
+	if err != nil {
+		t.Fatal(err)
+	}
+	response := serveCredentialRequest(
+		t,
+		engine,
+		http.MethodPost,
+		fmt.Sprintf("/api/groups/%d/credentials/connect/inspect", groupID),
+		string(encoded),
+		auth,
+		"",
+	)
+	if response.Code != http.StatusOK {
+		t.Fatalf("inspection = %d %s", response.Code, response.Body.String())
+	}
+	var envelope struct {
+		Code int `json:"code"`
+		Data struct {
+			DuplicatedStageIDs []string `json:"duplicated_stage_ids"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{existing.StageID}
+	if newFirst.StageID < newSecond.StageID {
+		want = append(want, newSecond.StageID)
+	} else {
+		want = append(want, newFirst.StageID)
+	}
+	sort.Strings(want)
+	sort.Strings(envelope.Data.DuplicatedStageIDs)
+	if envelope.Code != 0 || !reflect.DeepEqual(envelope.Data.DuplicatedStageIDs, want) {
+		t.Fatalf("inspection = %#v, want duplicate stages %#v", envelope, want)
+	}
+}

--- a/internal/control/credential_connections.go
+++ b/internal/control/credential_connections.go
@@ -52,7 +52,7 @@ func (s *Service) InspectGroupCredentialConnection(
 	if err != nil {
 		return CredentialConnectInspection{}, err
 	}
-	duplicatedStageIDs, err := duplicateCredentialStageIDs(db, groupID, stages)
+	duplicatedStageIDs, _, err := classifyCredentialStages(db, groupID, stages)
 	if err != nil {
 		return CredentialConnectInspection{}, err
 	}

--- a/internal/control/credential_connections.go
+++ b/internal/control/credential_connections.go
@@ -19,8 +19,44 @@ type CredentialConnectRequest struct {
 	StagedCredentialIDs []string `json:"staged_credential_ids"`
 }
 
+type CredentialConnectInspection struct {
+	DuplicatedStageIDs []string `json:"duplicated_stage_ids"`
+}
+
 type credentialConnectDigestBody struct {
 	StagedCredentialIDs []string `json:"staged_credential_ids"`
+}
+
+// InspectGroupCredentialConnection identifies ready stages that the final
+// connection will skip because their subscription identity is already present.
+func (s *Service) InspectGroupCredentialConnection(
+	ctx context.Context,
+	groupID uint,
+	stageIDs []string,
+) (CredentialConnectInspection, error) {
+	normalized, err := normalizeCredentialStageIDs(stageIDs)
+	if groupID == 0 || err != nil {
+		return CredentialConnectInspection{}, app_errors.ErrValidation
+	}
+	db := s.db.WithContext(ctx)
+	group, err := loadGroupRow(db, groupID)
+	if err != nil {
+		return CredentialConnectInspection{}, err
+	}
+	if normalizeGroupConnectionType(group.ConnectionType) != models.ConnectionTypeSubscription {
+		return CredentialConnectInspection{}, app_errors.ErrValidation
+	}
+	stages, err := s.loadConsumableCredentialStages(
+		db, channel.ID(group.ChannelID), group.ConnectionType, normalized, false,
+	)
+	if err != nil {
+		return CredentialConnectInspection{}, err
+	}
+	duplicatedStageIDs, err := duplicateCredentialStageIDs(db, groupID, stages)
+	if err != nil {
+		return CredentialConnectInspection{}, err
+	}
+	return CredentialConnectInspection{DuplicatedStageIDs: duplicatedStageIDs}, nil
 }
 
 // ConnectGroupCredentialsIdempotent consumes subscription stages exactly once
@@ -124,7 +160,7 @@ func (s *Service) connectGroupCredentialsMutation(
 	if normalizeGroupConnectionType(group.ConnectionType) != models.ConnectionTypeSubscription {
 		return CredentialImportResult{}, nil, app_errors.ErrValidation
 	}
-	added, err := s.consumeCredentialStages(
+	added, duplicatedStageIDs, err := s.consumeCredentialStages(
 		tx, group.ID, channel.ID(group.ChannelID), group.ConnectionType, stageIDs,
 	)
 	if err != nil {
@@ -134,5 +170,8 @@ func (s *Service) connectGroupCredentialsMutation(
 	if err != nil {
 		return CredentialImportResult{}, nil, err
 	}
-	return CredentialImportResult{GroupID: groupID, CredentialsAdded: added}, entries, nil
+	return CredentialImportResult{
+		GroupID: groupID, CredentialsAdded: added,
+		CredentialsDuplicated: len(duplicatedStageIDs),
+	}, entries, nil
 }

--- a/internal/control/credential_stages.go
+++ b/internal/control/credential_stages.go
@@ -1316,95 +1316,161 @@ func normalizeCredentialStageIDs(values []string) ([]string, error) {
 	return normalized, nil
 }
 
-// consumeCredentialStages promotes ready subscription credentials and consumes
-// their short-lived stages in the caller's Group-create transaction.
+func (s *Service) loadConsumableCredentialStages(
+	tx *gorm.DB,
+	channelID channel.ID,
+	connectionType models.ConnectionType,
+	stageIDs []string,
+	lock bool,
+) ([]models.CredentialStage, error) {
+	if s == nil || tx == nil || channelID == "" ||
+		connectionType != models.ConnectionTypeSubscription || len(stageIDs) == 0 {
+		return nil, app_errors.ErrValidation
+	}
+	query := tx
+	if lock {
+		query = query.Clauses(clause.Locking{Strength: "UPDATE"})
+	}
+	var stages []models.CredentialStage
+	if err := query.Where("id IN ?", stageIDs).Order("id ASC").Find(&stages).Error; err != nil {
+		return nil, app_errors.ParseDBError(err)
+	}
+	if len(stages) != len(stageIDs) {
+		return nil, app_errors.ErrStagedCredentialNotReady
+	}
+	nowMS := s.now().UnixMilli()
+	for _, stage := range stages {
+		if stage.ChannelID != string(channelID) || stage.ConnectionType != connectionType {
+			return nil, app_errors.ErrStagedCredentialMismatch
+		}
+		switch stage.Status {
+		case models.CredentialStageConsumed:
+			return nil, app_errors.ErrStagedCredentialConsumed
+		case models.CredentialStageReady:
+		default:
+			return nil, app_errors.ErrStagedCredentialNotReady
+		}
+		if nowMS >= stage.ExpiresAtMS {
+			return nil, app_errors.ErrStagedCredentialExpired
+		}
+		if stage.IdentityFingerprint == "" {
+			return nil, app_errors.ErrStagedCredentialMismatch
+		}
+	}
+	return stages, nil
+}
+
+func duplicateCredentialStageIDs(
+	tx *gorm.DB,
+	groupID uint,
+	stages []models.CredentialStage,
+) ([]string, error) {
+	if tx == nil || groupID == 0 || len(stages) == 0 {
+		return nil, app_errors.ErrValidation
+	}
+	identities := make([]string, 0, len(stages))
+	for _, stage := range stages {
+		identities = append(identities, stage.IdentityFingerprint)
+	}
+	var existingIdentities []string
+	if err := tx.Model(&models.Credential{}).
+		Where("group_id = ? AND identity_fingerprint IN ?", groupID, identities).
+		Pluck("identity_fingerprint", &existingIdentities).Error; err != nil {
+		return nil, app_errors.ParseDBError(err)
+	}
+	seen := make(map[string]struct{}, len(existingIdentities)+len(stages))
+	for _, identity := range existingIdentities {
+		seen[identity] = struct{}{}
+	}
+	duplicatedStageIDs := make([]string, 0)
+	for _, stage := range stages {
+		if _, duplicate := seen[stage.IdentityFingerprint]; duplicate {
+			duplicatedStageIDs = append(duplicatedStageIDs, stage.ID)
+			continue
+		}
+		seen[stage.IdentityFingerprint] = struct{}{}
+	}
+	return duplicatedStageIDs, nil
+}
+
+// consumeCredentialStages promotes unique ready subscription credentials and
+// consumes every supplied stage in the caller's transaction. Existing or
+// repeated identities are reported as skipped instead of rejecting the batch.
 func (s *Service) consumeCredentialStages(
 	tx *gorm.DB,
 	groupID uint,
 	channelID channel.ID,
 	connectionType models.ConnectionType,
 	stageIDs []string,
-) (int, error) {
-	if s == nil || s.encryption == nil || tx == nil || groupID == 0 ||
-		connectionType != models.ConnectionTypeSubscription || len(stageIDs) == 0 {
-		return 0, app_errors.ErrValidation
+) (int, []string, error) {
+	if s == nil || s.encryption == nil || tx == nil || groupID == 0 {
+		return 0, nil, app_errors.ErrValidation
 	}
-	var stages []models.CredentialStage
-	if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
-		Where("id IN ?", stageIDs).Order("id ASC").Find(&stages).Error; err != nil {
-		return 0, app_errors.ParseDBError(err)
+	stages, err := s.loadConsumableCredentialStages(
+		tx, channelID, connectionType, stageIDs, true,
+	)
+	if err != nil {
+		return 0, nil, err
 	}
-	if len(stages) != len(stageIDs) {
-		return 0, app_errors.ErrStagedCredentialNotReady
+	duplicatedStageIDs, err := duplicateCredentialStageIDs(tx, groupID, stages)
+	if err != nil {
+		return 0, nil, err
 	}
-	nowMS := s.now().UnixMilli()
-	identities := make(map[string]struct{}, len(stages))
-	for _, stage := range stages {
-		if stage.ChannelID != string(channelID) || stage.ConnectionType != connectionType {
-			return 0, app_errors.ErrStagedCredentialMismatch
-		}
-		switch stage.Status {
-		case models.CredentialStageConsumed:
-			return 0, app_errors.ErrStagedCredentialConsumed
-		case models.CredentialStageReady:
-		default:
-			return 0, app_errors.ErrStagedCredentialNotReady
-		}
-		if nowMS >= stage.ExpiresAtMS {
-			return 0, app_errors.ErrStagedCredentialExpired
-		}
-		if stage.IdentityFingerprint == "" {
-			return 0, app_errors.ErrStagedCredentialMismatch
-		}
-		if _, duplicate := identities[stage.IdentityFingerprint]; duplicate {
-			return 0, app_errors.ErrDuplicateCredentialIdentity
-		}
-		identities[stage.IdentityFingerprint] = struct{}{}
+	duplicated := make(map[string]struct{}, len(duplicatedStageIDs))
+	for _, stageID := range duplicatedStageIDs {
+		duplicated[stageID] = struct{}{}
 	}
 
+	nowMS := s.now().UnixMilli()
+	added := 0
 	for _, stage := range stages {
 		plaintext, err := s.encryption.Decrypt(stage.EncryptedPayload)
 		if err != nil {
-			return 0, app_errors.ErrStagedCredentialMismatch
+			return 0, nil, app_errors.ErrStagedCredentialMismatch
 		}
 		var payload stagedSubscriptionPayload
 		if err := json.Unmarshal([]byte(plaintext), &payload); err != nil {
 			plaintext = ""
-			return 0, app_errors.ErrStagedCredentialMismatch
+			return 0, nil, app_errors.ErrStagedCredentialMismatch
 		}
 		plaintext = ""
 		driver, driverOK := subscriptionsDriver(s.subscriptions, channelID)
 		if !driverOK {
-			return 0, app_errors.ErrStagedCredentialMismatch
+			return 0, nil, app_errors.ErrStagedCredentialMismatch
 		}
 		credential, err := driver.Parse(payload.Credential)
 		if err != nil {
-			return 0, app_errors.ErrStagedCredentialMismatch
+			return 0, nil, app_errors.ErrStagedCredentialMismatch
 		}
 		canonical := credential.Canonical()
 		identity := s.subscriptionIdentityFingerprint(channelID, credential.Identity())
 		if identity != stage.IdentityFingerprint {
 			clear(canonical)
-			return 0, app_errors.ErrStagedCredentialMismatch
+			return 0, nil, app_errors.ErrStagedCredentialMismatch
 		}
-		fingerprint := s.encryption.Hash(string(canonical))
-		ciphertext, err := s.encryption.Encrypt(string(canonical))
-		clear(canonical)
-		if err != nil {
-			return 0, app_errors.ErrInternalServer
-		}
-		row := models.Credential{
-			GroupID: groupID, Data: ciphertext, Fingerprint: fingerprint,
-			IdentityFingerprint: identity, SecretVersion: 1,
-			AuthState: models.CredentialAuthStateReady, Status: models.CredentialStatusActive,
-			CreatedAtMS: nowMS, UpdatedAtMS: nowMS,
-		}
-		if err := tx.Create(&row).Error; err != nil {
-			if app_errors.ParseDBError(err) == app_errors.ErrDuplicateResource {
-				return 0, app_errors.ErrDuplicateCredentialIdentity
+		if _, skip := duplicated[stage.ID]; !skip {
+			fingerprint := s.encryption.Hash(string(canonical))
+			ciphertext, encryptErr := s.encryption.Encrypt(string(canonical))
+			if encryptErr != nil {
+				clear(canonical)
+				return 0, nil, app_errors.ErrInternalServer
 			}
-			return 0, app_errors.ParseDBError(err)
+			row := models.Credential{
+				GroupID: groupID, Data: ciphertext, Fingerprint: fingerprint,
+				IdentityFingerprint: identity, SecretVersion: 1,
+				AuthState: models.CredentialAuthStateReady, Status: models.CredentialStatusActive,
+				CreatedAtMS: nowMS, UpdatedAtMS: nowMS,
+			}
+			if err := tx.Create(&row).Error; err != nil {
+				clear(canonical)
+				if app_errors.ParseDBError(err) == app_errors.ErrDuplicateResource {
+					return 0, nil, app_errors.ErrDuplicateCredentialIdentity
+				}
+				return 0, nil, app_errors.ParseDBError(err)
+			}
+			added++
 		}
+		clear(canonical)
 		result := tx.Model(&models.CredentialStage{}).
 			Where("id = ? AND status = ?", stage.ID, models.CredentialStageReady).
 			Updates(map[string]any{
@@ -1413,13 +1479,13 @@ func (s *Service) consumeCredentialStages(
 				"consumed_group_id": groupID, "updated_at_ms": nowMS,
 			})
 		if result.Error != nil {
-			return 0, app_errors.ParseDBError(result.Error)
+			return 0, nil, app_errors.ParseDBError(result.Error)
 		}
 		if result.RowsAffected != 1 {
-			return 0, app_errors.ErrStagedCredentialConsumed
+			return 0, nil, app_errors.ErrStagedCredentialConsumed
 		}
 	}
-	return len(stages), nil
+	return added, duplicatedStageIDs, nil
 }
 
 func (s *Service) loadCredentialStage(ctx context.Context, stageID string) (models.CredentialStage, error) {

--- a/internal/control/credential_stages.go
+++ b/internal/control/credential_stages.go
@@ -1360,42 +1360,53 @@ func (s *Service) loadConsumableCredentialStages(
 	return stages, nil
 }
 
-func duplicateCredentialStageIDs(
+func classifyCredentialStages(
 	tx *gorm.DB,
 	groupID uint,
 	stages []models.CredentialStage,
-) ([]string, error) {
+) ([]string, map[string]models.Credential, error) {
 	if tx == nil || groupID == 0 || len(stages) == 0 {
-		return nil, app_errors.ErrValidation
+		return nil, nil, app_errors.ErrValidation
 	}
 	identities := make([]string, 0, len(stages))
 	for _, stage := range stages {
 		identities = append(identities, stage.IdentityFingerprint)
 	}
-	var existingIdentities []string
-	if err := tx.Model(&models.Credential{}).
+	var existingRows []models.Credential
+	if err := tx.Select("id", "identity_fingerprint", "secret_version", "auth_state").
 		Where("group_id = ? AND identity_fingerprint IN ?", groupID, identities).
-		Pluck("identity_fingerprint", &existingIdentities).Error; err != nil {
-		return nil, app_errors.ParseDBError(err)
+		Find(&existingRows).Error; err != nil {
+		return nil, nil, app_errors.ParseDBError(err)
 	}
-	seen := make(map[string]struct{}, len(existingIdentities)+len(stages))
-	for _, identity := range existingIdentities {
-		seen[identity] = struct{}{}
+	seen := make(map[string]struct{}, len(existingRows)+len(stages))
+	replaceable := make(map[string]models.Credential)
+	for _, row := range existingRows {
+		switch row.AuthState {
+		case models.CredentialAuthStateReauthorizationRequired,
+			models.CredentialAuthStateOutcomeUnknown:
+			replaceable[row.IdentityFingerprint] = row
+		default:
+			seen[row.IdentityFingerprint] = struct{}{}
+		}
 	}
 	duplicatedStageIDs := make([]string, 0)
+	replacements := make(map[string]models.Credential)
 	for _, stage := range stages {
 		if _, duplicate := seen[stage.IdentityFingerprint]; duplicate {
 			duplicatedStageIDs = append(duplicatedStageIDs, stage.ID)
 			continue
 		}
 		seen[stage.IdentityFingerprint] = struct{}{}
+		if row, ok := replaceable[stage.IdentityFingerprint]; ok {
+			replacements[stage.ID] = row
+		}
 	}
-	return duplicatedStageIDs, nil
+	return duplicatedStageIDs, replacements, nil
 }
 
-// consumeCredentialStages promotes unique ready subscription credentials and
-// consumes every supplied stage in the caller's transaction. Existing or
-// repeated identities are reported as skipped instead of rejecting the batch.
+// consumeCredentialStages creates new credentials, repairs credentials that
+// require reauthorization, and consumes every supplied stage in the caller's
+// transaction. Existing healthy or repeated identities are reported as skipped.
 func (s *Service) consumeCredentialStages(
 	tx *gorm.DB,
 	groupID uint,
@@ -1412,7 +1423,7 @@ func (s *Service) consumeCredentialStages(
 	if err != nil {
 		return 0, nil, err
 	}
-	duplicatedStageIDs, err := duplicateCredentialStageIDs(tx, groupID, stages)
+	duplicatedStageIDs, replacements, err := classifyCredentialStages(tx, groupID, stages)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -1455,18 +1466,44 @@ func (s *Service) consumeCredentialStages(
 				clear(canonical)
 				return 0, nil, app_errors.ErrInternalServer
 			}
-			row := models.Credential{
-				GroupID: groupID, Data: ciphertext, Fingerprint: fingerprint,
-				IdentityFingerprint: identity, SecretVersion: 1,
-				AuthState: models.CredentialAuthStateReady, Status: models.CredentialStatusActive,
-				CreatedAtMS: nowMS, UpdatedAtMS: nowMS,
-			}
-			if err := tx.Create(&row).Error; err != nil {
-				clear(canonical)
-				if app_errors.ParseDBError(err) == app_errors.ErrDuplicateResource {
-					return 0, nil, app_errors.ErrDuplicateCredentialIdentity
+			if existing, replace := replacements[stage.ID]; replace {
+				updated := tx.Model(&models.Credential{}).
+					Where(
+						"id = ? AND group_id = ? AND identity_fingerprint = ? AND secret_version = ? AND auth_state IN ?",
+						existing.ID, groupID, identity, existing.SecretVersion,
+						[]models.CredentialAuthState{
+							models.CredentialAuthStateReauthorizationRequired,
+							models.CredentialAuthStateOutcomeUnknown,
+						},
+					).
+					Updates(map[string]any{
+						"data": ciphertext, "fingerprint": fingerprint,
+						"secret_version": existing.SecretVersion + 1,
+						"auth_state":     models.CredentialAuthStateReady, "auth_error_code": "",
+						"updated_at_ms": nowMS,
+					})
+				if updated.Error != nil {
+					clear(canonical)
+					return 0, nil, app_errors.ParseDBError(updated.Error)
 				}
-				return 0, nil, app_errors.ParseDBError(err)
+				if updated.RowsAffected != 1 {
+					clear(canonical)
+					return 0, nil, app_errors.ErrCredentialVersionConflict
+				}
+			} else {
+				row := models.Credential{
+					GroupID: groupID, Data: ciphertext, Fingerprint: fingerprint,
+					IdentityFingerprint: identity, SecretVersion: 1,
+					AuthState: models.CredentialAuthStateReady, Status: models.CredentialStatusActive,
+					CreatedAtMS: nowMS, UpdatedAtMS: nowMS,
+				}
+				if err := tx.Create(&row).Error; err != nil {
+					clear(canonical)
+					if app_errors.ParseDBError(err) == app_errors.ErrDuplicateResource {
+						return 0, nil, app_errors.ErrDuplicateCredentialIdentity
+					}
+					return 0, nil, app_errors.ParseDBError(err)
+				}
 			}
 			added++
 		}

--- a/internal/control/group_create.go
+++ b/internal/control/group_create.go
@@ -121,13 +121,15 @@ func (s *Service) CreateGroup(ctx context.Context, request GroupCreateRequest) (
 		result.GroupID = group.ID
 		result.GroupName = group.Name
 		if normalized.connectionType == models.ConnectionTypeSubscription {
-			result.CredentialsAdded, err = s.consumeCredentialStages(
+			var duplicatedStageIDs []string
+			result.CredentialsAdded, duplicatedStageIDs, err = s.consumeCredentialStages(
 				tx,
 				group.ID,
 				normalized.channelID,
 				normalized.connectionType,
 				normalized.stagedCredentialIDs,
 			)
+			result.CredentialsDuplicated = len(duplicatedStageIDs)
 		} else {
 			result.CredentialsAdded, result.CredentialsDuplicated, err =
 				s.persistCredentials(tx, group.ID, normalized.credentials)

--- a/internal/control/group_idempotency.go
+++ b/internal/control/group_idempotency.go
@@ -137,13 +137,15 @@ func (s *Service) CreateGroupIdempotent(
 			added := 0
 			duplicated := 0
 			if normalized.connectionType == models.ConnectionTypeSubscription {
-				added, err = s.consumeCredentialStages(
+				var duplicatedStageIDs []string
+				added, duplicatedStageIDs, err = s.consumeCredentialStages(
 					tx,
 					group.ID,
 					normalized.channelID,
 					normalized.connectionType,
 					normalized.stagedCredentialIDs,
 				)
+				duplicated = len(duplicatedStageIDs)
 			} else {
 				added, duplicated, err = s.persistCredentials(tx, group.ID, normalized.credentials)
 			}

--- a/internal/control/http_routes.go
+++ b/internal/control/http_routes.go
@@ -372,6 +372,12 @@ func (s *Server) HTTPModule() httproute.Module {
 				s.handleImportGroupCredentials,
 			),
 			controlRoute(
+				"control.group-credentials.connect.inspect",
+				http.MethodPost,
+				"/groups/:group_id/credentials/connect/inspect",
+				s.handleInspectGroupCredentialConnection,
+			),
+			controlRoute(
 				"control.group-credentials.connect",
 				http.MethodPost,
 				"/groups/:group_id/credentials/connect",

--- a/internal/control/server.go
+++ b/internal/control/server.go
@@ -728,6 +728,26 @@ func (s *Server) handleConnectGroupCredentials(c *gin.Context) {
 	response.SuccessI18n(c, "common.success", result)
 }
 
+func (s *Server) handleInspectGroupCredentialConnection(c *gin.Context) {
+	id, ok := groupID(c, "inspect_group_credential_connection")
+	if !ok {
+		return
+	}
+	var request CredentialConnectRequest
+	if err := bindStrictJSON(c, &request); err != nil {
+		writeServiceError(c, "inspect_group_credential_connection", mapControlJSONError(err))
+		return
+	}
+	result, err := s.service.InspectGroupCredentialConnection(
+		c.Request.Context(), id, request.StagedCredentialIDs,
+	)
+	if err != nil {
+		writeServiceError(c, "inspect_group_credential_connection", err)
+		return
+	}
+	response.SuccessI18n(c, "common.success", result)
+}
+
 func (s *Server) handleDiscoverGroupModels(c *gin.Context) {
 	id, ok := groupID(c, "discover_group_models")
 	if !ok {

--- a/web/src/app/resources/credential-stages.ts
+++ b/web/src/app/resources/credential-stages.ts
@@ -4,6 +4,7 @@ import { InvalidResponseError } from '@/api/errors'
 
 import {
   assertNoSecretLikeFields,
+  projectArray,
   projectEpochMilliseconds,
   projectEnum,
   projectHTTPURL,
@@ -39,6 +40,11 @@ export interface CredentialStage {
   account: CredentialStageAccount
   expires_at_ms: number
   error_code?: string
+  duplicate?: boolean
+}
+
+export interface CredentialConnectInspection {
+  duplicated_stage_ids: string[]
 }
 
 export interface CredentialConnectResult {
@@ -152,6 +158,14 @@ function projectConnectResult(value: unknown): CredentialConnectResult {
   }
 }
 
+function projectConnectInspection(value: unknown): CredentialConnectInspection {
+  const record = projectRecord(value)
+  assertNoSecretLikeFields(record, ['duplicated_stage_ids'])
+  const duplicatedStageIDs = projectArray(record.duplicated_stage_ids, projectStageID)
+  if (new Set(duplicatedStageIDs).size !== duplicatedStageIDs.length) invalidResponse()
+  return { duplicated_stage_ids: duplicatedStageIDs }
+}
+
 export async function beginCredentialAuthorization(
   client: ApiClient,
   channelID: string,
@@ -250,5 +264,24 @@ export async function connectGroupCredentials(
     }),
   )
   if (result.group_id !== groupID) invalidResponse()
+  return result
+}
+
+export async function inspectGroupCredentialConnection(
+  client: ApiClient,
+  groupID: number,
+  stageIDs: string[],
+  signal?: AbortSignal,
+): Promise<CredentialConnectInspection> {
+  const requestedStageIDs = stageIDs.map(projectStageID)
+  const requested = new Set(requestedStageIDs)
+  const result = projectConnectInspection(
+    await client.request(`/api/groups/${groupID}/credentials/connect/inspect`, {
+      method: 'POST',
+      json: { staged_credential_ids: requestedStageIDs },
+      signal,
+    }),
+  )
+  if (result.duplicated_stage_ids.some((stageID) => !requested.has(stageID))) invalidResponse()
   return result
 }

--- a/web/src/features/groups/credentials/GroupCredentialsTab.vue
+++ b/web/src/features/groups/credentials/GroupCredentialsTab.vue
@@ -978,19 +978,23 @@ async function inspectConnectionStages(signature: string, stageIDs: string[]): P
       stageIDs,
       controller.signal,
     )
+    const inspectedStageIDs = new Set(stageIDs)
     if (
       controller.signal.aborted ||
       owner !== connectionInspectionOwner ||
-      readyConnectionSignature(connectionStages.value) !== signature
+      readyConnectionSignature(
+        connectionStages.value.filter(({ stage_id }) => inspectedStageIDs.has(stage_id)),
+      ) !== signature
     ) {
       return
     }
     const duplicated = new Set(result.duplicated_stage_ids)
     inspectedConnectionSignature.value = signature
-    connectionStages.value = connectionStages.value.map((stage) => ({
-      ...stage,
-      duplicate: duplicated.has(stage.stage_id),
-    }))
+    connectionStages.value = connectionStages.value.map((stage) =>
+      inspectedStageIDs.has(stage.stage_id)
+        ? { ...stage, duplicate: duplicated.has(stage.stage_id) }
+        : stage,
+    )
   } catch (cause) {
     if (controller.signal.aborted || owner !== connectionInspectionOwner) return
     connectFeedback.value = t(
@@ -1057,7 +1061,7 @@ async function saveConnectedAccounts(): Promise<void> {
   const ready = connectionStages.value.filter(
     ({ status, expires_at_ms }) => status === 'ready' && expires_at_ms > now,
   )
-  const signature = readyConnectionSignature(connectionStages.value)
+  const signature = readyConnectionSignature(ready)
   if (ready.length === 0 || signature === undefined) {
     if (connectionStages.value.some(({ status }) => status === 'ready')) {
       connectionStages.value = connectionStages.value.map((stage) =>

--- a/web/src/features/groups/credentials/GroupCredentialsTab.vue
+++ b/web/src/features/groups/credentials/GroupCredentialsTab.vue
@@ -10,7 +10,7 @@ import {
   Search,
 } from '@lucide/vue'
 import { useQuery, useQueryClient } from '@tanstack/vue-query'
-import { computed, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 
@@ -41,7 +41,11 @@ import {
   refreshCredentialObservation,
   updateCredential,
 } from '@/app/resources/credentials'
-import { connectGroupCredentials, type CredentialStage } from '@/app/resources/credential-stages'
+import {
+  connectGroupCredentials,
+  inspectGroupCredentialConnection,
+  type CredentialStage,
+} from '@/app/resources/credential-stages'
 import { groupDetailLocation, importLocation } from '@/app/route-locations'
 import { controlQueryKeys } from '@/app/query-keys'
 import { useToast } from '@/app/toast'
@@ -132,6 +136,11 @@ const connectionStages = ref<CredentialStage[]>([])
 const connectOperationKey = ref<string>()
 // 抽屉打开时列表区被遮住，连接失败的提示必须落在抽屉内部才看得见。
 const connectFeedback = ref('')
+const connectionInspectionPending = ref(false)
+const inspectedConnectionSignature = ref('')
+const inspectingConnectionSignature = ref('')
+let connectionInspectionController: AbortController | undefined
+let connectionInspectionOwner = 0
 const copyControllers = useAbortControllerPool()
 const searchDebounce = useDebouncedAction(250)
 const collection = computed(() => credentialsQuery.data.value)
@@ -931,18 +940,89 @@ const readyConnectionStages = computed(() =>
   connectionStages.value.filter(({ status }) => status === 'ready'),
 )
 
+function readyConnectionSignature(stages: CredentialStage[]): string | undefined {
+  const now = Date.now()
+  if (
+    stages.length === 0 ||
+    !stages.every(({ status, expires_at_ms }) => status === 'ready' && expires_at_ms > now)
+  ) {
+    return undefined
+  }
+  return stages
+    .map(({ stage_id }) => stage_id)
+    .sort()
+    .join(',')
+}
+
+function resetConnectionInspection(): void {
+  connectionInspectionOwner += 1
+  connectionInspectionController?.abort()
+  connectionInspectionController = undefined
+  connectionInspectionPending.value = false
+  inspectedConnectionSignature.value = ''
+  inspectingConnectionSignature.value = ''
+}
+
+async function inspectConnectionStages(signature: string, stageIDs: string[]): Promise<void> {
+  connectionInspectionController?.abort()
+  const controller = new AbortController()
+  const owner = ++connectionInspectionOwner
+  connectionInspectionController = controller
+  connectionInspectionPending.value = true
+  inspectingConnectionSignature.value = signature
+  connectFeedback.value = ''
+  try {
+    const result = await inspectGroupCredentialConnection(
+      client,
+      props.groupId,
+      stageIDs,
+      controller.signal,
+    )
+    if (
+      controller.signal.aborted ||
+      owner !== connectionInspectionOwner ||
+      readyConnectionSignature(connectionStages.value) !== signature
+    ) {
+      return
+    }
+    const duplicated = new Set(result.duplicated_stage_ids)
+    inspectedConnectionSignature.value = signature
+    connectionStages.value = connectionStages.value.map((stage) => ({
+      ...stage,
+      duplicate: duplicated.has(stage.stage_id),
+    }))
+  } catch (cause) {
+    if (controller.signal.aborted || owner !== connectionInspectionOwner) return
+    connectFeedback.value = t(
+      presentSubscriptionErrorKey(cause, 'group.credentials.subscription.connectFailed'),
+    )
+  } finally {
+    if (owner === connectionInspectionOwner) {
+      connectionInspectionController = undefined
+      connectionInspectionPending.value = false
+      inspectingConnectionSignature.value = ''
+    }
+  }
+}
+
 // 授权就绪即写入，省掉一次多余的确认点击。同时发起多个授权时等全部落定
-// 再一次性写入，避免第一个完成就把抽屉关掉；有失败的暂存时不自动写入，
-// 让用户先处理那一条。
+// 再一次性写入，避免第一个完成就把抽屉关掉。写入前先标出将跳过的重复账号；
+// 有失败的暂存时不自动写入，让用户先处理那一条。
 watch(
   connectionStages,
   (stages) => {
     if (!connectionWorkspaceOpen.value || connectBusy.value || stages.length === 0) return
-    const now = Date.now()
-    if (!stages.every(({ status, expires_at_ms }) => status === 'ready' && expires_at_ms > now)) {
+    const signature = readyConnectionSignature(stages)
+    if (!signature) return
+    if (inspectedConnectionSignature.value !== signature) {
+      if (inspectingConnectionSignature.value !== signature) {
+        void inspectConnectionStages(
+          signature,
+          stages.map(({ stage_id }) => stage_id),
+        )
+      }
       return
     }
-    const signature = stages.map(({ stage_id }) => stage_id).join(',')
     if (autoWrittenSignatures.has(signature)) return
     autoWrittenSignatures.add(signature)
     void saveConnectedAccounts()
@@ -952,6 +1032,7 @@ watch(
 
 // 抽屉自己管理焦点与滚动，这里只负责重置暂存状态。
 function openConnectionWorkspace(): void {
+  resetConnectionInspection()
   connectionStages.value = []
   connectOperationKey.value = undefined
   connectFeedback.value = ''
@@ -963,6 +1044,7 @@ function setConnectionWorkspace(open: boolean): void {
   if (!open && connectBusy.value) return
   connectionWorkspaceOpen.value = open
   if (!open) {
+    resetConnectionInspection()
     connectionStages.value = []
     connectOperationKey.value = undefined
     connectFeedback.value = ''
@@ -975,8 +1057,9 @@ async function saveConnectedAccounts(): Promise<void> {
   const ready = connectionStages.value.filter(
     ({ status, expires_at_ms }) => status === 'ready' && expires_at_ms > now,
   )
-  if (ready.length === 0 || connectBusy.value) {
-    if (!connectBusy.value && connectionStages.value.some(({ status }) => status === 'ready')) {
+  const signature = readyConnectionSignature(connectionStages.value)
+  if (ready.length === 0 || signature === undefined) {
+    if (connectionStages.value.some(({ status }) => status === 'ready')) {
       connectionStages.value = connectionStages.value.map((stage) =>
         stage.status === 'ready' && stage.expires_at_ms <= now
           ? { ...stage, status: 'expired' }
@@ -986,6 +1069,17 @@ async function saveConnectedAccounts(): Promise<void> {
     }
     return
   }
+  if (connectBusy.value || connectionInspectionPending.value) return
+  if (inspectedConnectionSignature.value !== signature) {
+    void inspectConnectionStages(
+      signature,
+      ready.map(({ stage_id }) => stage_id),
+    )
+    return
+  }
+  const duplicatedAccounts = ready
+    .filter(({ duplicate }) => duplicate)
+    .map(({ account }) => account.email_mask || t('import.subscription.pendingAccount'))
   connectFeedback.value = ''
   let succeeded = false
   setPending(0, 'connect', true)
@@ -1006,11 +1100,14 @@ async function saveConnectedAccounts(): Promise<void> {
     toast.show({
       message: t(
         result.credentials_duplicated > 0
-          ? 'group.credentials.subscription.connectDuplicated'
+          ? duplicatedAccounts.length === result.credentials_duplicated
+            ? 'group.credentials.subscription.connectDuplicatedAccounts'
+            : 'group.credentials.subscription.connectDuplicated'
           : 'group.credentials.subscription.connectSucceeded',
         {
           added: n(result.credentials_added),
           duplicated: n(result.credentials_duplicated),
+          accounts: duplicatedAccounts.join(', '),
         },
       ),
       tone: result.credentials_added === 0 ? 'warning' : 'success',
@@ -1026,6 +1123,8 @@ async function saveConnectedAccounts(): Promise<void> {
     if (succeeded) setConnectionWorkspace(false)
   }
 }
+
+onBeforeUnmount(resetConnectionInspection)
 
 async function reconcileBatch(
   action: 'enable' | 'disable' | 'delete',
@@ -1273,8 +1372,8 @@ async function runBatch(
         </AppButton>
         <AppButton
           size="compact"
-          :busy="connectBusy"
-          :disabled="readyConnectionStages.length === 0"
+          :busy="connectBusy || connectionInspectionPending"
+          :disabled="readyConnectionStages.length === 0 || connectionInspectionPending"
           @click="saveConnectedAccounts"
         >
           {{

--- a/web/src/features/import/SubscriptionCredentialStager.vue
+++ b/web/src/features/import/SubscriptionCredentialStager.vue
@@ -110,6 +110,7 @@ function replaceStage(stage: CredentialStage): void {
         authorization_method: stage.authorization_method ?? existing.authorization_method,
         user_code: stage.user_code ?? existing.user_code,
         next_poll_at_ms: stage.next_poll_at_ms ?? existing.next_poll_at_ms,
+        duplicate: stage.duplicate ?? existing.duplicate,
       }
     : stage
   const index = props.modelValue.findIndex((item) => item.stage_id === stage.stage_id)
@@ -445,6 +446,7 @@ async function removeStage(stage: CredentialStage): Promise<void> {
 }
 
 function statusTone(stage: CredentialStage): 'success' | 'warning' | 'danger' | 'neutral' {
+  if (stage.duplicate) return 'warning'
   if (stage.status === 'ready') return 'success'
   if (stage.status === 'pending_authorization' || stage.status === 'exchanging') return 'warning'
   if (stage.status === 'consumed') return 'neutral'
@@ -592,18 +594,27 @@ onBeforeUnmount(() => {
               stage.account.email_mask || t('import.subscription.pendingAccount')
             }}</strong>
             <span v-if="stage.status === 'ready'">
-              {{ t(`import.subscription.readyNotice.${context}`) }} ·
-              {{ t('import.subscription.expires') }}
-              <AppRelativeTime
-                :instant="stage.expires_at_ms"
-                :locale="locale"
-                :empty-label="t('import.subscription.unknown')"
-                hint
-              />
+              <template v-if="stage.duplicate">
+                {{ t('import.subscription.duplicateNotice') }}
+              </template>
+              <template v-else>
+                {{ t(`import.subscription.readyNotice.${context}`) }} ·
+                {{ t('import.subscription.expires') }}
+                <AppRelativeTime
+                  :instant="stage.expires_at_ms"
+                  :locale="locale"
+                  :empty-label="t('import.subscription.unknown')"
+                  hint
+                />
+              </template>
             </span>
           </div>
           <StatusBadge :tone="statusTone(stage)" size="compact">
-            {{ t(`import.subscription.status.${stage.status}`) }}
+            {{
+              stage.duplicate
+                ? t('import.subscription.duplicateStatus')
+                : t(`import.subscription.status.${stage.status}`)
+            }}
           </StatusBadge>
           <AppButton
             variant="ghost"

--- a/web/src/features/import/SubscriptionCredentialStager.vue
+++ b/web/src/features/import/SubscriptionCredentialStager.vue
@@ -446,7 +446,7 @@ async function removeStage(stage: CredentialStage): Promise<void> {
 }
 
 function statusTone(stage: CredentialStage): 'success' | 'warning' | 'danger' | 'neutral' {
-  if (stage.duplicate) return 'warning'
+  if (stage.status === 'ready' && stage.duplicate) return 'warning'
   if (stage.status === 'ready') return 'success'
   if (stage.status === 'pending_authorization' || stage.status === 'exchanging') return 'warning'
   if (stage.status === 'consumed') return 'neutral'
@@ -611,7 +611,7 @@ onBeforeUnmount(() => {
           </div>
           <StatusBadge :tone="statusTone(stage)" size="compact">
             {{
-              stage.duplicate
+              stage.status === 'ready' && stage.duplicate
                 ? t('import.subscription.duplicateStatus')
                 : t(`import.subscription.status.${stage.status}`)
             }}

--- a/web/src/i18n/locales/en-US/group.ts
+++ b/web/src/i18n/locales/en-US/group.ts
@@ -384,6 +384,7 @@ export default {
         connectFailed: 'Unable to add the account to this group',
         connectSucceeded: 'Connected {added} account(s)',
         connectDuplicated: 'Connected {added} account(s), skipped {duplicated} already present',
+        connectDuplicatedAccounts: 'Connected {added} account(s); skipped: {accounts}',
         sync: 'Sync',
         syncingQuota: 'Syncing quota information',
         searchPlaceholder: 'Account, email, or mask',

--- a/web/src/i18n/locales/en-US/import.ts
+++ b/web/src/i18n/locales/en-US/import.ts
@@ -133,6 +133,8 @@ export default {
         create: 'Written in when the group is created',
         connect: 'Ready — will join this group',
       },
+      duplicateNotice: 'Already in this group and will be skipped',
+      duplicateStatus: 'Already added',
       manualHint:
         'A local deployment finishes on its own. For a remote deployment where the browser cannot reach {redirectUri}, authorize with the link below and paste back the final browser URL.',
       deviceInstructions:

--- a/web/src/i18n/locales/ja-JP/group.ts
+++ b/web/src/i18n/locales/ja-JP/group.ts
@@ -386,6 +386,8 @@ export default {
         connectSucceeded: '{added} 件のアカウントを接続しました',
         connectDuplicated:
           '{added} 件のアカウントを接続し、既存の {duplicated} 件をスキップしました',
+        connectDuplicatedAccounts:
+          '{added} 件を接続し、次の既存アカウントをスキップしました：{accounts}',
         sync: '同期',
         syncingQuota: 'クォータ情報を同期中',
         searchPlaceholder: 'アカウント、メール、またはマスク',

--- a/web/src/i18n/locales/ja-JP/import.ts
+++ b/web/src/i18n/locales/ja-JP/import.ts
@@ -130,6 +130,8 @@ export default {
         create: 'グループ作成時に書き込まれます',
         connect: '準備完了 — このグループに追加されます',
       },
+      duplicateNotice: 'このグループに既に存在するため、今回はスキップされます',
+      duplicateStatus: '追加済み',
       manualHint:
         'ローカル配置では自動的に完了します。リモート配置でブラウザーから {redirectUri} に到達できない場合は、下のリンクで認証し、ブラウザーが最後に表示した完全な URL を貼り付けてください。',
       deviceInstructions:

--- a/web/src/i18n/locales/zh-CN/group.ts
+++ b/web/src/i18n/locales/zh-CN/group.ts
@@ -373,6 +373,7 @@ export default {
         connectFailed: '无法将账号添加到当前分组',
         connectSucceeded: '已连接 {added} 个账号',
         connectDuplicated: '已连接 {added} 个账号，跳过 {duplicated} 个已存在的账号',
+        connectDuplicatedAccounts: '已连接 {added} 个账号，已跳过：{accounts}',
         sync: '同步',
         syncingQuota: '正在同步额度信息',
         searchPlaceholder: '账号、邮箱或掩码',

--- a/web/src/i18n/locales/zh-CN/import.ts
+++ b/web/src/i18n/locales/zh-CN/import.ts
@@ -123,6 +123,8 @@ export default {
         create: '创建分组时写入',
         connect: '已就绪，将加入当前分组',
       },
+      duplicateNotice: '已存在于当前分组，本次将跳过',
+      duplicateStatus: '已存在',
       manualHint:
         '本机部署会自动完成。远程部署若浏览器无法访问 {redirectUri}，请打开下面的链接授权，再粘贴浏览器最终停留的完整网址。',
       deviceInstructions: '打开授权链接并输入用户码；请保持此页面开启，授权完成后会自动继续。',


### PR DESCRIPTION
### 关联 Issue / Related Issue

无关联 Issue / N/A

### 变更内容 / Change Content

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

- 订阅凭据连接时跳过目标分组中已存在的账号以及同批次重复账号，继续原子写入其余新账号，并返回准确的新增/重复数量。
- 新增连接前重复检查，在账号完成授权后按 Stage 标出“已存在，本次将跳过”，不改变现有 Stage → Connect 流程、账号卡片结构或 CSS。
- 导入成功提示列出被跳过的脱敏账号，保留现有自动连接、幂等重试和批量交互。
- 增加新建分组、已有分组混合批次及精确重复 Stage 识别的后端回归测试。

验证：

- `make check`

兼容性：新增只读检查接口，不涉及数据迁移；API Key 导入行为保持不变；无需更新公开文档或发布说明。

### 自查清单 / Checklist

- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 连接订阅账号前可预览重复账号，避免重复添加。
  * 重复账号将自动跳过，其余账号继续正常连接。
  * 连接结果显示新增与跳过的账号数量及名称。
  * 暂存凭据明确标记“已添加”状态，并支持多语言提示。
  * 检查未完成或已过期时，将阻止继续连接。
  * 对需要重新授权的账号自动更新凭据并恢复可用状态。

* **测试**
  * 补充重复账号、批量连接及检查结果相关测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->