### PR TITLE
chore(deps): 更新 fasthttp 流式关闭修复

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -38,7 +38,7 @@ The complete MIT License text is distributed in `LICENSES/MIT.txt`.
 ## fasthttp
 
 - Module: `github.com/valyala/fasthttp`
-- Replaced by: `github.com/tbphp/fasthttp v1.73.1-0.20260816133733-575fecb86459`
+- Replaced by: `github.com/tbphp/fasthttp v1.73.1-0.20260828150536-1c6c09a6f6bc`
 - Copyright: 2015-present Aliaksandr Valialkin, VertaMedia, Kirill Danshin, Erik
   Dubbelboer, FastHTTP Authors
 - License: MIT License

--- a/go.mod
+++ b/go.mod
@@ -129,6 +129,6 @@ require (
 )
 
 // Temporary stream lifecycle fix: https://github.com/valyala/fasthttp/pull/2353
-replace github.com/valyala/fasthttp => github.com/tbphp/fasthttp v1.73.1-0.20260816133733-575fecb86459
+replace github.com/valyala/fasthttp => github.com/tbphp/fasthttp v1.73.1-0.20260828150536-1c6c09a6f6bc
 
 replace github.com/router-for-me/CLIProxyAPI/v7/gptload-embedded => ./third_party/cpaembedded

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/tbphp/fasthttp v1.73.1-0.20260816133733-575fecb86459 h1:4Pej2Vethec1iNZLLKQCh0pVzf9MzGF7hq9TxtxHLYI=
-github.com/tbphp/fasthttp v1.73.1-0.20260816133733-575fecb86459/go.mod h1:Av8ic1DRn/EaPql1f03OpyPnj/NR1GzcryOxVbWoQi0=
+github.com/tbphp/fasthttp v1.73.1-0.20260828150536-1c6c09a6f6bc h1:TDmArbphrQYHHCF6OZd7h5AJTgnQvEKfelaCs/8MWbo=
+github.com/tbphp/fasthttp v1.73.1-0.20260828150536-1c6c09a6f6bc/go.mod h1:Av8ic1DRn/EaPql1f03OpyPnj/NR1GzcryOxVbWoQi0=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=


### PR DESCRIPTION
### 关联 Issue / Related Issue

N/A

### 变更内容 / Change Content

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

- 将临时 fasthttp 替换版本更新到 `1c6c09a`，同步上游 PR #2353 对 late `SetConnectionClose` 兼容行为的修复。
- 同步 `go.sum` 模块校验和。
- 不改变 GPT-Load 公共 API、配置或数据格式。

验证：

- `go test -count=1 ./internal/gateway ./internal/execution/bifrost`
- `make check`

### 自查清单 / Checklist

- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 更新底层网络组件版本，修复流生命周期相关问题。
  * 提升相关网络连接处理的稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->