### PR TITLE
feat(gateway): 支持 OpenAI Embeddings API

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,14 @@ When working over SSH or from a remote browser, the browser's `localhost` may no
 | ----------------------- | -------------------------------------- |
 | OpenAI Chat Completions | `POST /v1/chat/completions`            |
 | OpenAI Responses        | `/v1/responses` and its resource paths |
+| OpenAI Images           | `POST /v1/images/...`                  |
+| OpenAI Embeddings       | `POST /v1/embeddings`                  |
 | Anthropic Messages      | `POST /v1/messages`                    |
 | Gemini                  | `/v1beta/models/...`                   |
 
 Each channel declares exactly which protocols and capabilities it can execute. GPT-Load converts between supported capabilities, but it is not a general-purpose any-protocol, any-JSON translator.
+
+Embeddings initially uses the native OpenAI-compatible wire only on the OpenAI, OpenRouter, and OpenAI Compatible API-key channels; subscription channels and protocol conversion are not supported. An AccessKey without a protocol filter keeps its existing “all enabled protocols” behavior and therefore gains Embeddings access after upgrade. Least-privilege deployments should configure an explicit protocol filter.
 
 ### Built-in channels
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -137,10 +137,14 @@ Codex、Claude、Antigravity 的 OAuth 客户端使用固定回调端口。Compo
 | ----------------------- | ---------------------------- |
 | OpenAI Chat Completions | `POST /v1/chat/completions`  |
 | OpenAI Responses        | `/v1/responses` 及其资源路径 |
+| OpenAI Images           | `POST /v1/images/...`       |
+| OpenAI Embeddings       | `POST /v1/embeddings`       |
 | Anthropic Messages      | `POST /v1/messages`          |
 | Gemini                  | `/v1beta/models/...`         |
 
 每个渠道会明确声明自己可执行的协议与能力。GPT-Load 在受支持的能力之间做转换，但不是任意协议、任意 JSON 的通用转换器。
+
+Embeddings 首期只在 OpenAI、OpenRouter 和 OpenAI Compatible API Key 渠道提供原生 OpenAI-compatible Wire，不支持订阅渠道或协议互转。未设置协议过滤器的 AccessKey 会按既有语义允许全部已启用协议，升级后也会获得 Embeddings 访问能力；最小权限部署请显式配置协议过滤器。
 
 ### 内置渠道
 

--- a/internal/channel/compiler.go
+++ b/internal/channel/compiler.go
@@ -395,7 +395,8 @@ func compileRoutes(
 func validProtocolOperation(clientProtocol protocol.Protocol, operation execution.Operation) bool {
 	switch operation {
 	case execution.OperationChatCompletion:
-		return clientProtocol != protocol.OpenAIResponses && clientProtocol != protocol.OpenAIImages
+		return clientProtocol != protocol.OpenAIResponses && clientProtocol != protocol.OpenAIImages &&
+			clientProtocol != protocol.OpenAIEmbeddings
 	case execution.OperationCountTokens:
 		return clientProtocol == protocol.Anthropic || clientProtocol == protocol.Gemini
 	case execution.OperationResponsesCreate,
@@ -410,8 +411,11 @@ func validProtocolOperation(clientProtocol protocol.Protocol, operation executio
 	case execution.OperationImagesGenerate,
 		execution.OperationImagesEdit:
 		return clientProtocol == protocol.OpenAIImages
+	case execution.OperationEmbeddingsCreate:
+		return clientProtocol == protocol.OpenAIEmbeddings
 	case execution.OperationListModels:
-		return clientProtocol != protocol.OpenAIResponses && clientProtocol != protocol.OpenAIImages
+		return clientProtocol != protocol.OpenAIResponses && clientProtocol != protocol.OpenAIImages &&
+			clientProtocol != protocol.OpenAIEmbeddings
 	case execution.OperationProbe:
 		return clientProtocol != protocol.OpenAIImages
 	default:

--- a/internal/channel/embeddings_module_test.go
+++ b/internal/channel/embeddings_module_test.go
@@ -1,0 +1,63 @@
+package channel
+
+import (
+	"testing"
+
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+)
+
+func TestOpenAIEmbeddingsNativeRouteIsLimitedToSupportedAPIKeyChannels(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	supported := map[ID]struct{}{
+		OpenAI: {}, OpenRouter: {}, OpenAICompatible: {},
+	}
+	for _, descriptor := range registry.List() {
+		definition, ok := registry.lookup(descriptor.ID)
+		if !ok {
+			t.Fatalf("lookup(%q) missing", descriptor.ID)
+		}
+		_, want := supported[descriptor.ID]
+		for _, operation := range []execution.Operation{
+			execution.OperationEmbeddingsCreate,
+			execution.OperationProbe,
+		} {
+			mode, ok := definition.modes[protocol.OpenAIEmbeddings][operation]
+			if want {
+				if !ok || mode != RouteNative {
+					t.Errorf("%q embeddings %q route = %q, %t; want native", descriptor.ID, operation, mode, ok)
+				}
+				continue
+			}
+			if ok {
+				t.Errorf("%q unexpectedly advertises embeddings %q route %q", descriptor.ID, operation, mode)
+			}
+		}
+	}
+}
+
+func TestValidProtocolOperationOpenAIEmbeddingsMatrix(t *testing.T) {
+	t.Parallel()
+
+	if !validProtocolOperation(protocol.OpenAIEmbeddings, execution.OperationEmbeddingsCreate) {
+		t.Fatal("openai-embeddings/embeddings_create must be valid")
+	}
+	if !validProtocolOperation(protocol.OpenAIEmbeddings, execution.OperationProbe) {
+		t.Fatal("openai-embeddings/probe must be valid")
+	}
+	for _, operation := range []execution.Operation{
+		execution.OperationChatCompletion,
+		execution.OperationResponsesCreate,
+		execution.OperationImagesGenerate,
+		execution.OperationListModels,
+	} {
+		if validProtocolOperation(protocol.OpenAIEmbeddings, operation) {
+			t.Errorf("openai-embeddings/%s must be invalid", operation)
+		}
+	}
+	if validProtocolOperation(protocol.OpenAICompletions, execution.OperationEmbeddingsCreate) {
+		t.Fatal("openai-completions accepted embeddings_create")
+	}
+}

--- a/internal/channel/modules/openai.go
+++ b/internal/channel/modules/openai.go
@@ -34,6 +34,8 @@ func OpenAI() spec.Module {
 			},
 			Routes: []spec.Route{
 				spec.NewRoute(protocol.OpenAICompletions, execution.OperationChatCompletion, execution.RouteNative),
+				spec.NewRoute(protocol.OpenAIEmbeddings, execution.OperationEmbeddingsCreate, execution.RouteNative),
+				spec.NewRoute(protocol.OpenAIEmbeddings, execution.OperationProbe, execution.RouteNative),
 				spec.NewRoute(protocol.OpenAIImages, execution.OperationImagesGenerate, execution.RouteNative),
 				spec.NewRoute(protocol.OpenAIImages, execution.OperationImagesEdit, execution.RouteNative),
 				spec.NewRoute(protocol.OpenAICompletions, execution.OperationListModels, execution.RouteNative),

--- a/internal/channel/modules/openai_compatible.go
+++ b/internal/channel/modules/openai_compatible.go
@@ -33,6 +33,8 @@ func OpenAICompatible() spec.Module {
 			},
 			Routes: []spec.Route{
 				spec.NewRoute(protocol.OpenAICompletions, execution.OperationChatCompletion, execution.RouteNative),
+				spec.NewRoute(protocol.OpenAIEmbeddings, execution.OperationEmbeddingsCreate, execution.RouteNative),
+				spec.NewRoute(protocol.OpenAIEmbeddings, execution.OperationProbe, execution.RouteNative),
 				spec.NewRoute(protocol.OpenAIImages, execution.OperationImagesGenerate, execution.RouteNative),
 				spec.NewRoute(protocol.OpenAIImages, execution.OperationImagesEdit, execution.RouteNative),
 				spec.NewRoute(protocol.OpenAICompletions, execution.OperationListModels, execution.RouteNative),

--- a/internal/channel/modules/openrouter.go
+++ b/internal/channel/modules/openrouter.go
@@ -34,6 +34,8 @@ func OpenRouter() spec.Module {
 			},
 			Routes: []spec.Route{
 				spec.NewRoute(protocol.OpenAICompletions, execution.OperationChatCompletion, execution.RouteNative),
+				spec.NewRoute(protocol.OpenAIEmbeddings, execution.OperationEmbeddingsCreate, execution.RouteNative),
+				spec.NewRoute(protocol.OpenAIEmbeddings, execution.OperationProbe, execution.RouteNative),
 				spec.NewRoute(protocol.OpenAICompletions, execution.OperationListModels, execution.RouteNative),
 				spec.NewRoute(protocol.OpenAICompletions, execution.OperationProbe, execution.RouteNative),
 				spec.NewRoute(protocol.OpenAIResponses, execution.OperationResponsesCreate, execution.RouteNative),

--- a/internal/channel/route_golden_test.go
+++ b/internal/channel/route_golden_test.go
@@ -41,7 +41,7 @@ func TestBuiltInRouteGolden(t *testing.T) {
 	}
 
 	digest := fmt.Sprintf("%x", sha256.Sum256([]byte(strings.Join(got, "\n"))))
-	const wantDigest = "4fb788d9792b871c7e2ea00d073756fb3464841370b85dcbfbbb9a904496dea8"
+	const wantDigest = "4d95bc5c1c3c37843eafe59a4fbad9ee223371fe8700ce0e29dd0045c951d0b9"
 	if digest != wantDigest {
 		t.Fatalf("built-in routes changed: digest = %s, want %s\n%s", digest, wantDigest, strings.Join(got, "\n"))
 	}
@@ -59,6 +59,9 @@ func allGoldenOperations() []execution.Operation {
 		execution.OperationResponsesInputTokens,
 		execution.OperationCountTokens,
 		execution.OperationResponsesPassthrough,
+		execution.OperationImagesGenerate,
+		execution.OperationImagesEdit,
+		execution.OperationEmbeddingsCreate,
 		execution.OperationListModels,
 		execution.OperationProbe,
 	}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -152,16 +152,18 @@ func BuildContainer() (*dig.Container, error) {
 		dialect.NewOpenAI,
 		dialect.NewOpenAIResponses,
 		dialect.NewOpenAIImages,
+		dialect.NewOpenAIEmbeddings,
 		dialect.NewAnthropic,
 		dialect.NewGemini,
 		func(
 			openAI *dialect.OpenAI,
 			openAIResponses *dialect.OpenAIResponses,
 			openAIImages *dialect.OpenAIImages,
+			openAIEmbeddings *dialect.OpenAIEmbeddings,
 			anthropic *dialect.Anthropic,
 			gemini *dialect.Gemini,
 		) dialect.Set {
-			return dialect.NewSet(openAI, openAIResponses, openAIImages, anthropic, gemini)
+			return dialect.NewSet(openAI, openAIResponses, openAIImages, openAIEmbeddings, anthropic, gemini)
 		},
 		func(registry *channel.Registry) (*bifrostexecutor.RuntimeManager, error) {
 			return bifrostexecutor.NewManagedRuntime(registry)

--- a/internal/container/container_test.go
+++ b/internal/container/container_test.go
@@ -446,6 +446,7 @@ func TestBuildContainerResolvesAllDialects(t *testing.T) {
 		openAI *dialect.OpenAI,
 		openAIResponses *dialect.OpenAIResponses,
 		openAIImages *dialect.OpenAIImages,
+		openAIEmbeddings *dialect.OpenAIEmbeddings,
 		anthropic *dialect.Anthropic,
 		gemini *dialect.Gemini,
 		values dialect.Set,
@@ -460,8 +461,9 @@ func TestBuildContainerResolvesAllDialects(t *testing.T) {
 		if values[protocol.OpenAICompletions] != openAI ||
 			values[protocol.OpenAIResponses] != openAIResponses ||
 			values[protocol.OpenAIImages] != openAIImages ||
+			values[protocol.OpenAIEmbeddings] != openAIEmbeddings ||
 			values[protocol.Anthropic] != anthropic ||
-			values[protocol.Gemini] != gemini || len(values) != 5 {
+			values[protocol.Gemini] != gemini || len(values) != 6 {
 			t.Fatalf("dialect Set = %#v", values)
 		}
 	})

--- a/internal/control/access_keys_test.go
+++ b/internal/control/access_keys_test.go
@@ -154,6 +154,7 @@ func TestAccessKeyCreateAcceptsAllEnabledProtocolsInCanonicalOrder(t *testing.T)
 			Protocols: []protocol.Protocol{
 				protocol.Gemini,
 				protocol.OpenAIImages,
+				protocol.OpenAIEmbeddings,
 				protocol.OpenAIResponses,
 				protocol.Anthropic,
 				protocol.OpenAICompletions,

--- a/internal/control/credential_probe.go
+++ b/internal/control/credential_probe.go
@@ -83,8 +83,9 @@ type credentialProbeCredential struct {
 }
 
 type credentialProbeExecution struct {
-	result  execution.AttemptResult
-	latency time.Duration
+	result   execution.AttemptResult
+	latency  time.Duration
+	protocol protocol.Protocol
 }
 
 type credentialProbeExecutor struct {
@@ -164,28 +165,10 @@ func (probe *credentialProbeExecutor) Probe(
 			app_errors.ErrInternalServer,
 		)
 	}
-	routeMode, supported := group.ResolvedTarget.ModeForModel(
-		target.protocol,
-		execution.OperationProbe,
-		target.model,
-	)
-	if !supported {
-		return credentialProbeExecution{}, newCredentialProbeFailure(
-			"request",
-			app_errors.ErrValidation,
-		)
-	}
 	requestID, err := newOperationID(cryptorand.Reader)
 	if err != nil {
 		return credentialProbeExecution{}, newCredentialProbeFailure(
 			"request_identity",
-			app_errors.ErrInternalServer,
-		)
-	}
-	attemptID, err := newOperationID(cryptorand.Reader)
-	if err != nil {
-		return credentialProbeExecution{}, newCredentialProbeFailure(
-			"attempt_identity",
 			app_errors.ErrInternalServer,
 		)
 	}
@@ -197,38 +180,69 @@ func (probe *credentialProbeExecutor) Probe(
 	if generation == 0 {
 		generation = 1
 	}
-	spec := execution.NewAttemptSpec(execution.AttemptSpec{
-		RequestID: requestID, AttemptID: attemptID, Sequence: 1,
-		ChannelID: string(group.ChannelID),
-		RouteMode: execution.RouteMode(routeMode), ClientProtocol: target.protocol,
-		Operation: execution.OperationProbe, ClientModel: target.model, UpstreamModel: target.model,
-		Header:       applyControlHeaderRules(group.HeaderRules, apiKey),
-		TargetConfig: group.ResolvedTarget.TargetConfig,
-		Timeouts:     executionTimeouts(group.Timeouts),
-		Credential: execution.NewCredentialSnapshot(
-			ref.ID,
-			version,
-			generation,
-			credential.CanonicalJSON(),
-		),
-		Proxy: proxy, ProxyFingerprint: proxyFingerprint,
-	})
-	if err := spec.Validate(); err != nil {
-		return credentialProbeExecution{}, newCredentialProbeFailure(
-			"request",
-			app_errors.ErrValidation,
-		)
+	probeProtocols := []protocol.Protocol{target.protocol}
+	if target.fallbackProtocol != "" {
+		probeProtocols = append(probeProtocols, target.fallbackProtocol)
 	}
 	startedAt := probe.now()
-	result := probe.executor.Execute(ctx, spec)
-	latency := probe.now().Sub(startedAt)
-	if latency < 0 {
-		latency = 0
+	for index, probeProtocol := range probeProtocols {
+		routeMode, supported := group.ResolvedTarget.ModeForModel(
+			probeProtocol,
+			execution.OperationProbe,
+			target.model,
+		)
+		if !supported {
+			return credentialProbeExecution{}, newCredentialProbeFailure(
+				"request",
+				app_errors.ErrValidation,
+			)
+		}
+		attemptID, attemptErr := newOperationID(cryptorand.Reader)
+		if attemptErr != nil {
+			return credentialProbeExecution{}, newCredentialProbeFailure(
+				"attempt_identity",
+				app_errors.ErrInternalServer,
+			)
+		}
+		spec := execution.NewAttemptSpec(execution.AttemptSpec{
+			RequestID: requestID, AttemptID: attemptID, Sequence: uint32(index + 1),
+			ChannelID: string(group.ChannelID),
+			RouteMode: execution.RouteMode(routeMode), ClientProtocol: probeProtocol,
+			Operation: execution.OperationProbe, ClientModel: target.model, UpstreamModel: target.model,
+			Header:       applyControlHeaderRules(group.HeaderRules, apiKey),
+			TargetConfig: group.ResolvedTarget.TargetConfig,
+			Timeouts:     executionTimeouts(group.Timeouts),
+			Credential: execution.NewCredentialSnapshot(
+				ref.ID,
+				version,
+				generation,
+				credential.CanonicalJSON(),
+			),
+			Proxy: proxy, ProxyFingerprint: proxyFingerprint,
+		})
+		if err := spec.Validate(); err != nil {
+			return credentialProbeExecution{}, newCredentialProbeFailure(
+				"request",
+				app_errors.ErrValidation,
+			)
+		}
+		result := probe.executor.Execute(ctx, spec)
+		if err := ctx.Err(); err != nil {
+			return credentialProbeExecution{}, err
+		}
+		latency := max(probe.now().Sub(startedAt), 0)
+		executed := credentialProbeExecution{
+			result: result, latency: latency, protocol: probeProtocol,
+		}
+		if credentialProbePassed(result) || index+1 == len(probeProtocols) ||
+			!validationProbeNeedsEmbeddingsFallback(result) {
+			return executed, nil
+		}
 	}
-	if err := ctx.Err(); err != nil {
-		return credentialProbeExecution{}, err
-	}
-	return credentialProbeExecution{result: result, latency: latency}, nil
+	return credentialProbeExecution{}, newCredentialProbeFailure(
+		"probe",
+		app_errors.ErrInternalServer,
+	)
 }
 
 func newCredentialProbeFailure(stage string, cause error) error {
@@ -353,7 +367,7 @@ func (s *Service) TestGroupCredential(
 		)
 	}
 	response := CredentialProbeResponse{
-		Outcome: outcome, Model: target.model, Protocol: target.protocol,
+		Outcome: outcome, Model: target.model, Protocol: executed.protocol,
 		LatencyMS:  max(executed.latency.Milliseconds(), 0),
 		Reason:     reason,
 		TestedAtMS: testedAt,

--- a/internal/control/credential_probe_test.go
+++ b/internal/control/credential_probe_test.go
@@ -171,6 +171,47 @@ func TestGroupCredentialProbeUsesExplicitValidationModel(t *testing.T) {
 	}
 }
 
+func TestGroupCredentialProbeFallsBackToEmbeddingsAndReportsProtocol(t *testing.T) {
+	t.Parallel()
+	fixture := newServiceFixture(t)
+	groupID := createGroupWithCredentials(t, fixture, "probe-embeddings-secret")
+	var credential models.Credential
+	if err := fixture.db.Where("group_id = ?", groupID).Take(&credential).Error; err != nil {
+		t.Fatal(err)
+	}
+	executor := &credentialProbeTestExecutor{execute: func(spec execution.AttemptSpec) execution.AttemptResult {
+		if spec.ClientProtocol == protocol.OpenAIEmbeddings {
+			return successfulCredentialProbeResult()
+		}
+		result := failedCredentialProbeResult(
+			http.StatusNotFound,
+			execution.ErrorKindHTTP,
+			execution.FailureHintModelUnavailable,
+		)
+		result.Error.OriginHint = execution.ErrorOriginUpstream
+		return result
+	}}
+	fixture.service.executor = executor
+
+	response, err := fixture.service.TestGroupCredential(t.Context(), groupID, credential.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.Outcome != CredentialProbeOutcomePassed ||
+		response.Protocol != protocol.OpenAIEmbeddings {
+		t.Fatalf("probe response = %#v", response)
+	}
+	calls := executor.recordedCalls()
+	if len(calls) != 2 ||
+		calls[0].ClientProtocol != protocol.OpenAICompletions ||
+		calls[1].ClientProtocol != protocol.OpenAIEmbeddings ||
+		calls[0].RequestID != calls[1].RequestID ||
+		calls[0].AttemptID == calls[1].AttemptID ||
+		calls[0].Sequence != 1 || calls[1].Sequence != 2 {
+		t.Fatalf("probe calls = %#v", calls)
+	}
+}
+
 func TestGroupCredentialProbeHTTPReturnsCompletedUpstreamFailureAsData(t *testing.T) {
 	t.Parallel()
 	initControlI18n(t)

--- a/internal/control/route_inspect_test.go
+++ b/internal/control/route_inspect_test.go
@@ -240,6 +240,7 @@ func TestRouteInspectDerivesStandardRequestMetadataFromProtocol(t *testing.T) {
 		{protocol: protocol.OpenAICompletions, operation: execution.OperationChatCompletion, routeMode: execution.RouteNative, routeRequirement: execution.RouteRequirementAny},
 		{protocol: protocol.OpenAIResponses, operation: execution.OperationResponsesCreate, routeMode: execution.RouteNative, routeRequirement: execution.RouteRequirementAny},
 		{protocol: protocol.OpenAIImages, operation: execution.OperationImagesGenerate, routeMode: execution.RouteNative, routeRequirement: execution.RouteRequirementNative},
+		{protocol: protocol.OpenAIEmbeddings, operation: execution.OperationEmbeddingsCreate, routeMode: execution.RouteNative, routeRequirement: execution.RouteRequirementNative},
 		{protocol: protocol.Anthropic, operation: execution.OperationChatCompletion, routeMode: execution.RouteConverted, routeRequirement: execution.RouteRequirementAny},
 		{protocol: protocol.Gemini, operation: execution.OperationChatCompletion, routeMode: execution.RouteConverted, routeRequirement: execution.RouteRequirementAny},
 	}

--- a/internal/control/validation.go
+++ b/internal/control/validation.go
@@ -6,6 +6,7 @@ import (
 	"crypto/subtle"
 	"encoding/binary"
 	"hash"
+	"net/http"
 	"net/textproto"
 	"sort"
 	"strings"
@@ -62,9 +63,10 @@ type validationWorker struct {
 type groupValidationSignature [sha256.Size]byte
 
 type groupValidationTarget struct {
-	protocol  protocol.Protocol
-	model     string
-	signature groupValidationSignature
+	protocol         protocol.Protocol
+	fallbackProtocol protocol.Protocol
+	model            string
+	signature        groupValidationSignature
 }
 
 var _ validationSweep = (*validationWorker)(nil)
@@ -190,14 +192,14 @@ func (worker *validationWorker) validateRef(ctx context.Context, snapshot *state
 	}
 	if !credentialProbePassed(executed.result) {
 		if ctx.Err() == nil {
-			logValidationFailure(ref, string(target.protocol), "probe")
+			logValidationFailure(ref, string(executed.protocol), "probe")
 		}
 		return
 	}
 
 	if worker.mutations == nil {
 		if ctx.Err() == nil {
-			logValidationFailure(ref, string(target.protocol), "conditional_recover")
+			logValidationFailure(ref, string(executed.protocol), "conditional_recover")
 		}
 		return
 	}
@@ -229,11 +231,11 @@ func (worker *validationWorker) validateRef(ctx context.Context, snapshot *state
 		return matched
 	})
 	if !recovered && ctx.Err() == nil {
-		logValidationFailure(ref, string(target.protocol), "conditional_recover")
+		logValidationFailure(ref, string(executed.protocol), "conditional_recover")
 		return
 	}
 	if recovered {
-		logValidationRecovery(ref, string(target.protocol))
+		logValidationRecovery(ref, string(executed.protocol))
 	}
 }
 
@@ -304,8 +306,18 @@ func buildGroupValidationTarget(group state.GroupView) (groupValidationTarget, b
 	if !ok {
 		return groupValidationTarget{}, false
 	}
+	fallbackProtocol := protocol.Protocol("")
+	if selectedProtocol != protocol.OpenAIEmbeddings {
+		if mode, supported := group.ResolvedTarget.ModeForModel(
+			protocol.OpenAIEmbeddings,
+			execution.OperationProbe,
+			probeModel,
+		); supported && mode == channel.RouteNative {
+			fallbackProtocol = protocol.OpenAIEmbeddings
+		}
+	}
 	return groupValidationTarget{
-		protocol:  selectedProtocol,
+		protocol: selectedProtocol, fallbackProtocol: fallbackProtocol,
 		model:     probeModel,
 		signature: computeGroupValidationSignature(group, selectedProtocol, probeModel),
 	}, true
@@ -313,6 +325,66 @@ func buildGroupValidationTarget(group state.GroupView) (groupValidationTarget, b
 
 func validationProtocol(target channel.ResolvedTarget, model string) (protocol.Protocol, bool) {
 	return target.PreferredProtocol(execution.OperationProbe, model)
+}
+
+func validationProbeNeedsEmbeddingsFallback(result execution.AttemptResult) bool {
+	if result.Validate() != nil || result.Error == nil ||
+		result.DispatchState != execution.DispatchMaybeSent || !result.ResponseStarted {
+		return false
+	}
+	if result.Error.OriginHint != execution.ErrorOriginUpstream &&
+		result.Error.OriginHint != execution.ErrorOriginClient {
+		return false
+	}
+	evidence := result.Error
+	status := result.StatusCode
+	if status == 0 {
+		status = evidence.StatusCode
+	}
+	switch status {
+	case http.StatusUnauthorized, http.StatusPaymentRequired, http.StatusForbidden,
+		http.StatusRequestTimeout, http.StatusConflict, http.StatusTooEarly,
+		http.StatusTooManyRequests:
+		return false
+	case http.StatusMethodNotAllowed, http.StatusNotImplemented:
+		return true
+	}
+	if status >= http.StatusInternalServerError ||
+		evidence.Hint == execution.FailureHintInvalidCredential ||
+		evidence.Hint == execution.FailureHintRefreshRequired ||
+		evidence.Hint == execution.FailureHintReauthorizationRequired ||
+		evidence.Hint == execution.FailureHintRateLimited ||
+		evidence.Hint == execution.FailureHintCandidateUnavailable ||
+		evidence.Hint == execution.FailureHintHostError {
+		return false
+	}
+	if evidence.Hint == execution.FailureHintModelUnavailable {
+		return true
+	}
+	for _, value := range []string{evidence.Type, evidence.Code} {
+		switch strings.ToLower(strings.TrimSpace(value)) {
+		case "model_not_found", "model_not_available", "deployment_not_found",
+			"unsupported_model", "unsupported_operation", "operation_not_supported",
+			"not_implemented":
+			return true
+		}
+	}
+	if evidence.Hint != execution.FailureHintRequestRejected {
+		return false
+	}
+	summary := strings.ToLower(evidence.Summary)
+	for _, marker := range []string{
+		"not a chat model",
+		"does not support chat completions",
+		"chat completions are not supported",
+		"not supported in the v1/chat/completions endpoint",
+		"operation is not supported",
+	} {
+		if strings.Contains(summary, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func computeGroupValidationSignature(

--- a/internal/control/validation_test.go
+++ b/internal/control/validation_test.go
@@ -52,6 +52,225 @@ func TestValidationWorkerUsesExplicitModelAndCanonicalRepresentativeProtocol(t *
 	}
 }
 
+func TestValidationWorkerFallsBackToEmbeddingsAfterExplicitModelRejection(t *testing.T) {
+	t.Parallel()
+
+	worker := newValidationWorkerForTest(
+		validationSnapshot(map[uint]state.GroupView{
+			1: validationGroup(
+				[]protocol.Protocol{protocol.OpenAICompletions},
+				"embedding-only-model",
+				nil,
+			),
+		}),
+		[]state.CredentialRef{{ID: 7, GroupID: 1, EncryptedValue: "key-7"}},
+		&validationProbeRecorder{},
+	)
+	var attempts []execution.AttemptSpec
+	worker.executor = scriptedDiscoveryExecutor{execute: func(
+		_ context.Context,
+		spec execution.AttemptSpec,
+	) execution.AttemptResult {
+		attempts = append(attempts, spec.Clone())
+		if spec.ClientProtocol == protocol.OpenAICompletions {
+			return validationStartedProbeFailure(
+				http.StatusBadRequest,
+				execution.FailureHintModelUnavailable,
+				execution.ErrorScopeModel,
+				"model_not_found",
+				"not a chat model",
+			)
+		}
+		return execution.AttemptResult{
+			DispatchState: execution.DispatchMaybeSent, ResponseStarted: true,
+			StatusCode: http.StatusOK, Header: http.Header{},
+		}
+	}}
+
+	worker.Validate(context.Background())
+
+	if len(attempts) != 2 ||
+		attempts[0].ClientProtocol != protocol.OpenAICompletions ||
+		attempts[1].ClientProtocol != protocol.OpenAIEmbeddings ||
+		attempts[0].Operation != execution.OperationProbe ||
+		attempts[1].Operation != execution.OperationProbe ||
+		attempts[0].UpstreamModel != "embedding-only-model" ||
+		attempts[1].UpstreamModel != "embedding-only-model" ||
+		attempts[0].RequestID != attempts[1].RequestID ||
+		attempts[0].AttemptID == attempts[1].AttemptID ||
+		attempts[0].Sequence != 1 || attempts[1].Sequence != 2 {
+		t.Fatalf("probe attempts = %#v", attempts)
+	}
+	for _, attempt := range attempts {
+		if attempt.Method != "" || attempt.Path != "" || len(attempt.Body) != 0 {
+			t.Fatalf("semantic probe contains provider wire shape: %#v", attempt)
+		}
+	}
+	if got, want := worker.recorder.events(), []string{
+		fmt.Sprintf("registry.weight:7:%d", state.DefaultWeight),
+		"registry.recover:7",
+		"stats.reset:7",
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("recovery events = %#v, want %#v", got, want)
+	}
+}
+
+func TestValidationWorkerKeepsCredentialBlacklistedWhenEmbeddingsFallbackFails(t *testing.T) {
+	t.Parallel()
+
+	worker := newValidationWorkerForTest(
+		validationSnapshot(map[uint]state.GroupView{
+			1: validationGroup(
+				[]protocol.Protocol{protocol.OpenAICompletions},
+				"embedding-only-model",
+				nil,
+			),
+		}),
+		[]state.CredentialRef{{ID: 7, GroupID: 1, EncryptedValue: "key-7"}},
+		&validationProbeRecorder{},
+	)
+	var protocols []protocol.Protocol
+	worker.executor = scriptedDiscoveryExecutor{execute: func(
+		_ context.Context,
+		spec execution.AttemptSpec,
+	) execution.AttemptResult {
+		protocols = append(protocols, spec.ClientProtocol)
+		if spec.ClientProtocol == protocol.OpenAICompletions {
+			return validationStartedProbeFailure(
+				http.StatusBadRequest,
+				execution.FailureHintModelUnavailable,
+				execution.ErrorScopeModel,
+				"model_not_found",
+				"not a chat model",
+			)
+		}
+		return validationStartedProbeFailure(
+			http.StatusTooManyRequests,
+			execution.FailureHintRateLimited,
+			execution.ErrorScopeCredential,
+			"rate_limit",
+			"rate limited",
+		)
+	}}
+
+	worker.Validate(context.Background())
+
+	if !reflect.DeepEqual(protocols, []protocol.Protocol{
+		protocol.OpenAICompletions,
+		protocol.OpenAIEmbeddings,
+	}) {
+		t.Fatalf("probe protocols = %#v", protocols)
+	}
+	if events := worker.recorder.events(); len(events) != 0 {
+		t.Fatalf("recovery events = %#v, want none", events)
+	}
+}
+
+func TestValidationProbeEmbeddingsFallbackEvidenceIsNarrow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		result execution.AttemptResult
+		want   bool
+	}{
+		{name: "model unavailable", result: validationStartedProbeFailure(
+			http.StatusBadRequest, execution.FailureHintModelUnavailable,
+			execution.ErrorScopeModel, "model_not_found", "not a chat model",
+		), want: true},
+		{name: "unsupported operation code", result: validationStartedProbeFailure(
+			http.StatusBadRequest, execution.FailureHintRequestRejected,
+			execution.ErrorScopeRequest, "unsupported_operation", "operation is not supported",
+		), want: true},
+		{name: "method not allowed", result: validationStartedProbeFailure(
+			http.StatusMethodNotAllowed, "", execution.ErrorScopeRequest, "", "method not allowed",
+		), want: true},
+		{name: "not implemented", result: validationStartedProbeFailure(
+			http.StatusNotImplemented, "", execution.ErrorScopeRequest, "", "not implemented",
+		), want: true},
+		{name: "generic invalid request", result: validationStartedProbeFailure(
+			http.StatusBadRequest, execution.FailureHintRequestRejected,
+			execution.ErrorScopeRequest, "invalid_request", "invalid request",
+		)},
+		{name: "unsupported operation without trusted origin", result: validationProbeFailureWithOrigin(
+			validationStartedProbeFailure(
+				http.StatusBadRequest, execution.FailureHintRequestRejected,
+				execution.ErrorScopeRequest, "unsupported_operation", "operation is not supported",
+			), "",
+		)},
+		{name: "generic not found", result: validationStartedProbeFailure(
+			http.StatusNotFound, "", execution.ErrorScopeRequest, "", "endpoint not found",
+		)},
+		{name: "candidate unavailable", result: validationStartedProbeFailure(
+			http.StatusForbidden, execution.FailureHintCandidateUnavailable,
+			execution.ErrorScopeModel, "", "candidate unavailable",
+		)},
+		{name: "authentication", result: validationStartedProbeFailure(
+			http.StatusUnauthorized, execution.FailureHintInvalidCredential,
+			execution.ErrorScopeCredential, "invalid_api_key", "invalid key",
+		)},
+		{name: "rate limited", result: validationStartedProbeFailure(
+			http.StatusTooManyRequests, execution.FailureHintRateLimited,
+			execution.ErrorScopeCredential, "rate_limit", "rate limited",
+		)},
+		{name: "host error", result: validationStartedProbeFailure(
+			http.StatusServiceUnavailable, execution.FailureHintHostError,
+			execution.ErrorScopeGroup, "service_unavailable", "unavailable",
+		)},
+		{name: "transport before response", result: execution.AttemptResult{
+			DispatchState: execution.DispatchMaybeSent,
+			Error: &execution.ErrorEvidence{
+				Kind: execution.ErrorKindTransport, OriginHint: execution.ErrorOriginUpstream,
+				ScopeHint: execution.ErrorScopeGroup, Summary: "connection reset",
+			},
+		}},
+		{name: "invalid result", result: execution.AttemptResult{
+			DispatchState: execution.DispatchNotSent, ResponseStarted: true,
+			StatusCode: http.StatusBadRequest,
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := validationProbeNeedsEmbeddingsFallback(test.result); got != test.want {
+				t.Fatalf("validationProbeNeedsEmbeddingsFallback() = %t, want %t; result=%#v", got, test.want, test.result)
+			}
+		})
+	}
+}
+
+func validationStartedProbeFailure(
+	status int,
+	hint execution.FailureHint,
+	scope execution.ErrorScope,
+	code string,
+	summary string,
+) execution.AttemptResult {
+	origin := execution.ErrorOriginUpstream
+	if hint == execution.FailureHintRequestRejected {
+		origin = execution.ErrorOriginClient
+	}
+	return execution.AttemptResult{
+		DispatchState: execution.DispatchMaybeSent, ResponseStarted: true,
+		StatusCode: status, Header: http.Header{},
+		Error: &execution.ErrorEvidence{
+			Kind: execution.ErrorKindHTTP, Hint: hint,
+			OriginHint: origin, ScopeHint: scope,
+			StatusCode: status, Code: code, Summary: summary,
+			ReplaySafety: execution.ReplaySafetyRejectedBeforeProcessing,
+		},
+	}
+}
+
+func validationProbeFailureWithOrigin(
+	result execution.AttemptResult,
+	origin execution.ErrorOrigin,
+) execution.AttemptResult {
+	result.Error.OriginHint = origin
+	return result
+}
+
 func TestBuildGroupValidationTargetSkipsSubscriptionGroups(t *testing.T) {
 	t.Parallel()
 

--- a/internal/dialect/openai_embeddings.go
+++ b/internal/dialect/openai_embeddings.go
@@ -1,0 +1,278 @@
+package dialect
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"strings"
+
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+)
+
+const openAIEmbeddingsPath = "/v1/embeddings"
+
+// OpenAIEmbeddings implements the OpenAI-compatible Embeddings wire contract.
+type OpenAIEmbeddings struct{}
+
+var (
+	_ Dialect       = (*OpenAIEmbeddings)(nil)
+	_ ModelRewriter = (*OpenAIEmbeddings)(nil)
+)
+
+func NewOpenAIEmbeddings() *OpenAIEmbeddings {
+	return &OpenAIEmbeddings{}
+}
+
+func (*OpenAIEmbeddings) Protocol() protocol.Protocol {
+	return protocol.OpenAIEmbeddings
+}
+
+func (d *OpenAIEmbeddings) InspectRequest(request *ParsedRequest) (RequestMetadata, error) {
+	if request == nil {
+		return RequestMetadata{}, fmt.Errorf("parsed request is required")
+	}
+	if request.Method != http.MethodPost {
+		return RequestMetadata{}, fmt.Errorf("%s only supports POST", d.Protocol())
+	}
+	if request.Path != openAIEmbeddingsPath {
+		return RequestMetadata{}, fmt.Errorf("unsupported %s path %q", d.Protocol(), request.Path)
+	}
+	contentType := request.Header.Get("Content-Type")
+	if strings.TrimSpace(contentType) != "" {
+		mediaType, _, err := mime.ParseMediaType(contentType)
+		if err != nil {
+			return RequestMetadata{}, fmt.Errorf("decode %s Content-Type: %w", d.Protocol(), err)
+		}
+		if !strings.EqualFold(mediaType, "application/json") {
+			return RequestMetadata{}, fmt.Errorf("unsupported %s Content-Type %q", d.Protocol(), contentType)
+		}
+	}
+	metadata, err := inspectJSONRequestFields(request.Body, true)
+	if err != nil {
+		return RequestMetadata{}, fmt.Errorf("decode %s request: %w", d.Protocol(), err)
+	}
+	if metadata.Stream {
+		return RequestMetadata{}, fmt.Errorf("%s does not support streaming", d.Protocol())
+	}
+	if err := validateOpenAIEmbeddingsInput(request.Body); err != nil {
+		return RequestMetadata{}, fmt.Errorf("decode %s request: %w", d.Protocol(), err)
+	}
+	metadata.Operation = execution.OperationEmbeddingsCreate
+	metadata.RouteRequirement = execution.RouteRequirementNative
+	metadata.ObserveUsage = true
+	return metadata, nil
+}
+
+func (d *OpenAIEmbeddings) RewriteRequestModel(
+	request *ParsedRequest,
+	model string,
+) (*ParsedRequest, error) {
+	return rewriteJSONRequestModel(request, model, string(d.Protocol()))
+}
+
+// SanitizeRequestForAttempt rebuilds one request for the selected model while
+// removing client controls that must never reach an upstream.
+func (d *OpenAIEmbeddings) SanitizeRequestForAttempt(
+	request *ParsedRequest,
+	model string,
+) (*ParsedRequest, error) {
+	if err := validateModelRewriteTarget(model, false); err != nil {
+		return nil, err
+	}
+	if _, err := d.InspectRequest(request); err != nil {
+		return nil, err
+	}
+	object, err := decodeJSONObject(request.Body)
+	if err != nil {
+		return nil, fmt.Errorf("sanitize %s request: %w", d.Protocol(), err)
+	}
+	for field := range object {
+		if openAIEmbeddingsControlField(field) || field == "stream" {
+			delete(object, field)
+		}
+	}
+	encodedModel, err := json.Marshal(model)
+	if err != nil {
+		return nil, fmt.Errorf("encode selected Embeddings model: %w", err)
+	}
+	object["model"] = encodedModel
+	body, err := json.Marshal(object)
+	if err != nil {
+		return nil, fmt.Errorf("encode sanitized %s request: %w", d.Protocol(), err)
+	}
+	clone, err := cloneParsedRequest(request)
+	if err != nil {
+		return nil, err
+	}
+	clone.Body = body
+	if clone.Header == nil {
+		clone.Header = make(http.Header)
+	}
+	if strings.TrimSpace(clone.Header.Get("Content-Type")) == "" {
+		clone.Header.Set("Content-Type", "application/json")
+	}
+	return clone, nil
+}
+
+func (*OpenAIEmbeddings) RewriteResponseModel(body []byte, model string) ([]byte, error) {
+	if err := validateModelRewriteTarget(model, false); err != nil {
+		return nil, err
+	}
+	return rewriteOptionalJSONField(body, "model", model)
+}
+
+func validateOpenAIEmbeddingsInput(body []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	root, err := decoder.Token()
+	if err != nil {
+		return fmt.Errorf("decode request object: %w", err)
+	}
+	rootDelimiter, ok := root.(json.Delim)
+	if !ok || rootDelimiter != '{' {
+		return fmt.Errorf("request body must be a JSON object")
+	}
+
+	inputSeen := false
+	for decoder.More() {
+		fieldToken, err := decoder.Token()
+		if err != nil {
+			return fmt.Errorf("decode request field: %w", err)
+		}
+		field, ok := fieldToken.(string)
+		if !ok {
+			return fmt.Errorf("request field name must be a string")
+		}
+		if strings.EqualFold(field, "input") {
+			if field != "input" || inputSeen {
+				return fmt.Errorf("input field must be unique lowercase input")
+			}
+			inputSeen = true
+			var input json.RawMessage
+			if err := decoder.Decode(&input); err != nil {
+				return fmt.Errorf("decode input: %w", err)
+			}
+			if !validOpenAIEmbeddingsInput(input) {
+				return fmt.Errorf("input must be a string, string array, token array, or token array list")
+			}
+			continue
+		}
+		var ignored json.RawMessage
+		if err := decoder.Decode(&ignored); err != nil {
+			return fmt.Errorf("decode request field %q: %w", field, err)
+		}
+	}
+	if _, err := decoder.Token(); err != nil {
+		return fmt.Errorf("close request object: %w", err)
+	}
+	var trailing json.RawMessage
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("request body contains multiple JSON values")
+		}
+		return fmt.Errorf("decode request tail: %w", err)
+	}
+	if !inputSeen {
+		return fmt.Errorf("input is required")
+	}
+	return nil
+}
+
+func validOpenAIEmbeddingsInput(raw json.RawMessage) bool {
+	if jsonEmbeddingString(raw) {
+		return true
+	}
+	var values []json.RawMessage
+	if json.Unmarshal(raw, &values) != nil || values == nil {
+		return false
+	}
+	if len(values) == 0 {
+		return true
+	}
+	if jsonEmbeddingString(values[0]) {
+		for _, value := range values[1:] {
+			if !jsonEmbeddingString(value) {
+				return false
+			}
+		}
+		return true
+	}
+	if jsonInteger(values[0]) {
+		for _, value := range values[1:] {
+			if !jsonInteger(value) {
+				return false
+			}
+		}
+		return true
+	}
+	if jsonIntegerArray(values[0]) {
+		for _, value := range values[1:] {
+			if !jsonIntegerArray(value) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func jsonEmbeddingString(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || trimmed[0] != '"' {
+		return false
+	}
+	var value string
+	return json.Unmarshal(trimmed, &value) == nil
+}
+
+func jsonIntegerArray(raw json.RawMessage) bool {
+	var values []json.RawMessage
+	if json.Unmarshal(raw, &values) != nil || values == nil {
+		return false
+	}
+	for _, value := range values {
+		if !jsonInteger(value) {
+			return false
+		}
+	}
+	return true
+}
+
+func jsonInteger(raw json.RawMessage) bool {
+	value := strings.TrimSpace(string(raw))
+	if value == "" {
+		return false
+	}
+	if value[0] == '-' {
+		value = value[1:]
+		if value == "" {
+			return false
+		}
+	}
+	if value == "0" {
+		return true
+	}
+	if value[0] < '1' || value[0] > '9' {
+		return false
+	}
+	for index := 1; index < len(value); index++ {
+		if value[index] < '0' || value[index] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func openAIEmbeddingsControlField(name string) bool {
+	normalized := strings.ReplaceAll(strings.ToLower(name), "-", "_")
+	switch normalized {
+	case "provider", "fallback", "fallbacks", "authorization", "proxy_authorization",
+		"api_key", "apikey", "x_api_key", "x_goog_api_key":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/dialect/openai_embeddings_test.go
+++ b/internal/dialect/openai_embeddings_test.go
@@ -1,0 +1,176 @@
+package dialect
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+)
+
+func TestOpenAIEmbeddingsInspectRequestAcceptsOfficialInputShapes(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name  string
+		input string
+	}{
+		{name: "string", input: `"hello"`},
+		{name: "strings", input: `["hello",""]`},
+		{name: "token IDs", input: `[1,-2,123456789012345678901234567890]`},
+		{name: "token ID arrays", input: `[[1,-2],[]]`},
+		{name: "empty array without provider length validation", input: `[]`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			body := []byte(`{"model":"Qwen/Qwen3-Embedding-8B","input":` + test.input + `,"dimensions":-1,"encoding_format":"base64","user":"tenant","future":{"kept":true}}`)
+			metadata, err := NewOpenAIEmbeddings().InspectRequest(&ParsedRequest{
+				Method: http.MethodPost,
+				Path:   "/v1/embeddings",
+				Header: http.Header{"Content-Type": {"application/json; charset=utf-8"}},
+				Body:   body,
+			})
+			if err != nil {
+				t.Fatalf("InspectRequest() error = %v", err)
+			}
+			if metadata.Model == nil || *metadata.Model != "Qwen/Qwen3-Embedding-8B" ||
+				metadata.Stream || metadata.Operation != execution.OperationEmbeddingsCreate ||
+				metadata.RouteRequirement != execution.RouteRequirementNative || !metadata.ObserveUsage {
+				t.Fatalf("metadata = %#v", metadata)
+			}
+		})
+	}
+}
+
+func TestOpenAIEmbeddingsInspectRequestRejectsInvalidContract(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name        string
+		method      string
+		path        string
+		contentType string
+		body        []byte
+	}{
+		{name: "wrong method", method: http.MethodGet, path: "/v1/embeddings", body: []byte(`{"model":"m","input":"x"}`)},
+		{name: "wrong path", method: http.MethodPost, path: "/v1/embedding", body: []byte(`{"model":"m","input":"x"}`)},
+		{name: "wrong content type", method: http.MethodPost, path: "/v1/embeddings", contentType: "text/plain", body: []byte(`{"model":"m","input":"x"}`)},
+		{name: "malformed content type", method: http.MethodPost, path: "/v1/embeddings", contentType: `application/json; charset="`, body: []byte(`{"model":"m","input":"x"}`)},
+		{name: "missing model", method: http.MethodPost, path: "/v1/embeddings", body: []byte(`{"input":"x"}`)},
+		{name: "missing input", method: http.MethodPost, path: "/v1/embeddings", body: []byte(`{"model":"m"}`)},
+		{name: "null input", method: http.MethodPost, path: "/v1/embeddings", body: []byte(`{"model":"m","input":null}`)},
+		{name: "mixed input", method: http.MethodPost, path: "/v1/embeddings", body: []byte(`{"model":"m","input":["x",1]}`)},
+		{name: "object input", method: http.MethodPost, path: "/v1/embeddings", body: []byte(`{"model":"m","input":{"text":"x"}}`)},
+		{name: "duplicate input", method: http.MethodPost, path: "/v1/embeddings", body: []byte(`{"model":"m","input":"x","input":"y"}`)},
+		{name: "input case alias", method: http.MethodPost, path: "/v1/embeddings", body: []byte(`{"model":"m","Input":"x"}`)},
+		{name: "stream true", method: http.MethodPost, path: "/v1/embeddings", body: []byte(`{"model":"m","input":"x","stream":true}`)},
+		{name: "stream non-boolean", method: http.MethodPost, path: "/v1/embeddings", body: []byte(`{"model":"m","input":"x","stream":"false"}`)},
+		{name: "duplicate stream", method: http.MethodPost, path: "/v1/embeddings", body: []byte(`{"model":"m","input":"x","stream":false,"stream":false}`)},
+		{name: "stream case alias", method: http.MethodPost, path: "/v1/embeddings", body: []byte(`{"model":"m","input":"x","Stream":false}`)},
+		{name: "trailing JSON", method: http.MethodPost, path: "/v1/embeddings", body: []byte(`{"model":"m","input":"x"}{}`)},
+		{name: "invalid UTF-8", method: http.MethodPost, path: "/v1/embeddings", body: []byte{'{', '"', 'm', 'o', 'd', 'e', 'l', '"', ':', '"', 0xff, '"', '}'}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			header := make(http.Header)
+			if test.contentType != "" {
+				header.Set("Content-Type", test.contentType)
+			}
+			metadata, err := NewOpenAIEmbeddings().InspectRequest(&ParsedRequest{
+				Method: test.method,
+				Path:   test.path,
+				Header: header,
+				Body:   test.body,
+			})
+			if err == nil {
+				t.Fatalf("InspectRequest() = %#v, nil error", metadata)
+			}
+		})
+	}
+}
+
+func TestOpenAIEmbeddingsSanitizeRequestForAttempt(t *testing.T) {
+	t.Parallel()
+
+	originalBody := []byte(`{"model":"public-model","input":[[1,2],[3,4]],"stream":false,"dimensions":256,"encoding_format":"base64","user":"tenant","api_key":"client-secret","fallbacks":["other"],"future":{"kept":true}}`)
+	original := &ParsedRequest{
+		Method: http.MethodPost,
+		Path:   "/v1/embeddings",
+		Header: http.Header{"Content-Type": {"application/json"}},
+		Body:   bytes.Clone(originalBody),
+	}
+	sanitized, err := NewOpenAIEmbeddings().SanitizeRequestForAttempt(original, "upstream-model")
+	if err != nil {
+		t.Fatalf("SanitizeRequestForAttempt() error = %v", err)
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(sanitized.Body, &object); err != nil {
+		t.Fatalf("decode sanitized body: %v", err)
+	}
+	var model string
+	if err := json.Unmarshal(object["model"], &model); err != nil || model != "upstream-model" {
+		t.Fatalf("model = %q, %v", model, err)
+	}
+	for _, removed := range []string{"stream", "api_key", "fallbacks"} {
+		if _, exists := object[removed]; exists {
+			t.Fatalf("control field %q remains in %s", removed, sanitized.Body)
+		}
+	}
+	for field, want := range map[string]string{
+		"input":           `[[1,2],[3,4]]`,
+		"dimensions":      `256`,
+		"encoding_format": `"base64"`,
+		"user":            `"tenant"`,
+		"future":          `{"kept":true}`,
+	} {
+		if got := string(object[field]); got != want {
+			t.Fatalf("%s = %s, want %s", field, got, want)
+		}
+	}
+	if !bytes.Equal(original.Body, originalBody) {
+		t.Fatalf("original body mutated: %s", original.Body)
+	}
+}
+
+func TestOpenAIEmbeddingsRewriteResponseModelOnlyChangesTopLevel(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"object":"list","model":"provider-model","data":[{"object":"embedding","index":0,"embedding":"provider-model"}],"future":{"model":"provider-model"}}`)
+	rewritten, err := NewOpenAIEmbeddings().RewriteResponseModel(body, "public-model")
+	if err != nil {
+		t.Fatalf("RewriteResponseModel() error = %v", err)
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(rewritten, &object); err != nil {
+		t.Fatalf("decode rewritten body: %v", err)
+	}
+	if string(object["model"]) != `"public-model"` ||
+		!bytes.Contains(object["data"], []byte(`"embedding":"provider-model"`)) ||
+		!bytes.Contains(object["future"], []byte(`"model":"provider-model"`)) {
+		t.Fatalf("rewritten body = %s", rewritten)
+	}
+}
+
+func TestOpenAIEmbeddingsProtocol(t *testing.T) {
+	t.Parallel()
+
+	if got := NewOpenAIEmbeddings().Protocol(); got != protocol.OpenAIEmbeddings {
+		t.Fatalf("Protocol() = %q", got)
+	}
+}
+
+func TestOpenAIEmbeddingsStandardRequestUsesCreate(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := InspectStandardRequest(protocol.OpenAIEmbeddings, "text-embedding-3-small")
+	if err != nil {
+		t.Fatalf("InspectStandardRequest() error = %v", err)
+	}
+	if metadata.Operation != execution.OperationEmbeddingsCreate || metadata.Model == nil ||
+		*metadata.Model != "text-embedding-3-small" || metadata.Stream ||
+		metadata.RouteRequirement != execution.RouteRequirementNative || !metadata.ObserveUsage {
+		t.Fatalf("metadata = %#v", metadata)
+	}
+}

--- a/internal/dialect/openai_embeddings_usage.go
+++ b/internal/dialect/openai_embeddings_usage.go
@@ -1,0 +1,103 @@
+package dialect
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"gpt-load/internal/usage"
+)
+
+var _ UsageExtractor = (*OpenAIEmbeddings)(nil)
+
+func (*OpenAIEmbeddings) ExtractUsage(body []byte) (usage.Result, error) {
+	envelope, err := decodeOpenAIEmbeddingsUsageEnvelope(body)
+	if err != nil {
+		return usage.Result{}, fmt.Errorf("decode OpenAI Embeddings usage response")
+	}
+	patch, found := openAIEmbeddingsUsagePatch(openAIEmbeddingsUsageRoot(envelope.Usage))
+	var accumulator usage.Accumulator
+	if found {
+		if err := accumulator.ReplaceSnapshot(patch); err != nil {
+			return usage.Result{}, fmt.Errorf("normalize OpenAI Embeddings usage response")
+		}
+	} else if err := accumulator.MergePatch(patch); err != nil {
+		return usage.Result{}, fmt.Errorf("normalize OpenAI Embeddings usage response")
+	}
+	result, _ := accumulator.Finalize(true)
+	return result, nil
+}
+
+type openAIEmbeddingsUsageEnvelope struct {
+	Usage json.RawMessage `json:"usage"`
+}
+
+func decodeOpenAIEmbeddingsUsageEnvelope(body []byte) (openAIEmbeddingsUsageEnvelope, error) {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return openAIEmbeddingsUsageEnvelope{}, fmt.Errorf("decode JSON object")
+	}
+	var envelope openAIEmbeddingsUsageEnvelope
+	if err := json.Unmarshal(trimmed, &envelope); err != nil {
+		return openAIEmbeddingsUsageEnvelope{}, fmt.Errorf("decode JSON object")
+	}
+	return envelope, nil
+}
+
+func openAIEmbeddingsUsageRoot(raw json.RawMessage) map[string]json.RawMessage {
+	root := make(map[string]json.RawMessage, 1)
+	if len(raw) > 0 {
+		root["usage"] = raw
+	}
+	return root
+}
+
+func (*OpenAIEmbeddings) NewUsageStreamExtractor() UsageStreamExtractor {
+	return &openAIEmbeddingsUnsupportedStreamUsage{}
+}
+
+type openAIEmbeddingsUnsupportedStreamUsage struct {
+	finalized bool
+}
+
+func (*openAIEmbeddingsUnsupportedStreamUsage) Observe([]byte) error {
+	return fmt.Errorf("OpenAI Embeddings does not support streaming usage")
+}
+
+func (e *openAIEmbeddingsUnsupportedStreamUsage) Finalize() (usage.Result, bool) {
+	if e.finalized {
+		return usage.Result{}, false
+	}
+	e.finalized = true
+	return usage.Result{State: usage.StateNotApplicable}, true
+}
+
+func openAIEmbeddingsUsagePatch(root map[string]json.RawMessage) (usage.Patch, bool) {
+	usageObject, diagnostics := usageOptionalObject(root, "usage")
+	if usageObject == nil {
+		return usage.Patch{Diagnostics: diagnostics}, false
+	}
+
+	prompt, promptDiagnostics := usageInteger(usageObject, "prompt_tokens", true)
+	diagnostics.Merge(promptDiagnostics)
+	if !usageIntegerUsable(promptDiagnostics) {
+		prompt = nil
+	}
+	total, totalDiagnostics := usageInteger(usageObject, "total_tokens", true)
+	diagnostics.Merge(totalDiagnostics)
+	if !usageIntegerUsable(totalDiagnostics) {
+		total = nil
+	}
+
+	patch := usage.Patch{
+		UncachedInput: prompt,
+		Final:         true,
+		Diagnostics:   diagnostics,
+	}
+	tokens := usage.Tokens{}
+	if prompt != nil {
+		tokens.UncachedInput = *prompt
+	}
+	usageNormalizedTotal(total, tokens, &patch.Diagnostics)
+	return patch, true
+}

--- a/internal/dialect/openai_embeddings_usage_test.go
+++ b/internal/dialect/openai_embeddings_usage_test.go
@@ -1,0 +1,150 @@
+package dialect
+
+import (
+	"strings"
+	"testing"
+
+	"gpt-load/internal/usage"
+)
+
+func TestOpenAIEmbeddingsUsageNonStreaming(t *testing.T) {
+	t.Parallel()
+
+	extractor, ok := any(NewOpenAIEmbeddings()).(UsageExtractor)
+	if !ok {
+		t.Fatal("OpenAI Embeddings does not expose UsageExtractor capability")
+	}
+	tests := []struct {
+		name        string
+		body        string
+		want        usage.Tokens
+		state       usage.State
+		diagnostics []usage.DiagnosticCode
+		wantDelta   *int64
+	}{
+		{
+			name:  "complete input-only usage",
+			body:  `{"object":"list","usage":{"prompt_tokens":7,"total_tokens":7}}`,
+			want:  usage.Tokens{UncachedInput: 7},
+			state: usage.StateComplete,
+		},
+		{
+			name:  "missing usage",
+			body:  `{"object":"list"}`,
+			state: usage.StateMissing,
+		},
+		{
+			name:  "null usage",
+			body:  `{"object":"list","usage":null}`,
+			state: usage.StateMissing,
+		},
+		{
+			name:        "missing prompt tokens",
+			body:        `{"usage":{"total_tokens":0}}`,
+			state:       usage.StateMissing,
+			diagnostics: []usage.DiagnosticCode{usage.DiagnosticMissingRequiredField},
+		},
+		{
+			name:        "missing total tokens",
+			body:        `{"usage":{"prompt_tokens":7}}`,
+			want:        usage.Tokens{UncachedInput: 7},
+			state:       usage.StateComplete,
+			diagnostics: []usage.DiagnosticCode{usage.DiagnosticMissingRequiredField},
+		},
+		{
+			name:        "negative prompt tokens",
+			body:        `{"usage":{"prompt_tokens":-1,"total_tokens":0}}`,
+			state:       usage.StateMissing,
+			diagnostics: []usage.DiagnosticCode{usage.DiagnosticNegativeValue},
+		},
+		{
+			name:        "fractional prompt tokens",
+			body:        `{"usage":{"prompt_tokens":1.5,"total_tokens":0}}`,
+			state:       usage.StateMissing,
+			diagnostics: []usage.DiagnosticCode{usage.DiagnosticInvalidNumber},
+		},
+		{
+			name:        "overflowing prompt tokens",
+			body:        `{"usage":{"prompt_tokens":9223372036854775808,"total_tokens":9223372036854775808}}`,
+			state:       usage.StateMissing,
+			diagnostics: []usage.DiagnosticCode{usage.DiagnosticInvalidNumber},
+		},
+		{
+			name:        "inconsistent total",
+			body:        `{"usage":{"prompt_tokens":7,"total_tokens":9}}`,
+			want:        usage.Tokens{UncachedInput: 7},
+			state:       usage.StateComplete,
+			diagnostics: []usage.DiagnosticCode{usage.DiagnosticInconsistentTotal},
+			wantDelta:   int64Pointer(2),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := extractor.ExtractUsage([]byte(test.body))
+			if err != nil {
+				t.Fatalf("ExtractUsage() error = %v", err)
+			}
+			if result.State != test.state || result.Tokens != test.want {
+				t.Fatalf(
+					"ExtractUsage() = %#v, want state=%q tokens=%#v",
+					result,
+					test.state,
+					test.want,
+				)
+			}
+			requireUsageDiagnostics(t, result.Diagnostics, test.diagnostics...)
+			if test.wantDelta != nil {
+				delta, present := result.Diagnostics.TotalDelta()
+				if !present || delta != *test.wantDelta {
+					t.Fatalf("TotalDelta() = %d, %t, want %d, true", delta, present, *test.wantDelta)
+				}
+			}
+		})
+	}
+}
+
+func TestOpenAIEmbeddingsUsageRejectsMalformedBodies(t *testing.T) {
+	t.Parallel()
+
+	extractor := NewOpenAIEmbeddings()
+	for _, body := range [][]byte{[]byte(`[]`), []byte(`{"usage":{}} {}`)} {
+		if _, err := extractor.ExtractUsage(body); err == nil {
+			t.Fatalf("ExtractUsage(%q) succeeded", body)
+		}
+	}
+}
+
+func TestOpenAIEmbeddingsUsageEnvelopeSkipsVectorData(t *testing.T) {
+	t.Parallel()
+
+	vector := strings.Repeat("A", 1<<20)
+	usageJSON := `{"prompt_tokens":7,"total_tokens":7}`
+	body := []byte(`{"object":"list","data":[{"embedding":"` + vector + `"}],"usage":` + usageJSON + `}`)
+	envelope, err := decodeOpenAIEmbeddingsUsageEnvelope(body)
+	if err != nil || string(envelope.Usage) != usageJSON {
+		t.Fatalf("decodeOpenAIEmbeddingsUsageEnvelope() = %#v, %v", envelope, err)
+	}
+	result, err := NewOpenAIEmbeddings().ExtractUsage(body)
+	if err != nil || result.State != usage.StateComplete ||
+		result.Tokens != (usage.Tokens{UncachedInput: 7}) {
+		t.Fatalf("ExtractUsage() = %#v, %v", result, err)
+	}
+}
+
+func TestOpenAIEmbeddingsUsageStreamIsNotApplicable(t *testing.T) {
+	t.Parallel()
+
+	stream := NewOpenAIEmbeddings().NewUsageStreamExtractor()
+	if err := stream.Observe([]byte(`{"usage":{"prompt_tokens":1,"total_tokens":1}}`)); err == nil {
+		t.Fatal("Observe() error = nil for unsupported Embeddings stream")
+	}
+	result, ok := stream.Finalize()
+	if !ok || result != (usage.Result{State: usage.StateNotApplicable}) {
+		t.Fatalf("Finalize() = %#v, %t", result, ok)
+	}
+	if second, ok := stream.Finalize(); ok || second != (usage.Result{}) {
+		t.Fatalf("second Finalize() = %#v, %t", second, ok)
+	}
+}

--- a/internal/dialect/standard_request.go
+++ b/internal/dialect/standard_request.go
@@ -40,6 +40,10 @@ func standardRequest(
 		selected = NewOpenAIImages()
 		request.Path = openAIImagesGenerationsPath
 		body = map[string]any{"model": model, "prompt": ""}
+	case protocol.OpenAIEmbeddings:
+		selected = NewOpenAIEmbeddings()
+		request.Path = openAIEmbeddingsPath
+		body = map[string]any{"model": model, "input": ""}
 	case protocol.Anthropic:
 		selected = NewAnthropic()
 		request.Path = "/v1/messages"

--- a/internal/execution/bifrost/capabilities.go
+++ b/internal/execution/bifrost/capabilities.go
@@ -61,6 +61,9 @@ func nativeRouteImplemented(
 ) bool {
 	switch providerKind {
 	case channel.ProviderOpenAI:
+		if clientProtocol == protocol.OpenAIEmbeddings {
+			return operation == execution.OperationEmbeddingsCreate || operation == execution.OperationProbe
+		}
 		if clientProtocol == protocol.OpenAIImages {
 			return operation == execution.OperationImagesGenerate || operation == execution.OperationImagesEdit
 		}
@@ -70,6 +73,9 @@ func nativeRouteImplemented(
 	case channel.ProviderGemini:
 		return clientProtocol == protocol.Gemini && standardProtocolOperation(clientProtocol, operation)
 	case channel.ProviderOpenAICompatible:
+		if clientProtocol == protocol.OpenAIEmbeddings {
+			return operation == execution.OperationEmbeddingsCreate || operation == execution.OperationProbe
+		}
 		if clientProtocol == protocol.OpenAIImages {
 			return operation == execution.OperationImagesGenerate || operation == execution.OperationImagesEdit
 		}
@@ -83,7 +89,12 @@ func nativeRouteImplemented(
 		default:
 			return false
 		}
-	case channel.ProviderOpenRouter, channel.ProviderXAI:
+	case channel.ProviderOpenRouter:
+		if clientProtocol == protocol.OpenAIEmbeddings {
+			return operation == execution.OperationEmbeddingsCreate || operation == execution.OperationProbe
+		}
+		return nativeOpenAIProtocolOperation(clientProtocol, operation, false)
+	case channel.ProviderXAI:
 		return nativeOpenAIProtocolOperation(clientProtocol, operation, false)
 	case channel.ProviderGroq:
 		return clientProtocol == protocol.OpenAICompletions && standardProtocolOperation(clientProtocol, operation)

--- a/internal/execution/bifrost/embedding_wire_test.go
+++ b/internal/execution/bifrost/embedding_wire_test.go
@@ -1,0 +1,297 @@
+package bifrost
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	core "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestBifrostEmbeddingWirePreservesRawOpenAIContract(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *schemas.EmbeddingInput
+		body     string
+		response string
+	}{
+		{
+			name:  "string input with optional and unknown fields",
+			input: &schemas.EmbeddingInput{Text: schemas.Ptr("hello")},
+			body:  `{"model":"provider-model","input":"hello","dimensions":3,"encoding_format":"float","user":"user-1","vendor_extension":{"precise":1.2300}}`,
+			response: `{"object":"list","data":[{"object":"embedding","index":0,"embedding":[0.12345678901234567,-0.00000000000000001234]}],` +
+				`"model":"provider-model","usage":{"prompt_tokens":1,"total_tokens":1},"vendor":{"precise":1.2300}}`,
+		},
+		{
+			name:     "string array input and base64 response",
+			input:    &schemas.EmbeddingInput{Texts: []string{"hello", "world"}},
+			body:     `{"model":"provider-model","input":["hello","world"],"encoding_format":"base64"}`,
+			response: `{"object":"list","data":[{"object":"embedding","index":0,"embedding":"AQIDBA=="}],"model":"provider-model","usage":{"prompt_tokens":2,"total_tokens":2}}`,
+		},
+		{
+			name:     "token array input",
+			input:    &schemas.EmbeddingInput{Embedding: []int{10, 20, 30}},
+			body:     `{"model":"provider-model","input":[10,20,30],"encoding_format":"float"}`,
+			response: `{"object":"list","data":[{"object":"embedding","index":0,"embedding":[0.25,-0.5]}],"model":"provider-model","usage":{"prompt_tokens":3,"total_tokens":3}}`,
+		},
+		{
+			name:     "token matrix input",
+			input:    &schemas.EmbeddingInput{Embeddings: [][]int{{10, 20}, {30, 40}}},
+			body:     `{"model":"provider-model","input":[[10,20],[30,40]],"encoding_format":"float"}`,
+			response: `{"object":"list","data":[{"object":"embedding","index":0,"embedding":[0.25,-0.5]},{"object":"embedding","index":1,"embedding":[0.75,-1]}],"model":"provider-model","usage":{"prompt_tokens":4,"total_tokens":4}}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var calls atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				calls.Add(1)
+				if request.URL.Path != "/v1/embeddings" {
+					t.Errorf("path = %q, want /v1/embeddings", request.URL.Path)
+				}
+				if got := request.Header.Get("Authorization"); got != "Bearer "+testAPIKey {
+					t.Errorf("Authorization = %q", got)
+				}
+				body, err := io.ReadAll(request.Body)
+				if err != nil {
+					t.Errorf("read request body: %v", err)
+					return
+				}
+				if !bytes.Equal(body, []byte(test.body)) {
+					t.Errorf("request body changed:\n got: %s\nwant: %s", body, test.body)
+				}
+				writer.Header().Set("Content-Type", "application/json")
+				writer.Header().Set("X-Request-Id", "embedding-request-1")
+				_, _ = io.WriteString(writer, test.response)
+			}))
+			defer server.Close()
+
+			wire := newEmbeddingWireTestRuntime(t, schemas.OpenAI, server.URL+"/v1", true)
+			response, bifrostErr := wire.request(test.input, []byte(test.body), nil)
+			if bifrostErr != nil || response == nil {
+				t.Fatalf("EmbeddingRequest() response=%#v error=%v", response, bifrostErr)
+			}
+			if got := rawEmbeddingResponseBytes(t, response.ExtraFields.RawResponse); !bytes.Equal(got, []byte(test.response)) {
+				t.Fatalf("raw response changed:\n got: %s\nwant: %s", got, test.response)
+			}
+			if calls.Load() != 1 {
+				t.Fatalf("upstream calls = %d, want 1", calls.Load())
+			}
+			if wire.account.keyPoolCalls.Load() != 0 {
+				t.Fatalf("key-pool calls = %d, want DirectKey only", wire.account.keyPoolCalls.Load())
+			}
+		})
+	}
+}
+
+func TestBifrostEmbeddingWireUsesCompleteCompatiblePrefix(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		baseSuffix string
+		wantPath   string
+	}{
+		{name: "standard v1 prefix", baseSuffix: "/v1", wantPath: "/v1/embeddings"},
+		{name: "nonstandard complete prefix", baseSuffix: "/gateway/openai", wantPath: "/gateway/openai/embeddings"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var calls atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				calls.Add(1)
+				if request.URL.Path != test.wantPath {
+					t.Errorf("path = %q, want %q", request.URL.Path, test.wantPath)
+				}
+				writer.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(writer, `{"object":"list","data":[{"object":"embedding","index":0,"embedding":[1]}],"model":"provider-model","usage":{"prompt_tokens":1,"total_tokens":1}}`)
+			}))
+			defer server.Close()
+
+			wire := newEmbeddingWireTestRuntime(t, schemas.OpenAI, server.URL+test.baseSuffix, true)
+			response, bifrostErr := wire.request(
+				&schemas.EmbeddingInput{Text: schemas.Ptr("hello")},
+				[]byte(`{"model":"provider-model","input":"hello"}`),
+				nil,
+			)
+			if bifrostErr != nil || response == nil {
+				t.Fatalf("EmbeddingRequest() response=%#v error=%v", response, bifrostErr)
+			}
+			if calls.Load() != 1 || wire.account.keyPoolCalls.Load() != 0 {
+				t.Fatalf("upstream/key-pool calls = %d/%d, want 1/0", calls.Load(), wire.account.keyPoolCalls.Load())
+			}
+		})
+	}
+}
+
+func TestBifrostEmbeddingWireSupportsOpenRouterTypedRequest(t *testing.T) {
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		calls.Add(1)
+		if request.URL.Path != "/v1/embeddings" {
+			t.Errorf("path = %q, want /v1/embeddings", request.URL.Path)
+		}
+		body, err := io.ReadAll(request.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+			return
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Errorf("decode request body: %v", err)
+			return
+		}
+		if payload["model"] != "provider-model" || payload["input"] != "hello" || payload["dimensions"] != float64(8) || payload["user"] != "user-1" {
+			t.Errorf("typed request body = %s", body)
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(writer, `{"object":"list","data":[{"object":"embedding","index":0,"embedding":[1]}],"model":"provider-model","usage":{"prompt_tokens":1,"total_tokens":1}}`)
+	}))
+	defer server.Close()
+
+	wire := newEmbeddingWireTestRuntime(t, schemas.OpenRouter, server.URL, false)
+	dimensions := 8
+	response, bifrostErr := wire.request(
+		&schemas.EmbeddingInput{Text: schemas.Ptr("hello")},
+		nil,
+		&schemas.EmbeddingParameters{
+			Dimensions: &dimensions,
+			ExtraParams: map[string]any{
+				"user": "user-1",
+			},
+		},
+	)
+	if bifrostErr != nil || response == nil {
+		t.Fatalf("EmbeddingRequest() response=%#v error=%v", response, bifrostErr)
+	}
+	if calls.Load() != 1 || wire.account.keyPoolCalls.Load() != 0 {
+		t.Fatalf("upstream/key-pool calls = %d/%d, want 1/0", calls.Load(), wire.account.keyPoolCalls.Load())
+	}
+}
+
+func TestBifrostEmbeddingWirePreservesNon2xxEvidence(t *testing.T) {
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Header().Set("X-Request-Id", "embedding-429")
+		writer.Header().Set("Retry-After", "3")
+		writer.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(writer, `{"error":{"type":"rate_limit_error","code":"rate_limit","message":"slow down"}}`)
+	}))
+	defer server.Close()
+
+	wire := newEmbeddingWireTestRuntime(t, schemas.OpenAI, server.URL+"/v1", true)
+	response, bifrostErr := wire.request(
+		&schemas.EmbeddingInput{Text: schemas.Ptr("hello")},
+		[]byte(`{"model":"provider-model","input":"hello"}`),
+		nil,
+	)
+	if response != nil || bifrostErr == nil {
+		t.Fatalf("EmbeddingRequest() response=%#v error=%v", response, bifrostErr)
+	}
+	if bifrostErr.StatusCode == nil || *bifrostErr.StatusCode != http.StatusTooManyRequests ||
+		bifrostErr.Error == nil || bifrostErr.Error.Type == nil || *bifrostErr.Error.Type != "rate_limit_error" ||
+		bifrostErr.Error.Code == nil || *bifrostErr.Error.Code != "rate_limit" {
+		t.Fatalf("error evidence = %v", bifrostErr)
+	}
+	headers := wire.responseHeaders()
+	if headers.Get("X-Request-Id") != "embedding-429" || headers.Get("Retry-After") != "3" {
+		t.Fatalf("response headers = %#v", headers)
+	}
+	rawError, err := json.Marshal(bifrostErr.ExtraFields.RawResponse)
+	if err != nil || !bytes.Contains(rawError, []byte(`"rate_limit_error"`)) {
+		t.Fatalf("raw error response = %s, err=%v", rawError, err)
+	}
+	if calls.Load() != 1 || wire.account.keyPoolCalls.Load() != 0 {
+		t.Fatalf("upstream/key-pool calls = %d/%d, want 1/0", calls.Load(), wire.account.keyPoolCalls.Load())
+	}
+}
+
+type embeddingWireTestRuntime struct {
+	core     *core.Bifrost
+	account  *directAccount
+	provider schemas.ModelProvider
+	context  *schemas.BifrostContext
+}
+
+func newEmbeddingWireTestRuntime(
+	t *testing.T,
+	baseProvider schemas.ModelProvider,
+	baseURL string,
+	custom bool,
+) *embeddingWireTestRuntime {
+	t.Helper()
+	provider := baseProvider
+	if custom {
+		provider = customProviderKey(baseProvider, baseURL)
+	}
+	config := providerConfig(baseURL, custom, baseProvider, true)
+	account := newDirectAccount()
+	account.setConfig(provider, config)
+	bifrostCore, err := core.Init(context.Background(), schemas.BifrostConfig{
+		Account:         account,
+		LLMPlugins:      []schemas.LLMPlugin{},
+		MCPPlugins:      []schemas.MCPPlugin{},
+		Logger:          core.NewNoOpLogger(),
+		InitialPoolSize: 1,
+	})
+	if err != nil {
+		t.Fatalf("initialize Bifrost embedding wire: %v", err)
+	}
+	t.Cleanup(bifrostCore.Shutdown)
+	return &embeddingWireTestRuntime{core: bifrostCore, account: account, provider: provider}
+}
+
+func (runtime *embeddingWireTestRuntime) request(
+	input *schemas.EmbeddingInput,
+	rawBody []byte,
+	params *schemas.EmbeddingParameters,
+) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+	bifrostContext := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	bifrostContext.SetValue(schemas.BifrostContextKeyRequestID, "embedding-wire-gate")
+	bifrostContext.SetValue(schemas.BifrostContextKeyDirectKey, schemas.Key{
+		ID:     "embedding-key",
+		Name:   "selected credential",
+		Value:  plainSecret(testAPIKey),
+		Models: schemas.WhiteList{"*"},
+		Weight: 1,
+	})
+	bifrostContext.SetValue(schemas.BifrostContextKeyAllowPerRequestRawOverride, true)
+	bifrostContext.SetValue(schemas.BifrostContextKeySendBackRawResponse, true)
+	bifrostContext.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+	if len(rawBody) > 0 {
+		bifrostContext.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+	}
+	runtime.context = bifrostContext
+	return runtime.core.EmbeddingRequest(bifrostContext, &schemas.BifrostEmbeddingRequest{
+		Provider:       runtime.provider,
+		Model:          "provider-model",
+		Input:          input,
+		Params:         params,
+		RawRequestBody: bytes.Clone(rawBody),
+	})
+}
+
+func (runtime *embeddingWireTestRuntime) responseHeaders() http.Header {
+	return responseHeaders(nil, runtime.context, false)
+}
+
+func rawEmbeddingResponseBytes(t *testing.T, raw any) []byte {
+	t.Helper()
+	switch value := raw.(type) {
+	case json.RawMessage:
+		return bytes.Clone(value)
+	case []byte:
+		return bytes.Clone(value)
+	default:
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			t.Fatalf("marshal raw response: %v", err)
+		}
+		return encoded
+	}
+}

--- a/internal/execution/bifrost/embeddings.go
+++ b/internal/execution/bifrost/embeddings.go
@@ -1,0 +1,456 @@
+package bifrost
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	"github.com/maximhq/bifrost/core/schemas"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/dialect"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+)
+
+const (
+	// Bifrost 1.8.4 compares a compressed Content-Length before decoding. Force
+	// every Embeddings success body through its decoded streaming reader, then
+	// enforce GPT-Load's protocol limit while materializing the raw JSON once.
+	embeddingDecodedResponseThresholdBytes = int64(1)
+	embeddingDecodedResponsePrefetchBytes  = 2
+)
+
+func buildEmbeddingRequest(
+	spec execution.AttemptSpec,
+	provider schemas.ModelProvider,
+) (*schemas.BifrostEmbeddingRequest, error) {
+	sanitized, err := dialect.NewOpenAIEmbeddings().SanitizeRequestForAttempt(
+		&dialect.ParsedRequest{
+			Method: spec.Method, Path: spec.Path, RawQuery: spec.RawQuery,
+			Header: spec.Header.Clone(), Body: bytes.Clone(spec.Body),
+		},
+		spec.UpstreamModel,
+	)
+	if err != nil {
+		return nil, err
+	}
+	input, err := embeddingInputMarker(sanitized.Body)
+	if err != nil {
+		return nil, err
+	}
+	return &schemas.BifrostEmbeddingRequest{
+		Provider:       provider,
+		Model:          spec.UpstreamModel,
+		Input:          input,
+		Fallbacks:      nil,
+		RawRequestBody: bytes.Clone(sanitized.Body),
+	}, nil
+}
+
+func newEmbeddingProbeRequest(
+	provider schemas.ModelProvider,
+	model string,
+) *schemas.BifrostEmbeddingRequest {
+	input := "ping"
+	body, _ := json.Marshal(struct {
+		Model string `json:"model"`
+		Input string `json:"input"`
+	}{Model: model, Input: input})
+	return &schemas.BifrostEmbeddingRequest{
+		Provider:       provider,
+		Model:          model,
+		Input:          &schemas.EmbeddingInput{Text: &input},
+		RawRequestBody: body,
+	}
+}
+
+// embeddingInputMarker preserves only the validated input shape needed by
+// Bifrost's typed preflight. The selected provider receives RawRequestBody, so
+// GPT-Load does not impose Go integer bounds on token IDs or rebuild the wire.
+func embeddingInputMarker(body []byte) (*schemas.EmbeddingInput, error) {
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(body, &object); err != nil {
+		return nil, fmt.Errorf("decode Embeddings request")
+	}
+	raw := bytes.TrimSpace(object["input"])
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("Embeddings input is required")
+	}
+	if raw[0] == '"' {
+		var text string
+		if err := json.Unmarshal(raw, &text); err != nil {
+			return nil, fmt.Errorf("decode Embeddings text input")
+		}
+		return &schemas.EmbeddingInput{Text: &text}, nil
+	}
+	var values []json.RawMessage
+	if err := json.Unmarshal(raw, &values); err != nil || values == nil {
+		return nil, fmt.Errorf("decode Embeddings array input")
+	}
+	if len(values) == 0 {
+		return &schemas.EmbeddingInput{Texts: []string{}}, nil
+	}
+	first := bytes.TrimSpace(values[0])
+	if len(first) == 0 {
+		return nil, fmt.Errorf("decode Embeddings array input")
+	}
+	switch first[0] {
+	case '"':
+		var texts []string
+		if err := json.Unmarshal(raw, &texts); err != nil {
+			return nil, fmt.Errorf("decode Embeddings text array")
+		}
+		return &schemas.EmbeddingInput{Texts: texts}, nil
+	case '[':
+		return &schemas.EmbeddingInput{Embeddings: [][]int{}}, nil
+	default:
+		return &schemas.EmbeddingInput{Embedding: []int{}}, nil
+	}
+}
+
+func embeddingTypedTarget(
+	providerKind channel.ProviderKind,
+	targetConfig json.RawMessage,
+	rawQuery string,
+) (string, error) {
+	resourcePath := "/v1/embeddings"
+	baseURL, configured, err := targetBaseURL(targetConfig)
+	if err != nil {
+		return "", err
+	}
+	switch providerKind {
+	case channel.ProviderOpenAI:
+	case channel.ProviderOpenRouter:
+		// OpenRouter concatenates the configured provider base URL with the
+		// context path, so the per-request override must remain relative.
+		return appendTypedQuery(resourcePath, rawQuery), nil
+	case channel.ProviderOpenAICompatible:
+		if !configured {
+			return "", fmt.Errorf("compatible Embeddings target is required")
+		}
+		resourcePath = "/embeddings"
+	default:
+		return "", fmt.Errorf("unsupported Embeddings provider")
+	}
+	if configured {
+		return resolveTypedTargetURL(baseURL, resourcePath, rawQuery)
+	}
+	return appendTypedQuery(resourcePath, rawQuery), nil
+}
+
+func enableEmbeddingWireFidelity(ctx *schemas.BifrostContext) {
+	if ctx == nil {
+		return
+	}
+	ctx.SetValue(schemas.BifrostContextKeyAllowPerRequestRawOverride, true)
+	ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+	ctx.SetValue(schemas.BifrostContextKeySendBackRawResponse, true)
+	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+	ctx.SetValue(
+		schemas.BifrostContextKeyLargeResponseThreshold,
+		embeddingDecodedResponseThresholdBytes,
+	)
+	ctx.SetValue(
+		schemas.BifrostContextKeyLargePayloadPrefetchSize,
+		embeddingDecodedResponsePrefetchBytes,
+	)
+}
+
+func (r *Runtime) executeEmbedding(
+	parent context.Context,
+	spec execution.AttemptSpec,
+	prepared preparedAttempt,
+) execution.AttemptResult {
+	requestContext, requestCancel := boundedRequestContext(parent, spec.Timeouts.Request)
+	defer requestCancel()
+	callContext, callCancel := context.WithCancel(requestContext)
+	defer callCancel()
+
+	bifrostContext := r.newSDKContext(callContext, spec, prepared.directKey)
+	enableEmbeddingWireFidelity(bifrostContext)
+	setTypedRequestURL(bifrostContext, prepared.typedURL)
+	outcomeChannel := make(chan embeddingSDKResult, 1)
+	go func() {
+		response, bifrostError := r.core.EmbeddingRequest(bifrostContext, prepared.embeddingRequest)
+		outcomeChannel <- embeddingSDKResult{response: response, err: bifrostError}
+	}()
+
+	var outcome embeddingSDKResult
+	select {
+	case outcome = <-outcomeChannel:
+		if requestContext.Err() != nil {
+			return unaryContextFailure(requestContext, false)
+		}
+	case <-callContext.Done():
+		return unaryContextFailure(requestContext, false)
+	}
+	if outcome.err != nil {
+		result := unaryErrorResult(outcome.err, bifrostContext, prepared.secrets)
+		clearEmbeddingErrorRaw(outcome.err)
+		return result
+	}
+	var materializedHeaders http.Header
+	if large, _ := bifrostContext.Value(schemas.BifrostContextKeyLargeResponseMode).(bool); large {
+		materializedHeaders = responseHeaders(nil, bifrostContext, false)
+		body, tooLarge, materializeErr := materializeEmbeddingLargeResponse(
+			bifrostContext,
+			r.unaryResponseBodyLimit(spec),
+		)
+		if requestContext.Err() != nil {
+			return unaryContextFailure(requestContext, false)
+		}
+		if tooLarge {
+			return startedUnaryFailure(
+				http.StatusOK,
+				materializedHeaders,
+				execution.ErrorKindInternal,
+				"upstream response exceeds size limit",
+			)
+		}
+		if materializeErr != nil {
+			return startedUnaryFailure(
+				http.StatusOK,
+				materializedHeaders,
+				execution.ErrorKindProvider,
+				"read upstream Embeddings response",
+			)
+		}
+		var headerErr error
+		materializedHeaders, headerErr = normalizeMaterializedEmbeddingHeaders(
+			materializedHeaders,
+			len(body),
+		)
+		if headerErr != nil {
+			return startedUnaryFailure(
+				http.StatusOK,
+				materializedHeaders,
+				execution.ErrorKindProvider,
+				"unsupported Embeddings response encoding",
+			)
+		}
+		decoded, err := materializedEmbeddingResponse(body)
+		if err != nil {
+			return startedUnaryFailure(
+				http.StatusOK,
+				materializedHeaders,
+				execution.ErrorKindProvider,
+				"decode upstream Embeddings response",
+			)
+		}
+		outcome.response = decoded
+	}
+	if outcome.response == nil {
+		return attemptedUnaryFailure(execution.ErrorKindInternal, "execution runtime returned no Embeddings response")
+	}
+	body, ok := takeRawEmbeddingResponse(outcome.response)
+	headers := materializedHeaders
+	if headers == nil {
+		headers = responseHeaders(outcome.response.ExtraFields.ProviderResponseHeaders, bifrostContext, false)
+	}
+	if !ok {
+		return startedUnaryFailure(
+			http.StatusOK,
+			headers,
+			execution.ErrorKindInternal,
+			"execution runtime returned no raw Embeddings response",
+		)
+	}
+	// The raw body is the response authority. Clear typed data defensively before
+	// alias projection and gateway processing.
+	outcome.response.Data = nil
+	if spec.Operation == execution.OperationProbe && !validEmbeddingProbeResponse(body) {
+		return startedUnaryFailure(
+			http.StatusOK,
+			headers,
+			execution.ErrorKindProvider,
+			"upstream returned an invalid Embeddings probe response",
+		)
+	}
+	model := openAIResponseModel(body, "")
+	if spec.Operation != execution.OperationProbe && needsClientModelAlias(spec) {
+		var err error
+		body, err = rewriteClientResponseModel(spec.ClientProtocol, body, spec.ClientModel)
+		if err != nil {
+			return startedUnaryFailure(http.StatusOK, headers, execution.ErrorKindInternal, "rewrite Embeddings response model")
+		}
+	}
+	return execution.AttemptResult{
+		DispatchState:     execution.DispatchMaybeSent,
+		ResponseStarted:   true,
+		StatusCode:        http.StatusOK,
+		Header:            headers,
+		Body:              body,
+		Model:             model,
+		UpstreamRequestID: upstreamRequestID(headers),
+	}
+}
+
+func materializedEmbeddingResponse(body []byte) (*schemas.BifrostEmbeddingResponse, error) {
+	if !json.Valid(body) {
+		return nil, fmt.Errorf("invalid Embeddings response JSON")
+	}
+	response := &schemas.BifrostEmbeddingResponse{}
+	response.ExtraFields.RawResponse = json.RawMessage(body)
+	return response, nil
+}
+
+func materializeEmbeddingLargeResponse(
+	ctx *schemas.BifrostContext,
+	limit int64,
+) (body []byte, tooLarge bool, err error) {
+	if ctx == nil || limit <= 0 {
+		return nil, false, fmt.Errorf("invalid Embeddings response limit")
+	}
+	reader, ok := ctx.Value(schemas.BifrostContextKeyLargeResponseReader).(*providerUtils.LargeResponseReader)
+	if !ok || reader == nil || reader.Resp == nil {
+		return nil, false, fmt.Errorf("missing Embeddings response reader")
+	}
+	stopCancellation := providerUtils.SetupStreamCancellation(ctx, reader.Resp.BodyStream(), nil)
+	defer func() {
+		stopCancellation()
+		if closeErr := reader.Close(); err == nil && closeErr != nil {
+			err = closeErr
+		}
+		clearEmbeddingLargeResponseContext(ctx)
+	}()
+
+	body, err = io.ReadAll(io.LimitReader(reader, limit+1))
+	if err != nil {
+		abortEmbeddingLargeResponse(ctx, reader, err)
+		return nil, false, err
+	}
+	if int64(len(body)) > limit {
+		abortEmbeddingLargeResponse(
+			ctx,
+			reader,
+			fmt.Errorf("Embeddings response exceeds size limit"),
+		)
+		return nil, true, nil
+	}
+	return body, false, nil
+}
+
+func abortEmbeddingLargeResponse(
+	ctx *schemas.BifrostContext,
+	reader *providerUtils.LargeResponseReader,
+	cause error,
+) {
+	if ctx == nil || reader == nil || reader.Resp == nil {
+		return
+	}
+	if closed, _ := ctx.GetAndSetValue(
+		schemas.BifrostContextKeyConnectionClosed,
+		true,
+	).(bool); closed {
+		return
+	}
+	bodyStream := reader.Resp.BodyStream()
+	if closer, ok := bodyStream.(interface{ CloseWithError(error) error }); ok {
+		_ = closer.CloseWithError(cause)
+		return
+	}
+	if closer, ok := bodyStream.(io.Closer); ok {
+		_ = closer.Close()
+	}
+}
+
+func clearEmbeddingLargeResponseContext(ctx *schemas.BifrostContext) {
+	if ctx == nil {
+		return
+	}
+	for _, key := range []schemas.BifrostContextKey{
+		schemas.BifrostContextKeyLargeResponseMode,
+		schemas.BifrostContextKeyLargeResponseReader,
+		schemas.BifrostContextKeyLargeResponseContentLength,
+		schemas.BifrostContextKeyLargeResponseContentType,
+		schemas.BifrostContextKeyLargePayloadResponsePreview,
+	} {
+		ctx.ClearValue(key)
+	}
+}
+
+func normalizeMaterializedEmbeddingHeaders(
+	headers http.Header,
+	bodyLength int,
+) (http.Header, error) {
+	result := headers.Clone()
+	if result == nil {
+		result = make(http.Header)
+	}
+	// The Bifrost decoded reader does not retain a reliable signal that the
+	// upstream representation was compressed. Treat every materialized body as
+	// changed so stale validators can never describe different wire bytes.
+	for _, name := range []string{
+		"ETag", "Digest", "Content-MD5", "Content-Range",
+		"Content-Digest", "Repr-Digest", "Signature", "Signature-Input",
+	} {
+		result.Del(name)
+	}
+	encoding := strings.ToLower(strings.TrimSpace(result.Get("Content-Encoding")))
+	switch encoding {
+	case "", "identity":
+		result.Del("Content-Encoding")
+	case "gzip":
+		result.Del("Content-Encoding")
+	default:
+		return result, fmt.Errorf("unsupported Content-Encoding %q", encoding)
+	}
+	result.Del("Content-Length")
+	result.Set("Content-Length", strconv.Itoa(bodyLength))
+	return result, nil
+}
+
+func validEmbeddingProbeResponse(body []byte) bool {
+	var envelope struct {
+		Data []struct {
+			Embedding json.RawMessage `json:"embedding"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil || len(envelope.Data) == 0 {
+		return false
+	}
+	embedding := bytes.TrimSpace(envelope.Data[0].Embedding)
+	return len(embedding) > 0 && !bytes.Equal(embedding, []byte("null"))
+}
+
+func takeRawEmbeddingResponse(response *schemas.BifrostEmbeddingResponse) ([]byte, bool) {
+	if response == nil {
+		return nil, false
+	}
+	raw := response.ExtraFields.RawResponse
+	response.ExtraFields.RawResponse = nil
+	switch value := raw.(type) {
+	case json.RawMessage:
+		return value, len(value) > 0
+	case []byte:
+		return value, len(value) > 0
+	case string:
+		return []byte(value), value != ""
+	default:
+		return nil, false
+	}
+}
+
+func clearEmbeddingErrorRaw(bifrostError *schemas.BifrostError) {
+	if bifrostError == nil {
+		return
+	}
+	bifrostError.ExtraFields.RawRequest = nil
+	bifrostError.ExtraFields.RawResponse = nil
+}
+
+func normalizeEmbeddingsAttemptResult(spec execution.AttemptSpec, result *execution.AttemptResult) {
+	if result == nil || spec.ClientProtocol != protocol.OpenAIEmbeddings {
+		return
+	}
+	if result.Error != nil && result.Error.ReplaySafety == "" {
+		result.Error.ReplaySafety = execution.ReplaySafetyUnknown
+	}
+}

--- a/internal/execution/bifrost/embeddings_probe_test.go
+++ b/internal/execution/bifrost/embeddings_probe_test.go
@@ -1,0 +1,126 @@
+package bifrost
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+)
+
+func TestOpenAIEmbeddingsProbeUsesMinimalNativeWire(t *testing.T) {
+	t.Parallel()
+
+	for _, responseBody := range []string{
+		`{"object":"list","data":[{"index":0,"embedding":[0.1]}]}`,
+		`{"object":"list","data":[{"index":0,"embedding":"AAAA"}]}`,
+	} {
+		responseBody := responseBody
+		t.Run(responseBody, func(t *testing.T) {
+			t.Parallel()
+			var calls atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				calls.Add(1)
+				if request.Method != http.MethodPost || request.URL.Path != "/tenant/api/v4/embeddings" {
+					t.Errorf("probe target = %s %s", request.Method, request.URL.Path)
+				}
+				if request.Header.Get("Authorization") != "Bearer "+testAPIKey {
+					t.Errorf("Authorization = %q", request.Header.Get("Authorization"))
+				}
+				body, err := io.ReadAll(request.Body)
+				if err != nil {
+					t.Errorf("read probe body: %v", err)
+					return
+				}
+				var payload map[string]json.RawMessage
+				if err := json.Unmarshal(body, &payload); err != nil {
+					t.Errorf("decode probe body: %v", err)
+					return
+				}
+				if len(payload) != 2 || string(payload["model"]) != `"probe-upstream"` ||
+					string(payload["input"]) != `"ping"` {
+					t.Errorf("probe body = %s", body)
+				}
+				writer.Header().Set("Content-Type", "application/json")
+				writer.Header().Set("X-Request-Id", "embedding-probe")
+				_, _ = io.WriteString(writer, responseBody)
+			}))
+			defer server.Close()
+
+			runtime := newProtocolTestRuntime(t, testRuntimeOptions{allowPrivateNetwork: true})
+			result := runtime.Execute(context.Background(), embeddingsProbeSpec(
+				t, channel.OpenAICompatible, server.URL+"/tenant/api/v4",
+			))
+			if err := result.Validate(); err != nil {
+				t.Fatalf("result validation: %v; result=%+v", err, result)
+			}
+			if calls.Load() != 1 || result.Error != nil || result.StatusCode != http.StatusOK ||
+				result.UpstreamProtocol != protocol.OpenAIEmbeddings ||
+				result.UpstreamRequestID != "embedding-probe" {
+				t.Fatalf("calls/result = %d/%+v", calls.Load(), result)
+			}
+		})
+	}
+}
+
+func TestOpenAIEmbeddingsProbeRejectsInvalidSuccessShape(t *testing.T) {
+	t.Parallel()
+
+	for _, responseBody := range []string{
+		`{"object":"list","data":[]}`,
+		`{"object":"list","data":[{"index":0}]}`,
+		`{"object":"list","data":[{"index":0,"embedding":null}]}`,
+	} {
+		responseBody := responseBody
+		t.Run(responseBody, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				writer.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(writer, responseBody)
+			}))
+			defer server.Close()
+
+			runtime := newProtocolTestRuntime(t, testRuntimeOptions{allowPrivateNetwork: true})
+			result := runtime.Execute(context.Background(), embeddingsProbeSpec(
+				t, channel.OpenAICompatible, server.URL+"/v1",
+			))
+			if err := result.Validate(); err != nil {
+				t.Fatalf("result validation: %v; result=%+v", err, result)
+			}
+			if result.Error == nil || result.StatusCode != http.StatusOK ||
+				result.DispatchState != execution.DispatchMaybeSent || !result.ResponseStarted {
+				t.Fatalf("invalid probe result = %+v", result)
+			}
+		})
+	}
+}
+
+func embeddingsProbeSpec(
+	t *testing.T,
+	channelID channel.ID,
+	baseURL string,
+) execution.AttemptSpec {
+	t.Helper()
+	target, err := json.Marshal(map[string]string{"base_url": baseURL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	spec := utilitySpec(
+		channelID,
+		protocol.OpenAIEmbeddings,
+		execution.OperationProbe,
+		"",
+		"",
+		nil,
+	)
+	spec.TargetConfig = target
+	spec.ClientModel = "probe-client"
+	spec.UpstreamModel = "probe-upstream"
+	return freezeTestAttempt(spec)
+}

--- a/internal/execution/bifrost/embeddings_probe_test.go
+++ b/internal/execution/bifrost/embeddings_probe_test.go
@@ -14,7 +14,7 @@ import (
 	"gpt-load/internal/protocol"
 )
 
-func TestOpenAIEmbeddingsProbeUsesMinimalNativeWire(t *testing.T) {
+func TestOpenAIEmbeddingsProbeUsesMinimalNativeWireAndResolvedTarget(t *testing.T) {
 	t.Parallel()
 
 	for _, responseBody := range []string{
@@ -55,7 +55,7 @@ func TestOpenAIEmbeddingsProbeUsesMinimalNativeWire(t *testing.T) {
 
 			runtime := newProtocolTestRuntime(t, testRuntimeOptions{allowPrivateNetwork: true})
 			result := runtime.Execute(context.Background(), embeddingsProbeSpec(
-				t, channel.OpenAICompatible, server.URL+"/tenant/api/v4",
+				t, channel.OpenAICompatible, " "+server.URL+"/tenant/api/v4/ ",
 			))
 			if err := result.Validate(); err != nil {
 				t.Fatalf("result validation: %v; result=%+v", err, result)

--- a/internal/execution/bifrost/embeddings_test.go
+++ b/internal/execution/bifrost/embeddings_test.go
@@ -1,0 +1,446 @@
+package bifrost
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/maximhq/bifrost/core/schemas"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+)
+
+func TestOpenAIEmbeddingsRuntimeUsesOneTypedRawWireForSupportedChannels(t *testing.T) {
+	t.Parallel()
+
+	const responseBody = `{"object":"list","data":[{"object":"embedding","index":0,"embedding":[0.12345678901234567,-0.00000000000000001234]}],"model":"provider-model","usage":{"prompt_tokens":1,"total_tokens":1},"vendor":{"precise":1.2300}}`
+	for _, test := range []struct {
+		name       string
+		channelID  channel.ID
+		baseSuffix string
+		wantPath   string
+	}{
+		{name: "OpenAI", channelID: channel.OpenAI, wantPath: "/v1/embeddings"},
+		{name: "OpenRouter", channelID: channel.OpenRouter, wantPath: "/v1/embeddings"},
+		{name: "OpenAI Compatible complete prefix", channelID: channel.OpenAICompatible, baseSuffix: "/tenant/api/v4", wantPath: "/tenant/api/v4/embeddings"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				if request.URL.Path != test.wantPath {
+					t.Errorf("path = %q, want %q", request.URL.Path, test.wantPath)
+				}
+				if got := request.Header.Get("Authorization"); got != "Bearer "+testAPIKey {
+					t.Errorf("Authorization = %q", got)
+				}
+				body, err := io.ReadAll(request.Body)
+				if err != nil {
+					t.Errorf("read request body: %v", err)
+					return
+				}
+				var object map[string]json.RawMessage
+				if err := json.Unmarshal(body, &object); err != nil {
+					t.Errorf("request body = %s: %v", body, err)
+					return
+				}
+				if string(object["model"]) != `"provider-model"` ||
+					string(object["input"]) != `"hello"` ||
+					string(object["dimensions"]) != `8` ||
+					string(object["user"]) != `"tenant"` ||
+					string(object["vendor_extension"]) != `{"precise":1.2300}` {
+					t.Errorf("typed/raw request changed: %s", body)
+				}
+				for _, field := range []string{"stream", "provider", "fallbacks", "api_key"} {
+					if _, exists := object[field]; exists {
+						t.Errorf("control field %q reached upstream: %s", field, body)
+					}
+				}
+				writer.Header().Set("Content-Type", "application/json")
+				writer.Header().Set("X-Request-Id", "embedding-request")
+				_, _ = io.WriteString(writer, responseBody)
+			}))
+			defer server.Close()
+
+			options := testRuntimeOptions{allowPrivateNetwork: true}
+			if test.channelID == channel.OpenAI {
+				options.openAIBaseURL = server.URL
+			}
+			runtime := newProtocolTestRuntime(t, options)
+			spec := openAIEmbeddingsSpec(test.channelID, server.URL+test.baseSuffix,
+				[]byte(`{"model":"provider-model","input":"hello","stream":false,"dimensions":8,"user":"tenant","provider":"client","fallbacks":["other"],"api_key":"client","vendor_extension":{"precise":1.2300}}`))
+			result := runtime.Execute(context.Background(), spec)
+
+			if err := result.Validate(); err != nil {
+				t.Fatalf("result validation: %v; result=%+v", err, result)
+			}
+			if result.Error != nil || result.StatusCode != http.StatusOK ||
+				result.DispatchState != execution.DispatchMaybeSent || !result.ResponseStarted ||
+				result.Model != "provider-model" || result.UpstreamProtocol != protocol.OpenAIEmbeddings ||
+				result.UpstreamRequestID != "embedding-request" || !bytes.Equal(result.Body, []byte(responseBody)) {
+				t.Fatalf("result = %+v error=%+v body=%s", result, result.Error, result.Body)
+			}
+			if runtime.keyPoolCalls() != 0 {
+				t.Fatalf("key-pool calls = %d, want DirectKey only", runtime.keyPoolCalls())
+			}
+		})
+	}
+}
+
+func TestOpenAIEmbeddingsRequestShapeAndCapabilityAreExact(t *testing.T) {
+	t.Parallel()
+
+	manager := &RuntimeManager{}
+	for _, providerKind := range []channel.ProviderKind{
+		channel.ProviderOpenAI,
+		channel.ProviderOpenRouter,
+		channel.ProviderOpenAICompatible,
+	} {
+		for _, operation := range []execution.Operation{
+			execution.OperationEmbeddingsCreate,
+			execution.OperationProbe,
+		} {
+			if err := manager.ValidateRouteCapability(providerKind, channel.RouteDescriptor{
+				ClientProtocol: protocol.OpenAIEmbeddings,
+				Operation:      operation,
+				RouteMode:      execution.RouteNative,
+			}); err != nil {
+				t.Errorf("ValidateRouteCapability(%q, %q) error = %v", providerKind, operation, err)
+			}
+		}
+	}
+	for _, providerKind := range []channel.ProviderKind{
+		channel.ProviderAnthropic,
+		channel.ProviderGemini,
+		channel.ProviderXAI,
+	} {
+		if err := manager.ValidateRouteCapability(providerKind, channel.RouteDescriptor{
+			ClientProtocol: protocol.OpenAIEmbeddings,
+			Operation:      execution.OperationEmbeddingsCreate,
+			RouteMode:      execution.RouteNative,
+		}); err == nil {
+			t.Errorf("provider %q unexpectedly supports Embeddings", providerKind)
+		}
+	}
+
+	valid := openAIEmbeddingsSpec(channel.OpenAICompatible, "https://example.com/v1",
+		[]byte(`{"model":"provider-model","input":"hello"}`))
+	if !supportedRequestShape(valid, false) || supportedRequestShape(valid, true) {
+		t.Fatal("Embeddings shape must be unary only")
+	}
+	for _, mutate := range []func(*execution.AttemptSpec){
+		func(spec *execution.AttemptSpec) { spec.Method = http.MethodGet },
+		func(spec *execution.AttemptSpec) { spec.Path = "/v1/embedding" },
+		func(spec *execution.AttemptSpec) { spec.Operation = execution.OperationChatCompletion },
+		func(spec *execution.AttemptSpec) { spec.RouteMode = execution.RouteConverted },
+	} {
+		invalid := valid.Clone()
+		mutate(&invalid)
+		if supportedRequestShape(invalid, false) {
+			t.Errorf("invalid Embeddings shape was accepted: %+v", invalid)
+		}
+	}
+
+	probe := valid.Clone()
+	probe.Operation = execution.OperationProbe
+	probe.Method = ""
+	probe.Path = ""
+	probe.Body = nil
+	if !supportedRequestShape(probe, false) || supportedRequestShape(probe, true) {
+		t.Fatal("Embeddings probe shape must be semantic and unary only")
+	}
+}
+
+func TestTakeRawEmbeddingResponseMovesOwnershipAndClearsRaw(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`{"object":"list","data":[{"embedding":[1]}]}`)
+	response := &schemas.BifrostEmbeddingResponse{}
+	response.ExtraFields.RawResponse = raw
+	body, ok := takeRawEmbeddingResponse(response)
+	if !ok || !bytes.Equal(body, raw) {
+		t.Fatalf("takeRawEmbeddingResponse() = %s, %t", body, ok)
+	}
+	if response.ExtraFields.RawResponse != nil {
+		t.Fatalf("RawResponse remains = %#v", response.ExtraFields.RawResponse)
+	}
+	if len(body) == 0 || unsafe.SliceData(body) != unsafe.SliceData([]byte(raw)) {
+		t.Fatal("takeRawEmbeddingResponse copied the owned response body")
+	}
+}
+
+func TestMaterializedEmbeddingResponseKeepsVectorsOpaque(t *testing.T) {
+	t.Parallel()
+
+	for _, body := range [][]byte{
+		[]byte(`{"object":"list","data":[{"index":0,"embedding":[0.12345678901234567,1]}]}`),
+		[]byte(`{"object":"list","data":[{"index":0,"embedding":"AAAA"}]}`),
+	} {
+		response, err := materializedEmbeddingResponse(body)
+		if err != nil {
+			t.Fatalf("materializedEmbeddingResponse(%s) error = %v", body, err)
+		}
+		if response.Data != nil {
+			t.Fatalf("materializedEmbeddingResponse(%s) decoded vector data", body)
+		}
+		raw, ok := takeRawEmbeddingResponse(response)
+		if !ok || !bytes.Equal(raw, body) || unsafe.SliceData(raw) != unsafe.SliceData(body) {
+			t.Fatalf("materializedEmbeddingResponse(%s) did not retain raw body ownership", body)
+		}
+	}
+
+	if _, err := materializedEmbeddingResponse([]byte(`{"data":[}`)); err == nil {
+		t.Fatal("materializedEmbeddingResponse accepted invalid JSON")
+	}
+}
+
+func TestEmbeddingWireFidelityFlagsAreRequestLocal(t *testing.T) {
+	t.Parallel()
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	enableEmbeddingWireFidelity(ctx)
+	for _, key := range []schemas.BifrostContextKey{
+		schemas.BifrostContextKeyAllowPerRequestRawOverride,
+		schemas.BifrostContextKeyUseRawRequestBody,
+		schemas.BifrostContextKeySendBackRawResponse,
+		schemas.BifrostContextKeyPassthroughExtraParams,
+	} {
+		if value, ok := ctx.Value(key).(bool); !ok || !value {
+			t.Errorf("context flag %q = %#v", key, ctx.Value(key))
+		}
+	}
+	if got, _ := ctx.Value(schemas.BifrostContextKeyLargeResponseThreshold).(int64); got != embeddingDecodedResponseThresholdBytes {
+		t.Fatalf("decoded response threshold = %d", got)
+	}
+	if got, _ := ctx.Value(schemas.BifrostContextKeyLargePayloadPrefetchSize).(int); got != embeddingDecodedResponsePrefetchBytes {
+		t.Fatalf("decoded response prefetch = %d", got)
+	}
+}
+
+func TestOpenAIEmbeddingsProviderRejectionRemainsReplayUnknown(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Header().Set("X-Request-Id", "embedding-rejected")
+		writer.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(writer, `{"error":{"type":"invalid_request_error","code":"unsupported_model","message":"unsupported"}}`)
+	}))
+	defer server.Close()
+
+	runtime := newProtocolTestRuntime(t, testRuntimeOptions{allowPrivateNetwork: true})
+	result := runtime.Execute(context.Background(), openAIEmbeddingsSpec(
+		channel.OpenAICompatible,
+		server.URL+"/v1",
+		[]byte(`{"model":"provider-model","input":"hello"}`),
+	))
+	if result.DispatchState != execution.DispatchMaybeSent || !result.ResponseStarted ||
+		result.StatusCode != http.StatusBadRequest || result.Error == nil ||
+		result.Error.ReplaySafety != execution.ReplaySafetyUnknown ||
+		result.UpstreamRequestID != "embedding-rejected" {
+		t.Fatalf("result = %+v error=%+v", result, result.Error)
+	}
+}
+
+func TestOpenAIEmbeddingsRuntimeEnforcesConfiguredResponseLimit(t *testing.T) {
+	const limit = int64(4 << 10)
+	for _, test := range []struct {
+		name      string
+		bodyBytes int
+		wantError bool
+	}{
+		{name: "below limit", bodyBytes: int(limit) - 1},
+		{name: "above limit", bodyBytes: int(limit) + 1, wantError: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			prefix := []byte(`{"object":"list","data":[{"index":0,"embedding":"`)
+			suffix := []byte(`"}]}`)
+			payloadBytes := test.bodyBytes - len(prefix) - len(suffix)
+			body := make([]byte, 0, test.bodyBytes)
+			body = append(body, prefix...)
+			body = append(body, bytes.Repeat([]byte{'A'}, payloadBytes)...)
+			body = append(body, suffix...)
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				writer.Header().Set("Content-Type", "application/json")
+				_, _ = writer.Write(body)
+			}))
+			defer server.Close()
+
+			runtime := newProtocolTestRuntime(t, testRuntimeOptions{
+				allowPrivateNetwork:       true,
+				maxUnaryResponseBodyBytes: limit,
+			})
+			result := runtime.Execute(context.Background(), openAIEmbeddingsSpec(
+				channel.OpenAICompatible,
+				server.URL+"/v1",
+				[]byte(`{"model":"provider-model","input":"hello","encoding_format":"base64"}`),
+			))
+			if err := result.Validate(); err != nil {
+				t.Fatalf("result validation: %v; result=%+v", err, result)
+			}
+			if test.wantError {
+				if result.Error == nil || result.DispatchState != execution.DispatchMaybeSent ||
+					!result.ResponseStarted || len(result.Body) != 0 ||
+					result.Error.ReplaySafety != execution.ReplaySafetyUnknown {
+					t.Fatalf("over-limit result = %+v", result)
+				}
+				return
+			}
+			if result.Error != nil || !bytes.Equal(result.Body, body) {
+				t.Fatalf("below-limit result = %+v body=%d/%d", result, len(result.Body), len(body))
+			}
+		})
+	}
+}
+
+func TestOpenAIEmbeddingsRuntimeBoundsDecodedGzipResponse(t *testing.T) {
+	const limit = int64(4 << 10)
+	for _, test := range []struct {
+		name      string
+		bodyBytes int
+		wantError bool
+	}{
+		{name: "decoded body below limit", bodyBytes: int(limit) - 1},
+		{name: "decoded body above limit", bodyBytes: int(limit) + 1, wantError: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			plain := embeddingResponseBodyOfSize(t, test.bodyBytes)
+			var encoded bytes.Buffer
+			writer := gzip.NewWriter(&encoded)
+			if _, err := writer.Write(plain); err != nil {
+				t.Fatal(err)
+			}
+			if err := writer.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if encoded.Len() >= test.bodyBytes {
+				t.Fatalf("gzip fixture did not compress: %d >= %d", encoded.Len(), test.bodyBytes)
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+				response.Header().Set("Content-Type", "application/json")
+				response.Header().Set("Content-Encoding", "gzip")
+				response.Header().Set("ETag", `"compressed-wire"`)
+				_, _ = response.Write(encoded.Bytes())
+			}))
+			defer server.Close()
+
+			runtime := newProtocolTestRuntime(t, testRuntimeOptions{
+				allowPrivateNetwork:       true,
+				maxUnaryResponseBodyBytes: limit,
+			})
+			result := runtime.Execute(context.Background(), openAIEmbeddingsSpec(
+				channel.OpenAICompatible,
+				server.URL+"/v1",
+				[]byte(`{"model":"provider-model","input":"hello","encoding_format":"base64"}`),
+			))
+			if err := result.Validate(); err != nil {
+				t.Fatalf("result validation: %v; result=%+v", err, result)
+			}
+			if test.wantError {
+				if result.Error == nil || len(result.Body) != 0 ||
+					result.Error.ReplaySafety != execution.ReplaySafetyUnknown {
+					t.Fatalf("over-limit gzip result = %+v", result)
+				}
+				return
+			}
+			if result.Error != nil || !bytes.Equal(result.Body, plain) ||
+				result.Header.Get("Content-Encoding") != "" ||
+				result.Header.Get("ETag") != "" {
+				t.Fatalf("below-limit gzip result = %+v body=%d/%d", result, len(result.Body), len(plain))
+			}
+		})
+	}
+}
+
+func TestOpenAIEmbeddingsOverLimitResponseDoesNotDrainStalledStream(t *testing.T) {
+	const limit = int64(32 << 10)
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		response.Header().Set("Content-Type", "application/json")
+		response.Header().Set("Content-Length", "131072")
+		response.WriteHeader(http.StatusOK)
+		_, _ = response.Write(bytes.Repeat([]byte{'A'}, 64<<10))
+		response.(http.Flusher).Flush()
+		<-release
+	}))
+	defer server.Close()
+
+	runtime := newProtocolTestRuntime(t, testRuntimeOptions{
+		allowPrivateNetwork:       true,
+		maxUnaryResponseBodyBytes: limit,
+	})
+	spec := openAIEmbeddingsSpec(
+		channel.OpenAICompatible,
+		server.URL+"/v1",
+		[]byte(`{"model":"provider-model","input":"hello"}`),
+	)
+	spec.Timeouts.Request = 50 * time.Millisecond
+	resultChannel := make(chan execution.AttemptResult, 1)
+	go func() {
+		resultChannel <- runtime.Execute(context.Background(), spec)
+	}()
+
+	var result execution.AttemptResult
+	returnedPromptly := true
+	select {
+	case result = <-resultChannel:
+	case <-time.After(250 * time.Millisecond):
+		returnedPromptly = false
+	}
+	close(release)
+	if !returnedPromptly {
+		select {
+		case <-resultChannel:
+		case <-time.After(time.Second):
+		}
+		t.Fatal("over-limit response blocked while draining a stalled upstream stream")
+	}
+	if err := result.Validate(); err != nil || result.Error == nil ||
+		result.Error.ReplaySafety != execution.ReplaySafetyUnknown {
+		t.Fatalf("result = %+v validation=%v", result, err)
+	}
+}
+
+func embeddingResponseBodyOfSize(t *testing.T, size int) []byte {
+	t.Helper()
+	prefix := []byte(`{"object":"list","data":[{"index":0,"embedding":"`)
+	suffix := []byte(`"}]}`)
+	payloadBytes := size - len(prefix) - len(suffix)
+	if payloadBytes < 0 {
+		t.Fatalf("response fixture size %d is too small", size)
+	}
+	body := make([]byte, 0, size)
+	body = append(body, prefix...)
+	body = append(body, bytes.Repeat([]byte{'A'}, payloadBytes)...)
+	body = append(body, suffix...)
+	return body
+}
+
+func openAIEmbeddingsSpec(channelID channel.ID, baseURL string, body []byte) execution.AttemptSpec {
+	return freezeTestAttempt(execution.NewAttemptSpec(execution.AttemptSpec{
+		RequestID: "embeddings-request", AttemptID: "embeddings-attempt", Sequence: 1,
+		ChannelID: string(channelID), RouteMode: execution.RouteNative,
+		ClientProtocol: protocol.OpenAIEmbeddings, Operation: execution.OperationEmbeddingsCreate,
+		RouteRequirement: execution.RouteRequirementNative,
+		ClientModel:      "provider-model", UpstreamModel: "provider-model",
+		Method: http.MethodPost, Path: "/v1/embeddings", Query: make(map[string][]string),
+		Header: http.Header{
+			"Content-Type":        {"application/json"},
+			"Authorization":       {"Bearer client"},
+			"Proxy-Authorization": {"Basic client"},
+			"Api-Key":             {"client"},
+			"X-Api-Key":           {"client"},
+		},
+		Body: body, TargetConfig: json.RawMessage(`{"base_url":"` + baseURL + `"}`),
+		Timeouts:   execution.AttemptTimeouts{FirstByte: time.Second, Request: 2 * time.Second},
+		Credential: execution.NewCredentialSnapshot(23, 1, 1, []byte(`{"api_key":"`+testAPIKey+`"}`)),
+	}))
+}

--- a/internal/execution/bifrost/executor.go
+++ b/internal/execution/bifrost/executor.go
@@ -478,7 +478,7 @@ func (r *Runtime) prepare(spec execution.AttemptSpec, stream bool) (preparedAtte
 	}
 	if spec.Operation == execution.OperationProbe {
 		if spec.ClientProtocol == protocol.OpenAIEmbeddings {
-			typedURL, targetErr := embeddingTypedTarget(providerKind, spec.TargetConfig, "")
+			typedURL, targetErr := embeddingTypedTarget(providerKind, resolved.TargetConfig, "")
 			if targetErr != nil {
 				failure := notSentUnaryFailure(execution.ErrorKindInvalidRequest, "invalid Embeddings probe target")
 				return preparedAttempt{}, &failure

--- a/internal/execution/bifrost/executor.go
+++ b/internal/execution/bifrost/executor.go
@@ -35,6 +35,7 @@ type preparedAttempt struct {
 	mode               channel.RouteMode
 	upstreamProtocol   protocol.Protocol
 	request            *schemas.BifrostChatRequest
+	embeddingRequest   *schemas.BifrostEmbeddingRequest
 	responsesRequest   *schemas.BifrostResponsesRequest
 	countTokensRequest *schemas.BifrostResponsesRequest
 	listModelsRequest  *schemas.BifrostListModelsRequest
@@ -50,6 +51,11 @@ type unarySDKResult struct {
 	err      *schemas.BifrostError
 }
 
+type embeddingSDKResult struct {
+	response *schemas.BifrostEmbeddingResponse
+	err      *schemas.BifrostError
+}
+
 type streamSDKResult struct {
 	stream chan *schemas.BifrostStreamChunk
 	err    *schemas.BifrostError
@@ -59,6 +65,7 @@ type streamSDKResult struct {
 func (r *Runtime) Execute(parent context.Context, spec execution.AttemptSpec) (result execution.AttemptResult) {
 	defer func() {
 		normalizeImagesAttemptResult(spec, &result)
+		normalizeEmbeddingsAttemptResult(spec, &result)
 	}()
 	prepared, preflightError := r.prepare(spec, false)
 	if preflightError != nil {
@@ -79,6 +86,9 @@ func (r *Runtime) Execute(parent context.Context, spec execution.AttemptSpec) (r
 			result.Error.Hint = execution.FailureHintRequestRejected
 		}
 	}()
+	if prepared.embeddingRequest != nil {
+		return r.executeEmbedding(parent, spec, prepared)
+	}
 	if prepared.passthrough != nil {
 		return r.executeNative(parent, spec, prepared)
 	}
@@ -467,6 +477,19 @@ func (r *Runtime) prepare(spec execution.AttemptSpec, stream bool) (preparedAtte
 		directKey.UseAnthropicEndpoints = schemas.Ptr(true)
 	}
 	if spec.Operation == execution.OperationProbe {
+		if spec.ClientProtocol == protocol.OpenAIEmbeddings {
+			typedURL, targetErr := embeddingTypedTarget(providerKind, spec.TargetConfig, "")
+			if targetErr != nil {
+				failure := notSentUnaryFailure(execution.ErrorKindInvalidRequest, "invalid Embeddings probe target")
+				return preparedAttempt{}, &failure
+			}
+			return preparedAttempt{
+				provider: provider, mode: mode, upstreamProtocol: protocol.OpenAIEmbeddings,
+				embeddingRequest: newEmbeddingProbeRequest(provider, spec.UpstreamModel),
+				typedURL:         typedURL, clientProtocol: spec.ClientProtocol,
+				directKey: directKey, secrets: secrets,
+			}, nil
+		}
 		if mode == channel.RouteNative && providerKind == channel.ProviderGoogleVertex {
 			passthroughPath, pathErr := vertexNativeGeminiPath(spec.UpstreamModel, "generateContent")
 			if pathErr != nil {
@@ -518,6 +541,26 @@ func (r *Runtime) prepare(spec execution.AttemptSpec, stream bool) (preparedAtte
 			prepared.request = request
 		}
 		return prepared, nil
+	}
+	if spec.Operation == execution.OperationEmbeddingsCreate {
+		request, conversionErr := buildEmbeddingRequest(spec, provider)
+		if conversionErr != nil {
+			failure := notSentUnaryFailure(execution.ErrorKindInvalidRequest, "invalid Embeddings request body")
+			failure.Error.OriginHint = execution.ErrorOriginClient
+			failure.Error.ScopeHint = execution.ErrorScopeRequest
+			failure.Error.ReplaySafety = execution.ReplaySafetyUnknown
+			return preparedAttempt{}, &failure
+		}
+		typedURL, targetErr := embeddingTypedTarget(providerKind, resolved.TargetConfig, safeQuery)
+		if targetErr != nil {
+			failure := notSentUnaryFailure(execution.ErrorKindInvalidRequest, "invalid Embeddings target")
+			return preparedAttempt{}, &failure
+		}
+		return preparedAttempt{
+			provider: provider, mode: mode, upstreamProtocol: protocol.OpenAIEmbeddings,
+			embeddingRequest: request, typedURL: typedURL,
+			clientProtocol: spec.ClientProtocol, directKey: directKey, secrets: secrets,
+		}, nil
 	}
 	if mode == channel.RouteNative && providerSupportsPassthrough(providerKind, customTargetBaseURL, spec.ClientProtocol) {
 		body, sanitizedHeaders, err := sanitizeNativePassthroughRequest(spec, stream)
@@ -744,14 +787,17 @@ func providerKindNativeForClient(providerKind channel.ProviderKind, clientProtoc
 	switch providerKind {
 	case channel.ProviderOpenAI, channel.ProviderOpenAICompatible:
 		return clientProtocol == protocol.OpenAICompletions || clientProtocol == protocol.OpenAIResponses ||
-			clientProtocol == protocol.OpenAIImages
+			clientProtocol == protocol.OpenAIImages || clientProtocol == protocol.OpenAIEmbeddings
 	case channel.ProviderAnthropic:
 		return clientProtocol == protocol.Anthropic
 	case channel.ProviderGemini:
 		return clientProtocol == protocol.Gemini
 	case channel.ProviderGoogleVertex:
 		return clientProtocol == protocol.Gemini
-	case channel.ProviderDeepSeek, channel.ProviderOpenRouter, channel.ProviderGroq, channel.ProviderXAI:
+	case channel.ProviderOpenRouter:
+		return clientProtocol == protocol.OpenAICompletions || clientProtocol == protocol.OpenAIResponses ||
+			clientProtocol == protocol.OpenAIEmbeddings
+	case channel.ProviderDeepSeek, channel.ProviderGroq, channel.ProviderXAI:
 		return clientProtocol == protocol.OpenAICompletions || clientProtocol == protocol.OpenAIResponses
 	default:
 		return false
@@ -778,7 +824,8 @@ func supportedRequestShape(spec execution.AttemptSpec, stream bool) bool {
 			return false
 		}
 		switch spec.ClientProtocol {
-		case protocol.OpenAICompletions, protocol.OpenAIResponses, protocol.Anthropic, protocol.Gemini:
+		case protocol.OpenAICompletions, protocol.OpenAIResponses, protocol.OpenAIEmbeddings,
+			protocol.Anthropic, protocol.Gemini:
 			return true
 		default:
 			return false
@@ -819,6 +866,10 @@ func supportedRequestShape(spec execution.AttemptSpec, stream bool) bool {
 		default:
 			return false
 		}
+	case protocol.OpenAIEmbeddings:
+		return !stream && spec.RouteMode == execution.RouteNative &&
+			spec.Operation == execution.OperationEmbeddingsCreate &&
+			spec.Method == http.MethodPost && spec.Path == "/v1/embeddings"
 	case protocol.Anthropic:
 		return spec.Method == http.MethodPost &&
 			((spec.Operation == execution.OperationChatCompletion && spec.Path == "/v1/messages") ||

--- a/internal/execution/bifrost/list_models.go
+++ b/internal/execution/bifrost/list_models.go
@@ -103,31 +103,10 @@ func sanitizeListModelsResponse(provider schemas.ModelProvider, response *schema
 	clone := *response
 	clone.Data = append([]schemas.Model(nil), response.Data...)
 	prefix := string(provider) + "/"
-	filtered := clone.Data[:0]
-	for _, model := range clone.Data {
-		if provider == schemas.OpenRouter && embeddingOnlyOutputModel(model) {
-			continue
-		}
-		model.ID = strings.TrimPrefix(model.ID, prefix)
-		filtered = append(filtered, model)
+	for index := range clone.Data {
+		clone.Data[index].ID = strings.TrimPrefix(clone.Data[index].ID, prefix)
 	}
-	clear(clone.Data[len(filtered):])
-	clone.Data = filtered
 	clone.ExtraFields = schemas.BifrostResponseExtraFields{}
 	clone.KeyStatuses = nil
 	return &clone
-}
-
-func embeddingOnlyOutputModel(model schemas.Model) bool {
-	if model.Architecture == nil || len(model.Architecture.OutputModalities) == 0 {
-		return false
-	}
-	for _, modality := range model.Architecture.OutputModalities {
-		switch strings.ToLower(strings.TrimSpace(modality)) {
-		case "embedding", "embeddings":
-		default:
-			return false
-		}
-	}
-	return true
 }

--- a/internal/execution/bifrost/list_models_test.go
+++ b/internal/execution/bifrost/list_models_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-func TestSanitizeListModelsResponseFiltersOnlyOpenRouterEmbeddingOnlyModels(t *testing.T) {
+func TestSanitizeListModelsResponsePreservesOpenRouterEmbeddingModels(t *testing.T) {
 	t.Parallel()
 
 	response := &schemas.BifrostListModelsResponse{Data: []schemas.Model{
@@ -23,16 +23,21 @@ func TestSanitizeListModelsResponseFiltersOnlyOpenRouterEmbeddingOnlyModels(t *t
 	for _, model := range got.Data {
 		gotIDs = append(gotIDs, model.ID)
 	}
-	if want := []string{"text", "mixed", "unknown"}; !reflect.DeepEqual(gotIDs, want) {
+	if want := []string{"text", "embedding-singular", "embedding-plural", "mixed", "unknown"}; !reflect.DeepEqual(gotIDs, want) {
 		t.Fatalf("sanitized OpenRouter models = %v, want %v", gotIDs, want)
 	}
-	if response.Data[0].ID != "openrouter/text" || len(response.Data) != 5 {
-		t.Fatalf("sanitize mutated source response: %#v", response.Data)
+	originalIDs := make([]string, 0, len(response.Data))
+	for _, model := range response.Data {
+		originalIDs = append(originalIDs, model.ID)
 	}
-	for index, model := range got.Data[len(got.Data):cap(got.Data)] {
-		if !reflect.DeepEqual(model, schemas.Model{}) {
-			t.Fatalf("filtered model tail at index %d was retained: %#v", index, model)
-		}
+	if want := []string{
+		"openrouter/text",
+		"openrouter/embedding-singular",
+		"openrouter/embedding-plural",
+		"openrouter/mixed",
+		"openrouter/unknown",
+	}; !reflect.DeepEqual(originalIDs, want) {
+		t.Fatalf("sanitize mutated source response: %#v", response.Data)
 	}
 
 	other := sanitizeListModelsResponse(schemas.OpenAI, &schemas.BifrostListModelsResponse{Data: []schemas.Model{{

--- a/internal/execution/bifrost/runtime.go
+++ b/internal/execution/bifrost/runtime.go
@@ -209,6 +209,7 @@ func providerConfig(baseURL string, custom bool, baseProvider schemas.ModelProvi
 				ListModels:           true,
 				ChatCompletion:       true,
 				ChatCompletionStream: true,
+				Embedding:            true,
 				Passthrough:          true,
 				PassthroughStream:    true,
 			},
@@ -219,6 +220,7 @@ func providerConfig(baseURL string, custom bool, baseProvider schemas.ModelProvi
 			customConfig.RequestPathOverrides = map[schemas.RequestType]string{
 				schemas.ChatCompletionRequest:       baseURL + "/chat/completions",
 				schemas.ChatCompletionStreamRequest: baseURL + "/chat/completions",
+				schemas.EmbeddingRequest:            baseURL + "/embeddings",
 			}
 		}
 		config.CustomProviderConfig = customConfig

--- a/internal/execution/bifrost/runtime_manager_test.go
+++ b/internal/execution/bifrost/runtime_manager_test.go
@@ -1198,8 +1198,9 @@ func TestProductionRuntimeManagerUsesNativeProviderListModelsPaths(t *testing.T)
 			if test.channelID == channel.OpenRouter {
 				wantCalls = 2
 			}
+			wantEmbeddingModel := test.channelID == channel.OpenRouter
 			if calls.Load() != wantCalls || !bytes.Contains(result.Body, []byte(`"id":"model-one"`)) ||
-				bytes.Contains(result.Body, []byte(`"id":"embedding-only"`)) {
+				bytes.Contains(result.Body, []byte(`"id":"embedding-only"`)) != wantEmbeddingModel {
 				t.Fatalf("calls/body = %d/%s", calls.Load(), result.Body)
 			}
 		})

--- a/internal/execution/contracts.go
+++ b/internal/execution/contracts.go
@@ -42,6 +42,7 @@ const (
 	OperationResponsesPassthrough Operation = "responses_passthrough"
 	OperationImagesGenerate       Operation = "images_generate"
 	OperationImagesEdit           Operation = "images_edit"
+	OperationEmbeddingsCreate     Operation = "embeddings_create"
 	OperationListModels           Operation = "list_models"
 	OperationProbe                Operation = "probe"
 )
@@ -61,6 +62,7 @@ func (o Operation) Valid() bool {
 		OperationResponsesPassthrough,
 		OperationImagesGenerate,
 		OperationImagesEdit,
+		OperationEmbeddingsCreate,
 		OperationListModels,
 		OperationProbe:
 		return true
@@ -86,7 +88,7 @@ const (
 // ReplayPolicy returns the operation-level replay contract.
 func (o Operation) ReplayPolicy() ReplayPolicy {
 	switch o {
-	case OperationImagesGenerate, OperationImagesEdit:
+	case OperationImagesGenerate, OperationImagesEdit, OperationEmbeddingsCreate:
 		return ReplayPolicyRequireRejectedBeforeProcessing
 	default:
 		return ReplayPolicyLegacy

--- a/internal/execution/contracts_test.go
+++ b/internal/execution/contracts_test.go
@@ -29,6 +29,7 @@ func TestOperationAndDispatchEnums(t *testing.T) {
 		OperationResponsesPassthrough,
 		OperationImagesGenerate,
 		OperationImagesEdit,
+		OperationEmbeddingsCreate,
 		OperationListModels,
 		OperationProbe,
 	}
@@ -40,7 +41,11 @@ func TestOperationAndDispatchEnums(t *testing.T) {
 	if Operation("unknown").Valid() {
 		t.Fatal("expected unknown operation to be invalid")
 	}
-	for _, operation := range []Operation{OperationImagesGenerate, OperationImagesEdit} {
+	for _, operation := range []Operation{
+		OperationImagesGenerate,
+		OperationImagesEdit,
+		OperationEmbeddingsCreate,
+	} {
 		if !operationRequiresModel(operation) {
 			t.Fatalf("operation %q must require a model", operation)
 		}
@@ -439,6 +444,7 @@ func TestValidationAcceptsValidContractsAndRejectsInvalidFields(t *testing.T) {
 		OperationResponsesCompact,
 		OperationResponsesInputTokens,
 		OperationCountTokens,
+		OperationEmbeddingsCreate,
 		OperationProbe,
 	} {
 		modelRequired := spec.Clone()

--- a/internal/execution/resource_limits.go
+++ b/internal/execution/resource_limits.go
@@ -3,10 +3,11 @@ package execution
 import "gpt-load/internal/protocol"
 
 const (
-	DefaultUnaryResponseBodyLimitBytes      = int64(32 << 20)
-	OpenAIImagesUnaryResponseBodyLimitBytes = int64(64 << 20)
-	DefaultSSEEventLimitBytes               = 10 << 20
-	OpenAIImagesSSEEventLimitBytes          = 32 << 20
+	DefaultUnaryResponseBodyLimitBytes          = int64(32 << 20)
+	OpenAIImagesUnaryResponseBodyLimitBytes     = int64(64 << 20)
+	OpenAIEmbeddingsUnaryResponseBodyLimitBytes = int64(64 << 20)
+	DefaultSSEEventLimitBytes                   = 10 << 20
+	OpenAIImagesSSEEventLimitBytes              = 32 << 20
 )
 
 // UnaryResponseBodyLimit returns the internal buffered success-response limit
@@ -14,6 +15,9 @@ const (
 func UnaryResponseBodyLimit(clientProtocol protocol.Protocol) int64 {
 	if clientProtocol == protocol.OpenAIImages {
 		return OpenAIImagesUnaryResponseBodyLimitBytes
+	}
+	if clientProtocol == protocol.OpenAIEmbeddings {
+		return OpenAIEmbeddingsUnaryResponseBodyLimitBytes
 	}
 	return DefaultUnaryResponseBodyLimitBytes
 }

--- a/internal/execution/resource_limits_test.go
+++ b/internal/execution/resource_limits_test.go
@@ -13,6 +13,9 @@ func TestProtocolResourceLimits(t *testing.T) {
 	if got := UnaryResponseBodyLimit(protocol.OpenAIImages); got != 64<<20 {
 		t.Fatalf("Images unary response body limit = %d", got)
 	}
+	if got := UnaryResponseBodyLimit(protocol.OpenAIEmbeddings); got != 64<<20 {
+		t.Fatalf("Embeddings unary response body limit = %d", got)
+	}
 	if got := SSEEventLimit(protocol.OpenAICompletions); got != 10<<20 {
 		t.Fatalf("default SSE event limit = %d", got)
 	}

--- a/internal/execution/responsealias/response_alias.go
+++ b/internal/execution/responsealias/response_alias.go
@@ -65,6 +65,8 @@ func modelRewriter(clientProtocol protocol.Protocol) (dialect.ModelRewriter, err
 		return dialect.NewOpenAIResponses(), nil
 	case protocol.OpenAIImages:
 		return dialect.NewOpenAIImages(), nil
+	case protocol.OpenAIEmbeddings:
+		return dialect.NewOpenAIEmbeddings(), nil
 	case protocol.Anthropic:
 		return dialect.NewAnthropic(), nil
 	case protocol.Gemini:

--- a/internal/execution/responsealias/response_alias_test.go
+++ b/internal/execution/responsealias/response_alias_test.go
@@ -17,6 +17,7 @@ func TestRewriteJSONCoversClientProtocolShapes(t *testing.T) {
 	}{
 		{name: "OpenAI chat", clientProtocol: protocol.OpenAICompletions, body: `{"model":"provider-model","choices":[]}`},
 		{name: "OpenAI Responses", clientProtocol: protocol.OpenAIResponses, body: `{"type":"response.completed","response":{"model":"provider-model"}}`},
+		{name: "OpenAI Embeddings", clientProtocol: protocol.OpenAIEmbeddings, body: `{"object":"list","model":"provider-model","data":[]}`},
 		{name: "Anthropic", clientProtocol: protocol.Anthropic, body: `{"type":"message_start","message":{"model":"provider-model"}}`},
 		{name: "Gemini", clientProtocol: protocol.Gemini, body: `{"modelVersion":"provider-model","candidates":[]}`},
 	} {

--- a/internal/execution/validation.go
+++ b/internal/execution/validation.go
@@ -307,6 +307,7 @@ func operationRequiresModel(operation Operation) bool {
 		operation == OperationCountTokens ||
 		operation == OperationImagesGenerate ||
 		operation == OperationImagesEdit ||
+		operation == OperationEmbeddingsCreate ||
 		operation == OperationProbe
 }
 

--- a/internal/gateway/embeddings_response_representation_test.go
+++ b/internal/gateway/embeddings_response_representation_test.go
@@ -82,6 +82,27 @@ func TestEmbeddingsSuccessRepresentationFailsClosedOnCredentialOutsideVector(t *
 	}
 }
 
+func TestEmbeddingsSuccessRepresentationScansObjectVectorsForCredentials(t *testing.T) {
+	t.Parallel()
+
+	for _, body := range [][]byte{
+		[]byte(`{"object":"list","data":[{"embedding":{"vendor":"sk-secret"}}]}`),
+		[]byte(`{"object":"list","data":[{"embedding":{"sk-secret":1}}]}`),
+		[]byte(`{"object":"list","data":[{"embedding":[1,{"vendor":"sk-secret"}]}]}`),
+	} {
+		_, err := (&responseProcessor{redactor: redact.New()}).prepareSuccessRepresentation(
+			embeddingsForwardInput("model", "model"),
+			http.StatusOK,
+			http.Header{"Content-Type": {"application/json"}},
+			body,
+			[]string{"sk-secret"},
+		)
+		if err == nil {
+			t.Fatalf("prepareSuccessRepresentation(%s) error = nil, want fail closed", body)
+		}
+	}
+}
+
 func TestEmbeddingsSuccessRepresentationFailsClosedOnDuplicateOpaqueKeys(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gateway/embeddings_response_representation_test.go
+++ b/internal/gateway/embeddings_response_representation_test.go
@@ -1,0 +1,178 @@
+package gateway
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"net/http"
+	"strconv"
+	"testing"
+	"unsafe"
+
+	"gpt-load/internal/dialect"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/platform/redact"
+	"gpt-load/internal/protocol"
+)
+
+func TestEmbeddingsSuccessRepresentationPreservesOpaqueVectorsAndAliasesTopLevelModel(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"object":"list","model":"provider-model","data":[{"object":"embedding","index":0,"embedding":[0.12345678901234567,1]},{"object":"embedding","index":1,"embedding":"AAAA"}],"future":{"model":"provider-model","precise":1.2300}}`)
+	prepared, err := (&responseProcessor{redactor: redact.New()}).prepareSuccessRepresentation(
+		embeddingsForwardInput("public-model", "provider-model"),
+		http.StatusOK,
+		http.Header{"Content-Type": {"application/json"}},
+		body,
+		[]string{"A", "1"},
+	)
+	if err != nil {
+		t.Fatalf("prepareSuccessRepresentation() error = %v", err)
+	}
+	for _, want := range [][]byte{
+		[]byte(`"model":"public-model"`),
+		[]byte(`"embedding":[0.12345678901234567,1]`),
+		[]byte(`"embedding":"AAAA"`),
+		[]byte(`"future":{"model":"provider-model","precise":1.2300}`),
+	} {
+		if !bytes.Contains(prepared.downstream, want) {
+			t.Fatalf("downstream = %s, want %s", prepared.downstream, want)
+		}
+	}
+}
+
+func TestEmbeddingsSuccessRepresentationReusesAlreadyProjectedOpaqueBody(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"object":"list","model":"public-model","data":[{"embedding":[0.1]}]}`)
+	prepared, err := (&responseProcessor{redactor: redact.New()}).prepareSuccessRepresentation(
+		embeddingsForwardInput("public-model", "provider-model"),
+		http.StatusOK,
+		http.Header{"Content-Type": {"application/json"}},
+		body,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("prepareSuccessRepresentation() error = %v", err)
+	}
+	if !prepared.changed || len(prepared.downstream) == 0 ||
+		unsafe.SliceData(prepared.downstream) != unsafe.SliceData(body) {
+		t.Fatalf("prepared response copied or lost alias metadata: %#v", prepared)
+	}
+}
+
+func TestEmbeddingsSuccessRepresentationFailsClosedOnCredentialOutsideVector(t *testing.T) {
+	t.Parallel()
+
+	for _, body := range [][]byte{
+		[]byte(`{"object":"list","data":[{"embedding":[1]}],"vendor":"sk-secret"}`),
+		[]byte(`{"object":"list","data":[{"embedding":[1]}],"embedding":"sk-secret"}`),
+		[]byte(`{"object":"list","data":[{"embedding":[1]}],"vendor":{"embedding":"sk-secret"}}`),
+	} {
+		_, err := (&responseProcessor{redactor: redact.New()}).prepareSuccessRepresentation(
+			embeddingsForwardInput("model", "model"),
+			http.StatusOK,
+			http.Header{"Content-Type": {"application/json"}},
+			body,
+			[]string{"sk-secret"},
+		)
+		if err == nil {
+			t.Fatalf("prepareSuccessRepresentation(%s) error = nil, want fail closed", body)
+		}
+	}
+}
+
+func TestEmbeddingsSuccessRepresentationFailsClosedOnDuplicateOpaqueKeys(t *testing.T) {
+	t.Parallel()
+
+	for _, body := range [][]byte{
+		[]byte(`{"object":"list","data":[{"embedding":"sk-secret"}],"data":[{"embedding":[1]}]}`),
+		[]byte(`{"object":"list","data":[{"embedding":"sk-secret","embedding":[1]}]}`),
+	} {
+		_, err := (&responseProcessor{redactor: redact.New()}).prepareSuccessRepresentation(
+			embeddingsForwardInput("model", "model"),
+			http.StatusOK,
+			http.Header{"Content-Type": {"application/json"}},
+			body,
+			[]string{"sk-secret"},
+		)
+		if err == nil {
+			t.Fatalf("prepareSuccessRepresentation(%s) error = nil, want duplicate-key rejection", body)
+		}
+	}
+}
+
+func TestEmbeddingsSuccessRepresentationFailsClosedOnMalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	_, err := (&responseProcessor{redactor: redact.New()}).prepareSuccessRepresentation(
+		embeddingsForwardInput("model", "model"),
+		http.StatusOK,
+		http.Header{"Content-Type": {"application/json"}},
+		[]byte(`{"object":"list","data":[{"embedding":[1]}]`),
+		[]string{"sk-secret"},
+	)
+	if err == nil {
+		t.Fatal("prepareSuccessRepresentation() error = nil, want malformed JSON rejection")
+	}
+}
+
+func TestEmbeddingsSuccessRepresentationDecodesContentCodingBeforeOpaqueHandling(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"object":"list","model":"provider-model","data":[{"embedding":"AAAA"}]}`)
+	var encoded bytes.Buffer
+	writer := gzip.NewWriter(&encoded)
+	if _, err := writer.Write(body); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := (&responseProcessor{redactor: redact.New()}).prepareSuccessRepresentation(
+		embeddingsForwardInput("public-model", "provider-model"),
+		http.StatusOK,
+		http.Header{"Content-Type": {"application/json"}, "Content-Encoding": {"gzip"}},
+		encoded.Bytes(),
+		[]string{"A"},
+	)
+	if err != nil {
+		t.Fatalf("prepareSuccessRepresentation() error = %v", err)
+	}
+	if prepared.headers.Get("Content-Encoding") != "" ||
+		prepared.headers.Get("Content-Length") != strconv.Itoa(len(prepared.downstream)) ||
+		!bytes.Contains(prepared.downstream, []byte(`"model":"public-model"`)) ||
+		!bytes.Contains(prepared.downstream, []byte(`"embedding":"AAAA"`)) {
+		t.Fatalf("prepared = headers=%v body=%s", prepared.headers, prepared.downstream)
+	}
+}
+
+func TestEmbeddingsExecutionBoundaryMovesLargeBodyOwnership(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"object":"list","data":[{"embedding":[1]}]}`)
+	result := execution.AttemptResult{
+		DispatchState:   execution.DispatchMaybeSent,
+		ResponseStarted: true,
+		StatusCode:      http.StatusOK,
+		Body:            body,
+	}
+	upstream := upstreamFromExecutionResult(
+		context.Background(),
+		ForwardInput{ClientProtocol: protocol.OpenAIEmbeddings},
+		result,
+	)
+	if !bytes.Equal(upstream.Body, body) || unsafe.SliceData(upstream.Body) != unsafe.SliceData(body) {
+		t.Fatal("upstreamFromExecutionResult copied the owned Embeddings body")
+	}
+}
+
+func embeddingsForwardInput(externalModel, upstreamModel string) ForwardInput {
+	return ForwardInput{
+		Dialect:         dialect.NewOpenAIEmbeddings(),
+		ClientProtocol:  protocol.OpenAIEmbeddings,
+		Operation:       execution.OperationEmbeddingsCreate,
+		ExternalModel:   externalModel,
+		UpstreamModelID: upstreamModel,
+	}
+}

--- a/internal/gateway/execution_forward.go
+++ b/internal/gateway/execution_forward.go
@@ -47,7 +47,8 @@ func (forwarder *ExecutionForwarder) Forward(
 	}
 	result := upstreamFromExecutionResult(ctx, input, executionResult)
 	result = forwarder.prepareBufferedResult(input, result)
-	if input.ClientProtocol == protocol.OpenAIImages && input.ObserveUsage &&
+	if (input.ClientProtocol == protocol.OpenAIImages ||
+		input.ClientProtocol == protocol.OpenAIEmbeddings) && input.ObserveUsage &&
 		result.HasResponse() && result.StatusCode >= http.StatusOK &&
 		result.StatusCode < http.StatusMultipleChoices &&
 		result.Usage.State == usage.StateMissing && forwarder.usageCapture != nil {
@@ -55,6 +56,10 @@ func (forwarder *ExecutionForwarder) Forward(
 			input.Dialect,
 			result.ClassificationBody,
 		)
+	}
+	if input.ClientProtocol == protocol.OpenAIEmbeddings && result.Err == nil &&
+		result.StatusCode >= http.StatusOK && result.StatusCode < http.StatusMultipleChoices {
+		result.ClassificationBody = nil
 	}
 	return result
 }
@@ -736,10 +741,11 @@ func upstreamFromExecutionResult(
 		upstream.AppliedReasoning = result.AppliedReasoning.Clone()
 	}
 	upstream.UpstreamProtocol = result.UpstreamProtocol
-	if input.ClientProtocol == protocol.OpenAIImages {
-		// AttemptResult owns Body after the executor returns. The buffered Images
-		// representation consumes it synchronously, so move that ownership across
-		// the internal boundary instead of cloning a large base64 payload twice.
+	if input.ClientProtocol == protocol.OpenAIImages ||
+		input.ClientProtocol == protocol.OpenAIEmbeddings {
+		// AttemptResult owns Body after the executor returns. Buffered opaque
+		// representations consume it synchronously, so move that ownership across
+		// the internal boundary instead of cloning a large payload twice.
 		upstream.Body = result.Body
 		upstream.ClassificationBody = result.Body
 	} else {

--- a/internal/gateway/execution_forward_test.go
+++ b/internal/gateway/execution_forward_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unsafe"
 
 	"gpt-load/internal/dialect"
 	"gpt-load/internal/execution"
@@ -161,6 +162,45 @@ func TestExecutionForwarderCapturesImagesUsageFromUnaryBody(t *testing.T) {
 		Tokens: usage.Tokens{UncachedInput: 100, Output: 30},
 	}
 	if result.Err != nil || result.Usage != want {
+		t.Fatalf("Forward() usage = %#v, want %#v; result=%#v", result.Usage, want, result)
+	}
+}
+
+func TestExecutionForwarderCapturesEmbeddingsUsageFromUnaryBody(t *testing.T) {
+	t.Parallel()
+
+	responseBody := []byte(`{"object":"list","model":"upstream-embedding","data":[{"object":"embedding","index":0,"embedding":[0.1,0.2]}],"usage":{"prompt_tokens":7,"total_tokens":7}}`)
+	executor := fakeExecutionExecutor{unary: func(
+		_ context.Context,
+		_ execution.AttemptSpec,
+	) execution.AttemptResult {
+		return execution.AttemptResult{
+			DispatchState:   execution.DispatchMaybeSent,
+			ResponseStarted: true,
+			StatusCode:      http.StatusOK,
+			Header:          http.Header{"Content-Type": {"application/json"}},
+			Body:            responseBody,
+			Model:           "upstream-embedding",
+		}
+	}}
+	input := executionForwardInput()
+	input.Dialect = dialect.NewOpenAIEmbeddings()
+	input.ClientProtocol = protocol.OpenAIEmbeddings
+	input.ObserveUsage = true
+	input.Operation = execution.OperationEmbeddingsCreate
+	input.RouteRequirement = execution.RouteRequirementNative
+	input.ExternalModel = "upstream-embedding"
+	input.UpstreamModelID = "upstream-embedding"
+	input.Request.Path = "/v1/embeddings"
+	input.Request.Body = []byte(`{"model":"upstream-embedding","input":"hello"}`)
+
+	result := NewExecutionForwarder(executor).Forward(context.Background(), input)
+	want := usage.Result{
+		State:  usage.StateComplete,
+		Tokens: usage.Tokens{UncachedInput: 7},
+	}
+	if result.Err != nil || result.Usage != want || result.ClassificationBody != nil ||
+		len(result.Body) == 0 || unsafe.SliceData(result.Body) != unsafe.SliceData(responseBody) {
 		t.Fatalf("Forward() usage = %#v, want %#v; result=%#v", result.Usage, want, result)
 	}
 }

--- a/internal/gateway/models.go
+++ b/internal/gateway/models.go
@@ -136,6 +136,7 @@ func modelListProtocols(value protocol.Protocol) []protocol.Protocol {
 			protocol.OpenAICompletions,
 			protocol.OpenAIResponses,
 			protocol.OpenAIImages,
+			protocol.OpenAIEmbeddings,
 		}
 	}
 	return []protocol.Protocol{value}

--- a/internal/gateway/models_test.go
+++ b/internal/gateway/models_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"gpt-load/internal/channel"
+	"gpt-load/internal/execution"
 	"gpt-load/internal/protocol"
 	"gpt-load/internal/state"
 )
@@ -137,6 +138,75 @@ func TestVisibleOpenAIModelIDsUnionsChatAndResponses(t *testing.T) {
 				test.accessKey,
 				protocol.OpenAICompletions,
 			)
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("visibleModelIDs() = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestVisibleOpenAIModelIDsIncludesEmbeddingRoutes(t *testing.T) {
+	t.Parallel()
+
+	snapshot := &state.ConfigSnapshot{ExecutionCandidates: state.ExecutionCandidateIndex{
+		protocol.OpenAICompletions: {
+			execution.OperationChatCompletion: {
+				"chat-only": {{GroupID: 1}},
+				"shared":    {{GroupID: 1}},
+			},
+		},
+		protocol.OpenAIEmbeddings: {
+			execution.OperationEmbeddingsCreate: {
+				"embedding-only": {{GroupID: 2}},
+				"shared":         {{GroupID: 2}},
+			},
+		},
+	}}
+
+	tests := []struct {
+		name      string
+		accessKey state.AccessKeyView
+		want      []string
+	}{
+		{
+			name: "unrestricted union",
+			want: []string{"chat-only", "embedding-only", "shared"},
+		},
+		{
+			name: "embedding protocol filter",
+			accessKey: state.AccessKeyView{Filters: state.FilterSet{Protocols: map[protocol.Protocol]struct{}{
+				protocol.OpenAIEmbeddings: {},
+			}}},
+			want: []string{"embedding-only", "shared"},
+		},
+		{
+			name: "embedding protocol and matching group filters",
+			accessKey: state.AccessKeyView{Filters: state.FilterSet{
+				Protocols: map[protocol.Protocol]struct{}{protocol.OpenAIEmbeddings: {}},
+				Groups:    map[uint]struct{}{2: {}},
+			}},
+			want: []string{"embedding-only", "shared"},
+		},
+		{
+			name: "embedding protocol and nonmatching group filters",
+			accessKey: state.AccessKeyView{Filters: state.FilterSet{
+				Protocols: map[protocol.Protocol]struct{}{protocol.OpenAIEmbeddings: {}},
+				Groups:    map[uint]struct{}{1: {}},
+			}},
+			want: []string{},
+		},
+		{
+			name: "chat protocol filter excludes embedding-only routes",
+			accessKey: state.AccessKeyView{Filters: state.FilterSet{Protocols: map[protocol.Protocol]struct{}{
+				protocol.OpenAICompletions: {},
+			}}},
+			want: []string{"chat-only", "shared"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := visibleModelIDs(snapshot, test.accessKey, protocol.OpenAICompletions)
 			if !reflect.DeepEqual(got, test.want) {
 				t.Fatalf("visibleModelIDs() = %#v, want %#v", got, test.want)
 			}

--- a/internal/gateway/request_log.go
+++ b/internal/gateway/request_log.go
@@ -116,7 +116,7 @@ func (recorder *requestRecorder) emit() {
 		return
 	}
 	recorder.emitted = true
-	recorder.freezeImagesErrorSummaries()
+	recorder.freezeSensitiveInputErrorSummaries()
 	completedAt := recorder.now()
 	duration := completedAt.Sub(recorder.startedAt)
 	if duration < 0 {
@@ -147,8 +147,10 @@ func (recorder *requestRecorder) emit() {
 	})
 }
 
-func (recorder *requestRecorder) freezeImagesErrorSummaries() {
-	if recorder == nil || recorder.protocol != protocol.OpenAIImages {
+func (recorder *requestRecorder) freezeSensitiveInputErrorSummaries() {
+	if recorder == nil ||
+		(recorder.protocol != protocol.OpenAIImages &&
+			recorder.protocol != protocol.OpenAIEmbeddings) {
 		return
 	}
 	if recorder.outcome.errorCode != "" {

--- a/internal/gateway/request_log_test.go
+++ b/internal/gateway/request_log_test.go
@@ -568,6 +568,117 @@ func TestHandlerBillableResponsesUsageWithoutPriceIsUnpriced(t *testing.T) {
 	}
 }
 
+func TestHandlerRecordsEmbeddingsUsageAndPricing(t *testing.T) {
+	t.Parallel()
+
+	forwarder := &scriptedForwarder{results: []UpstreamResult{{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       []byte(`{"object":"list","data":[{"index":0,"embedding":"VkVDVE9SX1NFTlRJTkVM"}]}`),
+		Usage: usage.Result{
+			State:  usage.StateComplete,
+			Tokens: usage.Tokens{UncachedInput: 1_000_000},
+		},
+		RequestWritten: true,
+	}}}
+	sink := &recordingRequestLogSink{}
+	engine, handler, _, _ := newRequestLogHandlerTestRuntime(
+		t, forwarder, &recordingAccessKeyRPMLimiter{}, sink, "sk-first",
+	)
+	handler.dialects = dialect.NewSet(dialect.NewOpenAIEmbeddings())
+	handler.priceTables = &mutableGatewayPriceTableProvider{
+		table: mustGatewayPriceTable(t, 2_000_000_000, false),
+	}
+
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/embeddings",
+		strings.NewReader(`{"model":"gpt-4o","input":"input-sentinel"}`),
+	)
+	request.Header.Set("Authorization", "Bearer gl-client")
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, request)
+
+	events := sink.snapshot()
+	if response.Code != http.StatusOK || len(events) != 1 {
+		t.Fatalf("response/events = %d/%#v", response.Code, events)
+	}
+	event := events[0]
+	wantPricing := telemetry.PricingObservation{
+		UpstreamModel:        "gpt-4o",
+		CostState:            string(pricing.CostStatePriced),
+		PricingCompleteness:  string(pricing.CompletenessComplete),
+		EstimatedCostNanoUSD: 2_000_000_000,
+	}
+	if event.Protocol != protocol.OpenAIEmbeddings ||
+		event.Operation != execution.OperationEmbeddingsCreate ||
+		event.Usage.Result != (usage.Result{
+			State:  usage.StateComplete,
+			Tokens: usage.Tokens{UncachedInput: 1_000_000},
+		}) || withoutPricingReceipt(event.Usage.Pricing) != wantPricing {
+		t.Fatalf("Embeddings event = %#v", event)
+	}
+	encoded, err := json.Marshal(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"input-sentinel", "VkVDVE9SX1NFTlRJTkVM", "sk-first"} {
+		if bytes.Contains(encoded, []byte(forbidden)) {
+			t.Fatalf("Embeddings request log retained %q: %s", forbidden, encoded)
+		}
+	}
+}
+
+func TestHandlerRecordsMissingEmbeddingsUsageAsUnpriced(t *testing.T) {
+	t.Parallel()
+
+	forwarder := NewExecutionForwarder(fakeExecutionExecutor{unary: func(
+		_ context.Context,
+		_ execution.AttemptSpec,
+	) execution.AttemptResult {
+		return execution.AttemptResult{
+			DispatchState:   execution.DispatchMaybeSent,
+			ResponseStarted: true,
+			StatusCode:      http.StatusOK,
+			Header:          http.Header{"Content-Type": {"application/json"}},
+			Body: []byte(
+				`{"object":"list","model":"gpt-4o","data":[{"index":0,"embedding":"AAAA"}],` +
+					`"usage":{"prompt_tokens":-1,"total_tokens":0}}`,
+			),
+			Model: "gpt-4o",
+		}
+	}})
+	sink := &recordingRequestLogSink{}
+	engine, handler, _, _ := newRequestLogHandlerTestRuntime(
+		t, forwarder, &recordingAccessKeyRPMLimiter{}, sink, "sk-first",
+	)
+	handler.dialects = dialect.NewSet(dialect.NewOpenAIEmbeddings())
+	handler.priceTables = &mutableGatewayPriceTableProvider{
+		table: mustGatewayPriceTable(t, 2_000_000_000, false),
+	}
+
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/embeddings",
+		strings.NewReader(`{"model":"gpt-4o","input":"hello"}`),
+	)
+	request.Header.Set("Authorization", "Bearer gl-client")
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, request)
+
+	events := sink.snapshot()
+	if response.Code != http.StatusOK || len(events) != 1 ||
+		events[0].Protocol != protocol.OpenAIEmbeddings ||
+		events[0].Operation != execution.OperationEmbeddingsCreate ||
+		events[0].Usage.Result.State != usage.StateMissing ||
+		withoutPricingReceipt(events[0].Usage.Pricing) != (telemetry.PricingObservation{
+			UpstreamModel: "gpt-4o", CostState: string(pricing.CostStateUnpriced),
+			PricingCompleteness: string(pricing.CompletenessUnavailable),
+		}) {
+		t.Fatalf("response/events = %d/%#v", response.Code, events)
+	}
+}
+
 func TestRequestRecorderBindsUsageToRecordedAttempt(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -706,6 +817,55 @@ func TestOpenAIImagesRequestLogUsesFixedErrorsAndMissingUnpricedUsage(t *testing
 			t.Fatalf("Images usage/pricing = %#v", event.Usage)
 		}
 	})
+}
+
+func TestOpenAIEmbeddingsRequestLogFreezesProviderInputEcho(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingRequestLogSink{}
+	recorder := newRequestRecorder(
+		sink,
+		"req-embeddings-error",
+		time.Unix(100, 0),
+		9,
+		protocol.OpenAIEmbeddings,
+		func() time.Time { return time.Unix(101, 0) },
+	)
+	recorder.setOperation(execution.OperationEmbeddingsCreate)
+	providerSummary := "invalid input=input-sentinel vector=VkVDVE9SX1NFTlRJTkVM"
+	index := recorder.appendAttempt(
+		requestLogSelection(12, 22, "embeddings"),
+		UpstreamResult{StatusCode: http.StatusBadRequest},
+		telemetry.FailureCategoryClientError,
+		telemetry.ActionTerminate,
+		"upstream_client_error",
+		providerSummary,
+		time.Unix(100, 0),
+		time.Unix(100, 0),
+	)
+	recorder.completeResponse(
+		UpstreamResult{StatusCode: http.StatusBadRequest, ErrorSummary: providerSummary},
+		health.Decision{Category: health.FailureCategoryClientError},
+		"provider-embedding",
+		index,
+	)
+	recorder.emit()
+
+	if len(sink.events) != 1 {
+		t.Fatalf("events = %#v", sink.events)
+	}
+	event := sink.events[0]
+	want := fixedErrorSummary("upstream_client_error")
+	if event.ErrorSummary != want || len(event.Attempts) != 1 ||
+		event.Attempts[0].ErrorSummary != want {
+		t.Fatalf("Embeddings summaries = %q / %#v", event.ErrorSummary, event.Attempts)
+	}
+	encoded, _ := json.Marshal(event)
+	for _, forbidden := range []string{"input-sentinel", "VkVDVE9SX1NFTlRJTkVM"} {
+		if bytes.Contains(encoded, []byte(forbidden)) {
+			t.Fatalf("Embeddings request log retained %q: %s", forbidden, encoded)
+		}
+	}
 }
 
 func TestRequestRecorderInvalidAttemptIndexDoesNotForgeUsageAttribution(t *testing.T) {

--- a/internal/gateway/response_representation.go
+++ b/internal/gateway/response_representation.go
@@ -702,8 +702,9 @@ const (
 )
 
 // scanEmbeddingsCredentialValue walks one JSON value without materializing the
-// potentially large vector. Only root data[*].embedding is opaque; same-named
-// extension fields remain subject to exact credential inspection.
+// potentially large vector. Root data[*].embedding stays opaque across scalar
+// and array tokens; object subtrees and same-named extension fields remain
+// subject to exact credential inspection.
 func scanEmbeddingsCredentialValue(
 	decoder *json.Decoder,
 	residual *strings.Replacer,
@@ -717,6 +718,9 @@ func scanEmbeddingsCredentialValue(
 	case json.Delim:
 		switch typed {
 		case '{':
+			if location == embeddingsJSONOpaqueVector {
+				location = embeddingsJSONOther
+			}
 			dataSeen := false
 			embeddingSeen := false
 			for decoder.More() {

--- a/internal/gateway/response_representation.go
+++ b/internal/gateway/response_representation.go
@@ -55,9 +55,10 @@ func (forwarder *responseProcessor) prepareSuccessRepresentation(
 	if err != nil {
 		return preparedSuccessRepresentation{}, successRepresentationProtocolError("unsupported or malformed Content-Encoding")
 	}
-	imagesRepresentation := input.ClientProtocol == protocol.OpenAIImages
+	opaqueRepresentation := input.ClientProtocol == protocol.OpenAIImages ||
+		input.ClientProtocol == protocol.OpenAIEmbeddings
 	var originalPlain []byte
-	if imagesRepresentation && encoding == contentcoding.Identity {
+	if opaqueRepresentation && encoding == contentcoding.Identity {
 		// The buffered attempt result owns wire for the duration of this terminal
 		// representation step. Keep the identity bytes instead of copying a large
 		// base64 payload before exact credential inspection.
@@ -76,8 +77,8 @@ func (forwarder *responseProcessor) prepareSuccessRepresentation(
 	modelTracker.observe(originalPlain)
 
 	var safePlain []byte
-	if imagesRepresentation {
-		if imagesCredentialLiteralsRemain(originalPlain, secrets) {
+	if opaqueRepresentation {
+		if opaqueCredentialLiteralsRemain(input.ClientProtocol, originalPlain, secrets) {
 			return preparedSuccessRepresentation{}, successRepresentationProtocolError("credential remains in response body")
 		}
 		safePlain = originalPlain
@@ -102,30 +103,45 @@ func (forwarder *responseProcessor) prepareSuccessRepresentation(
 	}
 
 	inspectablePlain := safePlain
-	if !imagesRepresentation {
+	if !opaqueRepresentation {
 		inspectablePlain = bytes.Clone(safePlain)
 	}
 	downstreamPlain := safePlain
 	if needsModelRewrite(input) {
-		rewriter, supported := input.Dialect.(dialect.ModelRewriter)
-		if !supported {
-			return preparedSuccessRepresentation{}, successRepresentationProtocolError("dialect does not support model rewrite")
+		rewriteModel := true
+		if input.ClientProtocol == protocol.OpenAIEmbeddings {
+			if required, valid := embeddingsResponseModelRewriteRequired(
+				safePlain,
+				input.ExternalModel,
+			); valid {
+				rewriteModel = required
+			}
 		}
-		downstreamPlain, err = rewriter.RewriteResponseModel(safePlain, input.ExternalModel)
-		if err != nil {
-			return preparedSuccessRepresentation{}, successRepresentationProtocolError("rewrite response model")
-		}
-		if int64(len(downstreamPlain)) > bodyLimit {
-			return preparedSuccessRepresentation{}, successRepresentationProtocolError("rewritten response body exceeds limit")
-		}
-		var credentialRemains bool
-		if imagesRepresentation {
-			credentialRemains = imagesCredentialLiteralsRemain(downstreamPlain, secrets)
-		} else {
-			credentialRemains = credentialLiteralsRemain(downstreamPlain, secrets)
-		}
-		if credentialRemains {
-			return preparedSuccessRepresentation{}, successRepresentationProtocolError("credential remains after model rewrite")
+		if rewriteModel {
+			rewriter, supported := input.Dialect.(dialect.ModelRewriter)
+			if !supported {
+				return preparedSuccessRepresentation{}, successRepresentationProtocolError("dialect does not support model rewrite")
+			}
+			downstreamPlain, err = rewriter.RewriteResponseModel(safePlain, input.ExternalModel)
+			if err != nil {
+				return preparedSuccessRepresentation{}, successRepresentationProtocolError("rewrite response model")
+			}
+			if int64(len(downstreamPlain)) > bodyLimit {
+				return preparedSuccessRepresentation{}, successRepresentationProtocolError("rewritten response body exceeds limit")
+			}
+			var credentialRemains bool
+			if opaqueRepresentation {
+				credentialRemains = opaqueCredentialLiteralsRemain(
+					input.ClientProtocol,
+					downstreamPlain,
+					secrets,
+				)
+			} else {
+				credentialRemains = credentialLiteralsRemain(downstreamPlain, secrets)
+			}
+			if credentialRemains {
+				return preparedSuccessRepresentation{}, successRepresentationProtocolError("credential remains after model rewrite")
+			}
 		}
 	}
 
@@ -171,13 +187,35 @@ func (forwarder *responseProcessor) prepareSuccessRepresentation(
 		return preparedSuccessRepresentation{}, successRepresentationProtocolError("partial response lacks safe Content-Range")
 	}
 
+	downstream := downstreamPlain
+	if input.ClientProtocol != protocol.OpenAIEmbeddings {
+		downstream = bytes.Clone(downstreamPlain)
+	}
 	return preparedSuccessRepresentation{
 		headers:          preparedHeaders,
-		downstream:       bytes.Clone(downstreamPlain),
+		downstream:       downstream,
 		inspectable:      inspectablePlain,
 		modelObservation: modelTracker.observation(),
 		changed:          changed,
 	}, nil
+}
+
+func embeddingsResponseModelRewriteRequired(body []byte, model string) (bool, bool) {
+	var envelope struct {
+		Model json.RawMessage `json:"model"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return false, false
+	}
+	raw := bytes.TrimSpace(envelope.Model)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return false, true
+	}
+	var current string
+	if err := json.Unmarshal(raw, &current); err != nil {
+		return false, false
+	}
+	return current != model, true
 }
 
 func (forwarder *responseProcessor) prepareErrorRepresentation(
@@ -617,6 +655,149 @@ func imagesCredentialLiteralsRemain(body []byte, secrets []string) bool {
 		return credentialLiteralRemains(string(body), replacers.residual)
 	}
 	return imagesJSONCredentialLiteralsRemain(value, replacers.residual)
+}
+
+func embeddingsCredentialLiteralsRemain(body []byte, secrets []string) bool {
+	replacers, exists := newCredentialLiteralReplacers(secrets)
+	if !exists {
+		return false
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	remains, err := scanEmbeddingsCredentialValue(
+		decoder,
+		replacers.residual,
+		embeddingsJSONRoot,
+	)
+	if err != nil || remains {
+		return true
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return true
+	}
+	return false
+}
+
+func opaqueCredentialLiteralsRemain(
+	clientProtocol protocol.Protocol,
+	body []byte,
+	secrets []string,
+) bool {
+	if clientProtocol == protocol.OpenAIEmbeddings {
+		return embeddingsCredentialLiteralsRemain(body, secrets)
+	}
+	return imagesCredentialLiteralsRemain(body, secrets)
+}
+
+type embeddingsJSONLocation uint8
+
+const (
+	embeddingsJSONRoot embeddingsJSONLocation = iota
+	embeddingsJSONDataArray
+	embeddingsJSONDataItem
+	embeddingsJSONOpaqueVector
+	embeddingsJSONOther
+)
+
+// scanEmbeddingsCredentialValue walks one JSON value without materializing the
+// potentially large vector. Only root data[*].embedding is opaque; same-named
+// extension fields remain subject to exact credential inspection.
+func scanEmbeddingsCredentialValue(
+	decoder *json.Decoder,
+	residual *strings.Replacer,
+	location embeddingsJSONLocation,
+) (bool, error) {
+	token, err := decoder.Token()
+	if err != nil {
+		return false, err
+	}
+	switch typed := token.(type) {
+	case json.Delim:
+		switch typed {
+		case '{':
+			dataSeen := false
+			embeddingSeen := false
+			for decoder.More() {
+				keyToken, keyErr := decoder.Token()
+				if keyErr != nil {
+					return false, keyErr
+				}
+				key, ok := keyToken.(string)
+				if !ok {
+					return false, fmt.Errorf("JSON object key is not a string")
+				}
+				if location == embeddingsJSONRoot && key == "data" {
+					if dataSeen {
+						return false, fmt.Errorf("duplicate root data field")
+					}
+					dataSeen = true
+				}
+				valueIsVector := location == embeddingsJSONDataItem && key == "embedding"
+				if valueIsVector {
+					if embeddingSeen {
+						return false, fmt.Errorf("duplicate embedding field")
+					}
+					embeddingSeen = true
+				}
+				if location != embeddingsJSONOpaqueVector && !valueIsVector &&
+					credentialLiteralRemains(key, residual) {
+					return true, nil
+				}
+				nextLocation := embeddingsJSONOther
+				switch {
+				case location == embeddingsJSONRoot && key == "data":
+					nextLocation = embeddingsJSONDataArray
+				case valueIsVector:
+					nextLocation = embeddingsJSONOpaqueVector
+				case location == embeddingsJSONOpaqueVector:
+					nextLocation = embeddingsJSONOpaqueVector
+				}
+				remains, valueErr := scanEmbeddingsCredentialValue(
+					decoder,
+					residual,
+					nextLocation,
+				)
+				if valueErr != nil || remains {
+					return remains, valueErr
+				}
+			}
+			end, endErr := decoder.Token()
+			if endErr != nil || end != json.Delim('}') {
+				return false, fmt.Errorf("close JSON object")
+			}
+		case '[':
+			for decoder.More() {
+				nextLocation := embeddingsJSONOther
+				if location == embeddingsJSONDataArray {
+					nextLocation = embeddingsJSONDataItem
+				} else if location == embeddingsJSONOpaqueVector {
+					nextLocation = embeddingsJSONOpaqueVector
+				}
+				remains, valueErr := scanEmbeddingsCredentialValue(decoder, residual, nextLocation)
+				if valueErr != nil || remains {
+					return remains, valueErr
+				}
+			}
+			end, endErr := decoder.Token()
+			if endErr != nil || end != json.Delim(']') {
+				return false, fmt.Errorf("close JSON array")
+			}
+		default:
+			return false, fmt.Errorf("unexpected JSON delimiter")
+		}
+	case string:
+		if location != embeddingsJSONOpaqueVector && credentialLiteralRemains(typed, residual) {
+			return true, nil
+		}
+	case json.Number, bool, nil:
+		// Credentials are JSON strings. Numeric vector and usage values must not
+		// collide with short compatible-provider secrets such as "1".
+	default:
+		return false, fmt.Errorf("unexpected JSON token")
+	}
+	return false, nil
 }
 
 func imagesJSONCredentialLiteralsRemain(value any, residual *strings.Replacer) bool {

--- a/internal/gateway/router.go
+++ b/internal/gateway/router.go
@@ -17,6 +17,7 @@ const (
 	responsesResourcePattern    = openAIResponsesPath + "/*resource_path"
 	openAIImagesGenerationsPath = "/v1/images/generations"
 	openAIImagesEditsPath       = "/v1/images/edits"
+	openAIEmbeddingsPath        = "/v1/embeddings"
 )
 
 type endpointKind uint8
@@ -104,6 +105,12 @@ func dataPlaneEndpointCatalog() []dataPlaneEndpoint {
 			methods: []string{http.MethodPost},
 			path:    openAIImagesEditsPath,
 			resolve: staticRoute(protocol.OpenAIImages, endpointForward),
+		},
+		{
+			name:    "data.openai.embeddings",
+			methods: []string{http.MethodPost},
+			path:    openAIEmbeddingsPath,
+			resolve: staticRoute(protocol.OpenAIEmbeddings, endpointForward),
 		},
 	}
 }

--- a/internal/gateway/router_test.go
+++ b/internal/gateway/router_test.go
@@ -76,6 +76,11 @@ func TestDataPlaneEndpointCatalogDeclaresCompleteHTTPRoutes(t *testing.T) {
 			methods: []string{http.MethodPost},
 			path:    "/v1/images/edits",
 		},
+		{
+			name:    "data.openai.embeddings",
+			methods: []string{http.MethodPost},
+			path:    "/v1/embeddings",
+		},
 	}
 
 	catalog := dataPlaneEndpointCatalog()
@@ -210,6 +215,12 @@ func TestDataPlaneEndpointCatalogResolvesProtocolAndKind(t *testing.T) {
 			name: "Images edit", endpoint: "data.openai.images.edits",
 			method: http.MethodPost, path: "/v1/images/edits",
 			want:      route{Protocol: protocol.OpenAIImages, Kind: endpointForward},
+			validPath: true,
+		},
+		{
+			name: "OpenAI embeddings", endpoint: "data.openai.embeddings",
+			method: http.MethodPost, path: "/v1/embeddings",
+			want:      route{Protocol: protocol.OpenAIEmbeddings, Kind: endpointForward},
 			validPath: true,
 		},
 	}

--- a/internal/health/execution_judge.go
+++ b/internal/health/execution_judge.go
@@ -327,13 +327,17 @@ func decisionForExecutionCategory(
 	case FailureCategoryModelUnavailable:
 		retry := retryUnlessExplicitlyUnknown(attempt.Evidence)
 		if decisionContext.Operation.ReplayPolicy() == execution.ReplayPolicyRequireRejectedBeforeProcessing {
+			ruleID := RuleID("images.model_unavailable")
+			if decisionContext.Operation == execution.OperationEmbeddingsCreate {
+				ruleID = "embeddings.model_unavailable"
+			}
 			return decision(
 				category,
 				origin,
 				scopeOrDefault(scope, execution.ErrorScopeModel),
 				retry,
 				EffectNone,
-				"images.model_unavailable",
+				ruleID,
 			)
 		}
 		result := decision(

--- a/internal/health/execution_judge_v2_test.go
+++ b/internal/health/execution_judge_v2_test.go
@@ -45,6 +45,91 @@ func TestJudgeExecutionProducesIndependentRetryAndEffect(t *testing.T) {
 	}
 }
 
+func TestEmbeddingsExecutionJudgePreservesUnifiedHealthAndReplayRules(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(100, 0)
+	tests := []struct {
+		name      string
+		attempt   ExecutionAttempt
+		category  FailureCategory
+		retry     RetryDirective
+		effect    Effect
+		wantScope execution.ErrorScope
+		wantRule  RuleID
+	}{
+		{
+			name: "model rejection does not hurt credential",
+			attempt: ExecutionAttempt{DispatchState: execution.DispatchMaybeSent,
+				StatusCode: http.StatusNotFound, Now: now,
+				Evidence: &execution.ErrorEvidence{
+					Kind: execution.ErrorKindHTTP, Hint: execution.FailureHintModelUnavailable,
+					OriginHint: execution.ErrorOriginUpstream, ScopeHint: execution.ErrorScopeModel,
+					StatusCode: http.StatusNotFound, Code: "model_not_found",
+					Summary:      "model does not support embeddings",
+					ReplaySafety: execution.ReplaySafetyRejectedBeforeProcessing,
+				}},
+			category: FailureCategoryModelUnavailable, retry: RetryNextCandidate,
+			effect: EffectNone, wantScope: execution.ErrorScopeModel,
+			wantRule: "embeddings.model_unavailable",
+		},
+		{
+			name: "unsupported operation terminates without credential effect",
+			attempt: ExecutionAttempt{DispatchState: execution.DispatchMaybeSent,
+				StatusCode: http.StatusNotImplemented, Now: now,
+				Evidence: &execution.ErrorEvidence{
+					Kind: execution.ErrorKindHTTP, Hint: execution.FailureHintRequestRejected,
+					OriginHint: execution.ErrorOriginUpstream, ScopeHint: execution.ErrorScopeRequest,
+					StatusCode: http.StatusNotImplemented, Code: "unsupported_operation",
+					Summary: "operation is not supported",
+				}},
+			category: FailureCategoryClientError, retry: RetryNone,
+			effect: EffectNone, wantScope: execution.ErrorScopeRequest,
+			wantRule: "fallback.http_client_error",
+		},
+		{
+			name: "invalid credential keeps existing failure effect",
+			attempt: ExecutionAttempt{DispatchState: execution.DispatchMaybeSent,
+				StatusCode: http.StatusUnauthorized, Now: now,
+				Evidence: &execution.ErrorEvidence{
+					Kind: execution.ErrorKindHTTP, Hint: execution.FailureHintInvalidCredential,
+					OriginHint: execution.ErrorOriginUpstream, ScopeHint: execution.ErrorScopeCredential,
+					StatusCode: http.StatusUnauthorized, Summary: "invalid credential",
+					ReplaySafety: execution.ReplaySafetyRejectedBeforeProcessing,
+				}},
+			category: FailureCategoryInvalidKey, retry: RetryNextCandidate,
+			effect: EffectRecordCredentialFailure, wantScope: execution.ErrorScopeCredential,
+			wantRule: "auth.invalid_credential",
+		},
+		{
+			name: "unknown timeout does not replay",
+			attempt: ExecutionAttempt{DispatchState: execution.DispatchMaybeSent, Now: now,
+				Evidence: &execution.ErrorEvidence{
+					Kind: execution.ErrorKindTimeout, OriginHint: execution.ErrorOriginUpstream,
+					ScopeHint: execution.ErrorScopeGroup, Summary: "request timed out",
+					ReplaySafety: execution.ReplaySafetyUnknown,
+				}},
+			category: FailureCategoryAmbiguous, retry: RetryNone,
+			effect: EffectNone, wantScope: execution.ErrorScopeGroup,
+			wantRule: "transport.outcome_unknown",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			decision := JudgeExecution(test.attempt, DecisionContext{
+				Method: http.MethodPost, Operation: execution.OperationEmbeddingsCreate,
+			})
+			if decision.Category != test.category || decision.Retry != test.retry ||
+				decision.Effect != test.effect || decision.Scope != test.wantScope ||
+				decision.RuleID != test.wantRule {
+				t.Fatalf("JudgeExecution() = %#v", decision)
+			}
+		})
+	}
+}
+
 func TestJudgeExecutionCommittedKeepsOnlyTrustedCredentialEffect(t *testing.T) {
 	now := time.Date(2026, time.August, 24, 8, 0, 0, 0, time.UTC)
 	context := DecisionContext{DefaultRateLimitCooldown: time.Minute}

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -7,13 +7,14 @@ const (
 	OpenAICompletions Protocol = "openai-completions"
 	OpenAIResponses   Protocol = "openai-responses"
 	OpenAIImages      Protocol = "openai-images"
+	OpenAIEmbeddings  Protocol = "openai-embeddings"
 	Anthropic         Protocol = "anthropic"
 	Gemini            Protocol = "gemini"
 )
 
 func (p Protocol) Valid() bool {
 	switch p {
-	case OpenAICompletions, OpenAIResponses, OpenAIImages, Anthropic, Gemini:
+	case OpenAICompletions, OpenAIResponses, OpenAIImages, OpenAIEmbeddings, Anthropic, Gemini:
 		return true
 	default:
 		return false
@@ -22,7 +23,7 @@ func (p Protocol) Valid() bool {
 
 func (p Protocol) DataPlaneEnabled() bool {
 	switch p {
-	case OpenAICompletions, OpenAIResponses, OpenAIImages, Anthropic, Gemini:
+	case OpenAICompletions, OpenAIResponses, OpenAIImages, OpenAIEmbeddings, Anthropic, Gemini:
 		return true
 	default:
 		return false
@@ -38,6 +39,7 @@ func DataPlaneProtocols() []Protocol {
 		OpenAICompletions,
 		OpenAIResponses,
 		OpenAIImages,
+		OpenAIEmbeddings,
 		Anthropic,
 		Gemini,
 	}

--- a/internal/protocol/protocol_test.go
+++ b/internal/protocol/protocol_test.go
@@ -50,6 +50,7 @@ func TestProtocolKnownAndDataPlaneEnabled(t *testing.T) {
 		{value: OpenAICompletions, known: true, enabled: true},
 		{value: OpenAIResponses, known: true, enabled: true},
 		{value: OpenAIImages, known: true, enabled: true},
+		{value: OpenAIEmbeddings, known: true, enabled: true},
 		{value: Anthropic, known: true, enabled: true},
 		{value: Gemini, known: true, enabled: true},
 		{value: Protocol("openai"), known: false, enabled: false},
@@ -81,6 +82,7 @@ func TestProtocolModelOptionalRequestsAreLimitedToOpenAIResponses(t *testing.T) 
 	}{
 		{protocol: Protocol("openai-completions"), want: false},
 		{protocol: Protocol("openai-responses"), want: true},
+		{protocol: Protocol("openai-embeddings"), want: false},
 		{protocol: Protocol("anthropic"), want: false},
 		{protocol: Protocol("gemini"), want: false},
 	}
@@ -108,6 +110,7 @@ func TestDataPlaneProtocolsReturnsCanonicalOrderAndIndependentCopies(t *testing.
 		OpenAICompletions,
 		OpenAIResponses,
 		OpenAIImages,
+		OpenAIEmbeddings,
 		Anthropic,
 		Gemini,
 	}

--- a/internal/state/snapshot.go
+++ b/internal/state/snapshot.go
@@ -344,7 +344,8 @@ func appendExecutionTargets(
 				execution.OperationResponsesInputTokens,
 				execution.OperationCountTokens,
 				execution.OperationImagesGenerate,
-				execution.OperationImagesEdit:
+				execution.OperationImagesEdit,
+				execution.OperationEmbeddingsCreate:
 				for _, model := range group.Models {
 					modelMode, supported := target.ModeForModel(clientProtocol, operation, model.ID)
 					if !supported {

--- a/internal/state/snapshot_test.go
+++ b/internal/state/snapshot_test.go
@@ -81,6 +81,36 @@ func TestCompileIndexesOpenAIImagesOperationsForAllConfiguredModels(t *testing.T
 	}
 }
 
+func TestCompileIndexesOpenAIEmbeddingsForAllConfiguredModels(t *testing.T) {
+	t.Parallel()
+
+	snapshot, err := Compile(CompileInput{
+		ChannelRegistry: channel.NewRegistry(),
+		Groups: []GroupConfig{
+			{ConnectionType: "api_key", ID: 1, ChannelID: channel.OpenAI, Params: json.RawMessage(`{}`),
+				Models: []ModelConfig{{ID: "text-embedding-3-small", Alias: "public"}}, Enabled: true},
+			{ConnectionType: "api_key", ID: 2, ChannelID: channel.OpenAICompatible,
+				Params: json.RawMessage(`{"base_url":"https://proxy.example/api/v4"}`),
+				Models: []ModelConfig{{ID: "Qwen/Qwen3-Embedding-8B", Alias: "public"}}, Enabled: true},
+			{ConnectionType: "api_key", ID: 3, ChannelID: channel.OpenRouter, Params: json.RawMessage(`{}`),
+				Models: []ModelConfig{{ID: "openai/text-embedding-3-small", Alias: "public"}}, Enabled: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Compile() error = %v", err)
+	}
+
+	got := snapshot.ExecutionCandidates[protocol.OpenAIEmbeddings][execution.OperationEmbeddingsCreate]["public"]
+	if len(got) != 3 || got[0].GroupID != 1 || got[1].GroupID != 2 || got[2].GroupID != 3 {
+		t.Fatalf("Embeddings candidates = %#v", got)
+	}
+	for _, target := range got {
+		if target.Mode != channel.RouteNative {
+			t.Fatalf("Embeddings target = %#v, want native", target)
+		}
+	}
+}
+
 func TestCompileSubscriptionPublishesOnlyVerifiedCodexOperations(t *testing.T) {
 	t.Parallel()
 	snapshot, err := Compile(CompileInput{
@@ -107,6 +137,9 @@ func TestCompileSubscriptionPublishesOnlyVerifiedCodexOperations(t *testing.T) {
 	}
 	if got := snapshot.ExecutionCandidates[protocol.Gemini][execution.OperationCountTokens]["public"]; len(got) != 1 {
 		t.Fatalf("Gemini count token targets = %#v", got)
+	}
+	if got := snapshot.ExecutionCandidates[protocol.OpenAIEmbeddings]; len(got) != 0 {
+		t.Fatalf("subscription Embeddings targets = %#v, want none", got)
 	}
 	for _, operation := range []execution.Operation{
 		execution.OperationResponsesRetrieve, execution.OperationResponsesDelete,

--- a/web/src/api/control/protocols.ts
+++ b/web/src/api/control/protocols.ts
@@ -12,6 +12,10 @@ export const protocolCatalog = [
     supportsProtocolOnlyRouting: false,
   },
   {
+    value: 'openai-embeddings',
+    supportsProtocolOnlyRouting: false,
+  },
+  {
     value: 'anthropic',
     supportsProtocolOnlyRouting: false,
   },

--- a/web/src/app/resources/channels.ts
+++ b/web/src/app/resources/channels.ts
@@ -56,6 +56,7 @@ export type ChannelOperation =
   | 'responses_passthrough'
   | 'images_generate'
   | 'images_edit'
+  | 'embeddings_create'
   | 'list_models'
   | 'probe'
 
@@ -158,6 +159,7 @@ const operations = [
   'responses_passthrough',
   'images_generate',
   'images_edit',
+  'embeddings_create',
   'list_models',
   'probe',
 ] as const

--- a/web/src/app/resources/request-logs.ts
+++ b/web/src/app/resources/request-logs.ts
@@ -52,6 +52,7 @@ export type RequestLogOperation =
   | 'responses_passthrough'
   | 'images_generate'
   | 'images_edit'
+  | 'embeddings_create'
   | 'list_models'
   | 'probe'
 export type RequestLogRouteMode = 'native' | 'converted'
@@ -238,6 +239,7 @@ const operations = [
   'responses_passthrough',
   'images_generate',
   'images_edit',
+  'embeddings_create',
   'list_models',
   'probe',
 ] as const

--- a/web/src/app/resources/route-inspection.ts
+++ b/web/src/app/resources/route-inspection.ts
@@ -56,6 +56,7 @@ export type RouteInspectOperation =
   | 'responses_passthrough'
   | 'images_generate'
   | 'images_edit'
+  | 'embeddings_create'
 export type RouteInspectRequirement = 'any' | 'native'
 export type RouteInspectMode = 'native' | 'converted'
 
@@ -114,6 +115,7 @@ export const routeInspectOperations = [
   'responses_passthrough',
   'images_generate',
   'images_edit',
+  'embeddings_create',
 ] as const
 export const routeInspectRequirements = ['any', 'native'] as const
 const routeModes = ['native', 'converted'] as const

--- a/web/src/features/access-keys/AccessKeyCollection.vue
+++ b/web/src/features/access-keys/AccessKeyCollection.vue
@@ -55,7 +55,8 @@ const presentations = computed(() =>
       unlimited: t('accessKeys.unlimited'),
       costRules: (count) => t('accessKeys.costLimits.ruleCount', { count }),
     },
-    protocolLabel: (protocol) => protocol,
+    protocolLabel: (protocol) =>
+      protocol === 'openai-embeddings' ? t('common.protocols.openaiEmbeddings.label') : protocol,
   }),
 )
 function source(id: number): AccessKeyCollectionItemDto {

--- a/web/src/features/access-keys/AccessKeyScopeEditor.vue
+++ b/web/src/features/access-keys/AccessKeyScopeEditor.vue
@@ -41,7 +41,12 @@ const { t } = useI18n()
 const protocolMultiSelectOptions = computed<SearchableMultiSelectOption[]>(() =>
   props.protocolOptions.map((protocol) => ({
     value: protocol,
-    label: protocol,
+    label:
+      protocol === 'openai-embeddings' ? t('common.protocols.openaiEmbeddings.label') : protocol,
+    description:
+      protocol === 'openai-embeddings'
+        ? t('common.protocols.openaiEmbeddings.description')
+        : undefined,
   })),
 )
 

--- a/web/src/features/groups/credentials/CredentialTestDialog.vue
+++ b/web/src/features/groups/credentials/CredentialTestDialog.vue
@@ -40,6 +40,11 @@ const resultTone = computed(() => {
 const reasonLabel = computed(() =>
   props.result ? t(`group.credentials.test.reason.${props.result.reason ?? 'passed'}`) : '',
 )
+const protocolLabel = computed(() =>
+  props.result?.protocol === 'openai-embeddings'
+    ? t('common.protocols.openaiEmbeddings.label')
+    : (props.result?.protocol ?? ''),
+)
 
 function setOpen(open: boolean): void {
   if (!open && busy.value) return
@@ -79,7 +84,7 @@ function setOpen(open: boolean): void {
             <dt>{{ t('group.credentials.test.fields.model') }}</dt>
             <dd>{{ result.model }}</dd>
             <dt>{{ t('group.credentials.test.fields.protocol') }}</dt>
-            <dd>{{ result.protocol }}</dd>
+            <dd>{{ protocolLabel }}</dd>
             <dt>{{ t('group.credentials.test.fields.latency') }}</dt>
             <dd>{{ t('group.credentials.test.latency', { value: n(result.latency_ms) }) }}</dd>
             <dt>{{ t('group.credentials.test.fields.reason') }}</dt>

--- a/web/src/features/models/ModelSpecSheet.vue
+++ b/web/src/features/models/ModelSpecSheet.vue
@@ -17,7 +17,7 @@ interface CatalogSpec {
 }
 
 const metadata = computed(() => props.reference.model)
-const knownModalities = new Set(['audio', 'image', 'pdf', 'text', 'video'])
+const knownModalities = new Set(['audio', 'embedding', 'image', 'pdf', 'text', 'video'])
 const knownStatuses = new Set(['alpha', 'beta', 'deprecated'])
 
 const sourceLabel = computed(() =>

--- a/web/src/features/monitor/InspectorForm.vue
+++ b/web/src/features/monitor/InspectorForm.vue
@@ -20,6 +20,7 @@ interface SelectOption {
 
 const props = defineProps<{
   protocol: string
+  protocolDescription?: string
   model: string
   accessKeyId: string
   protocolOptions: SelectOption[]
@@ -94,6 +95,7 @@ function error(field: InspectorField): string | undefined {
           id="inspector-protocol"
           size="compact"
           :label="t('monitor.inspector.form.protocol')"
+          :description="protocolDescription"
           :error="error('protocol')"
           required
         >

--- a/web/src/features/monitor/InspectorTab.vue
+++ b/web/src/features/monitor/InspectorTab.vue
@@ -98,8 +98,16 @@ const groupOptionsQuery = useQuery(groupOptionsQueryOptions(client))
 const channelsQuery = useQuery(channelsQueryOptions(client, ''))
 const protocolOptions = computed(() => [
   { value: '', label: t('monitor.inspector.form.selectProtocol') },
-  ...enabledDataProtocols.map((value) => ({ value, label: value })),
+  ...enabledDataProtocols.map((value) => ({
+    value,
+    label: value === 'openai-embeddings' ? t('common.protocols.openaiEmbeddings.label') : value,
+  })),
 ])
+const protocolDescription = computed(() =>
+  draftProtocol.value === 'openai-embeddings'
+    ? t('common.protocols.openaiEmbeddings.description')
+    : undefined,
+)
 const configuredModels = computed(() =>
   [...new Set((groupOptionsQuery.data.value ?? []).flatMap((group) => group.models))].sort(
     (left, right) => left.localeCompare(right),
@@ -425,7 +433,7 @@ function modelLabel(value: string | null): string {
 }
 
 function protocolLabel(value: AccessProtocol): string {
-  return value
+  return value === 'openai-embeddings' ? t('common.protocols.openaiEmbeddings.label') : value
 }
 
 function formattedInteger(value: number): string {
@@ -544,6 +552,7 @@ onBeforeUnmount(() => {
   <div class="inspector-tab">
     <InspectorForm
       :protocol="draftProtocol"
+      :protocol-description="protocolDescription"
       :model="draftModel"
       :access-key-id="draftAccessKeyID"
       :protocol-options="protocolOptions"

--- a/web/src/features/monitor/LogsAdvancedFilterDrawer.vue
+++ b/web/src/features/monitor/LogsAdvancedFilterDrawer.vue
@@ -45,7 +45,12 @@ const booleanOptions = () => [
 ]
 const protocolOptions = () => [
   option('', t('monitor.logs.filters.anyProtocol')),
-  ...enabledDataProtocols.map((value) => option(value, value)),
+  ...enabledDataProtocols.map((value) =>
+    option(
+      value,
+      value === 'openai-embeddings' ? t('common.protocols.openaiEmbeddings.label') : value,
+    ),
+  ),
 ]
 const usageOptions = () => [
   option('', t('monitor.logs.filters.any')),

--- a/web/src/i18n/locales/en-US/access-keys.ts
+++ b/web/src/i18n/locales/en-US/access-keys.ts
@@ -212,7 +212,7 @@ export default {
         remove: 'Remove cost limit rule',
       },
       allGroupsAllowed: 'Currently allows routing to all Groups',
-      allProtocolsAllowed: 'Currently allows all five canonical protocols',
+      allProtocolsAllowed: 'Currently allows all six canonical protocols',
       allModelsAllowed: 'Currently allows every model routable by the target Groups',
       scopeExpansionWarning:
         'Changing Specified to All expands client permissions. Confirm that the current scope is intended.',

--- a/web/src/i18n/locales/en-US/core.ts
+++ b/web/src/i18n/locales/en-US/core.ts
@@ -1,6 +1,12 @@
 export default {
   common: {
     appName: 'GPT-Load',
+    protocols: {
+      openaiEmbeddings: {
+        label: 'OpenAI Embeddings',
+        description: 'OpenAI-compatible text embeddings · POST /v1/embeddings',
+      },
+    },
     retry: 'Retry',
     modelDiscoveryFailed: 'Discovery failed; draft unchanged',
     changeKey: 'Change sign-in key',

--- a/web/src/i18n/locales/en-US/models.ts
+++ b/web/src/i18n/locales/en-US/models.ts
@@ -117,6 +117,7 @@ export default {
       },
       modalities: {
         audio: 'Audio',
+        embedding: 'Embedding',
         image: 'Image',
         pdf: 'PDF',
         text: 'Text',

--- a/web/src/i18n/locales/en-US/monitor.ts
+++ b/web/src/i18n/locales/en-US/monitor.ts
@@ -388,7 +388,7 @@ export default {
       title: 'Route inspector',
       description: 'Inspect candidate Groups and credentials by protocol, model, and access key.',
       boundary:
-        'Simulates a standard stateless request without conversation content or an affinity hit; Responses uses store:false, while Images checks generation only. Read-only, with no upstream request or token usage.',
+        'Simulates a standard stateless request without conversation content or an affinity hit; Responses uses store:false, Images checks generation only, and Embeddings checks creation only. Read-only, with no upstream request or token usage.',
       routeModes: {
         native: 'Native',
         converted: 'Protocol conversion',
@@ -406,6 +406,7 @@ export default {
         responses_passthrough: 'Responses extension operation',
         images_generate: 'Generate image',
         images_edit: 'Edit image',
+        embeddings_create: 'Create embeddings',
       },
       routeRequirements: {
         any: 'Allow protocol conversion (possibly lossy)',
@@ -788,6 +789,7 @@ export default {
         responses_passthrough: 'Responses resource passthrough',
         images_generate: 'Generate image',
         images_edit: 'Edit image',
+        embeddings_create: 'Create embeddings',
         list_models: 'List models',
         probe: 'Health probe',
       },

--- a/web/src/i18n/locales/ja-JP/access-keys.ts
+++ b/web/src/i18n/locales/ja-JP/access-keys.ts
@@ -210,7 +210,7 @@ export default {
         remove: '費用上限ルールを削除',
       },
       allGroupsAllowed: '現在はすべてのグループへのルーティングを許可',
-      allProtocolsAllowed: '現在は 5 つの正規プロトコルをすべて許可',
+      allProtocolsAllowed: '現在は 6 つの正規プロトコルをすべて許可',
       allModelsAllowed: '現在は対象グループがルーティングできるすべてのモデルを許可',
       scopeExpansionWarning:
         '「指定」から「すべて」への変更はクライアント権限を拡大します。現在の範囲が意図どおりか確認してください。',

--- a/web/src/i18n/locales/ja-JP/core.ts
+++ b/web/src/i18n/locales/ja-JP/core.ts
@@ -1,6 +1,12 @@
 export default {
   common: {
     appName: 'GPT-Load',
+    protocols: {
+      openaiEmbeddings: {
+        label: 'OpenAI Embeddings',
+        description: 'OpenAI 互換 Wire でテキスト埋め込みを作成 · POST /v1/embeddings',
+      },
+    },
     retry: '再試行',
     modelDiscoveryFailed: 'モデル取得に失敗しました。下書きは未変更です',
     changeKey: 'ログインキーを変更',

--- a/web/src/i18n/locales/ja-JP/models.ts
+++ b/web/src/i18n/locales/ja-JP/models.ts
@@ -118,6 +118,7 @@ export default {
       },
       modalities: {
         audio: '音声',
+        embedding: '埋め込み',
         image: '画像',
         pdf: 'PDF',
         text: 'テキスト',

--- a/web/src/i18n/locales/ja-JP/monitor.ts
+++ b/web/src/i18n/locales/ja-JP/monitor.ts
@@ -388,7 +388,7 @@ export default {
       title: 'ルート検査',
       description: 'プロトコル、モデル、アクセスキーから候補グループと認証情報を確認します。',
       boundary:
-        '会話内容やアフィニティヒットを含まない標準的なステートレスリクエストを模擬します。Responses は store:false を使用し、Images は画像生成のみを確認します。読み取り専用で、上流送信や Token 消費はありません。',
+        '会話内容やアフィニティヒットを含まない標準的なステートレスリクエストを模擬します。Responses は store:false を使用し、Images は画像生成のみ、Embeddings は埋め込み作成のみを確認します。読み取り専用で、上流送信や Token 消費はありません。',
       routeModes: {
         native: 'ネイティブ',
         converted: 'プロトコル変換',
@@ -406,6 +406,7 @@ export default {
         responses_passthrough: 'Responses 拡張操作',
         images_generate: '画像を生成',
         images_edit: '画像を編集',
+        embeddings_create: '埋め込みを作成',
       },
       routeRequirements: {
         any: 'プロトコル変換を許可（損失の可能性あり）',
@@ -787,6 +788,7 @@ export default {
         responses_passthrough: 'Responses リソースの透過転送',
         images_generate: '画像を生成',
         images_edit: '画像を編集',
+        embeddings_create: '埋め込みを作成',
         list_models: 'モデル一覧',
         probe: 'ヘルスプローブ',
       },

--- a/web/src/i18n/locales/zh-CN/access-keys.ts
+++ b/web/src/i18n/locales/zh-CN/access-keys.ts
@@ -199,7 +199,7 @@ export default {
         remove: '删除费用规则',
       },
       allGroupsAllowed: '当前允许路由到全部分组',
-      allProtocolsAllowed: '当前允许全部 5 种规范协议',
+      allProtocolsAllowed: '当前允许全部 6 种规范协议',
       allModelsAllowed: '当前允许目标分组可路由的全部模型',
       scopeExpansionWarning: '把“指定”改为“全部”会扩大客户端权限，请确认当前范围符合预期。',
       save: '保存访问密钥',

--- a/web/src/i18n/locales/zh-CN/core.ts
+++ b/web/src/i18n/locales/zh-CN/core.ts
@@ -1,6 +1,12 @@
 export default {
   common: {
     appName: 'GPT-Load',
+    protocols: {
+      openaiEmbeddings: {
+        label: 'OpenAI Embeddings',
+        description: '使用 OpenAI-compatible Wire 创建文本向量 · POST /v1/embeddings',
+      },
+    },
     retry: '重试',
     modelDiscoveryFailed: '模型发现失败，草稿未变',
     changeKey: '更换登录密钥',

--- a/web/src/i18n/locales/zh-CN/models.ts
+++ b/web/src/i18n/locales/zh-CN/models.ts
@@ -117,6 +117,7 @@ export default {
       },
       modalities: {
         audio: '音频',
+        embedding: '向量',
         image: '图像',
         pdf: 'PDF',
         text: '文本',

--- a/web/src/i18n/locales/zh-CN/monitor.ts
+++ b/web/src/i18n/locales/zh-CN/monitor.ts
@@ -372,7 +372,7 @@ export default {
       title: '路由检查',
       description: '按协议、模型与访问密钥检查当前候选分组和凭据。',
       boundary:
-        '按所选协议模拟不含会话内容与亲和命中的标准无状态请求；Responses 使用 store:false，Images 只检查图片生成。只读检查，不会发送上游请求或消耗 Token。',
+        '按所选协议模拟不含会话内容与亲和命中的标准无状态请求；Responses 使用 store:false，Images 只检查图片生成，Embeddings 只检查向量创建。只读检查，不会发送上游请求或消耗 Token。',
       routeModes: {
         native: '原生',
         converted: '协议转换',
@@ -390,6 +390,7 @@ export default {
         responses_passthrough: 'Responses 扩展操作',
         images_generate: '生成图片',
         images_edit: '编辑图片',
+        embeddings_create: '创建向量',
       },
       routeRequirements: {
         any: '允许协议转换（可有损）',
@@ -769,6 +770,7 @@ export default {
         responses_passthrough: 'Responses 资源透传',
         images_generate: '生成图片',
         images_edit: '编辑图片',
+        embeddings_create: '创建向量',
         list_models: '列出模型',
         probe: '健康探测',
       },


### PR DESCRIPTION
### 关联 Issue / Related Issue

N/A（基于已确认的技术方案实施）

### 变更内容 / Change Content

- [ ] Bug 修复 / Bug fix
- [x] 新功能 / New feature
- [ ] 其他改动 / Other changes

- 新增严格原生 `POST /v1/embeddings`，仅支持 OpenAI Embeddings wire，不做协议转换。
- 覆盖 OpenAI、OpenRouter、OpenAI Compatible 三类 API Key 渠道；订阅渠道保持不支持。
- 复用现有 Bifrost、DirectKey、调度、重试、健康、日志、usage 与定价流程，并为 embedding-only 模型增加有界 Probe fallback。
- 模型发现、AccessKey 过滤、Route Inspector、请求日志和三语管理 UI 同步支持 `openai-embeddings` / `embeddings_create`。
- 对大向量响应执行解码后限额、敏感字段扫描和零拷贝投影，避免向量内容进入日志或被额外物化。
- 更新中英文 README 的能力矩阵、渠道边界和 AccessKey 兼容性说明。

兼容性：无数据库迁移。未配置协议过滤的 AccessKey 会自动获得新协议；显式过滤仍按原配置生效。降级前应先移除显式 `openai-embeddings` 过滤值。

### 自查清单 / Checklist

- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 OpenAI Embeddings 客户端协议，支持通过 `POST /v1/embeddings` 创建文本向量。
  * 支持 OpenAI、OpenRouter 和 OpenAI Compatible API-key 渠道的原生 Embeddings 请求。
  * 支持向量用量统计、模型别名处理、请求日志记录及模型列表展示。
  * 凭据探测在模型不可用时可回退至 Embeddings 协议。

* **改进**
  * 未设置协议过滤器的 AccessKey 升级后默认包含 Embeddings 访问能力。
  * 管理界面新增 Embeddings 协议、操作、路由检查及多语言显示支持。
  * Embeddings 暂不支持订阅渠道或协议转换。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->