### PR TITLE
fix(web): 统一协议显示规范

### DIFF
--- a/web/src/features/access-keys/AccessKeyCollection.vue
+++ b/web/src/features/access-keys/AccessKeyCollection.vue
@@ -55,8 +55,7 @@ const presentations = computed(() =>
       unlimited: t('accessKeys.unlimited'),
       costRules: (count) => t('accessKeys.costLimits.ruleCount', { count }),
     },
-    protocolLabel: (protocol) =>
-      protocol === 'openai-embeddings' ? t('common.protocols.openaiEmbeddings.label') : protocol,
+    protocolLabel: (protocol) => protocol,
   }),
 )
 function source(id: number): AccessKeyCollectionItemDto {

--- a/web/src/features/access-keys/AccessKeyScopeEditor.vue
+++ b/web/src/features/access-keys/AccessKeyScopeEditor.vue
@@ -41,12 +41,7 @@ const { t } = useI18n()
 const protocolMultiSelectOptions = computed<SearchableMultiSelectOption[]>(() =>
   props.protocolOptions.map((protocol) => ({
     value: protocol,
-    label:
-      protocol === 'openai-embeddings' ? t('common.protocols.openaiEmbeddings.label') : protocol,
-    description:
-      protocol === 'openai-embeddings'
-        ? t('common.protocols.openaiEmbeddings.description')
-        : undefined,
+    label: protocol,
   })),
 )
 

--- a/web/src/features/groups/credentials/CredentialTestDialog.vue
+++ b/web/src/features/groups/credentials/CredentialTestDialog.vue
@@ -40,11 +40,6 @@ const resultTone = computed(() => {
 const reasonLabel = computed(() =>
   props.result ? t(`group.credentials.test.reason.${props.result.reason ?? 'passed'}`) : '',
 )
-const protocolLabel = computed(() =>
-  props.result?.protocol === 'openai-embeddings'
-    ? t('common.protocols.openaiEmbeddings.label')
-    : (props.result?.protocol ?? ''),
-)
 
 function setOpen(open: boolean): void {
   if (!open && busy.value) return
@@ -84,7 +79,7 @@ function setOpen(open: boolean): void {
             <dt>{{ t('group.credentials.test.fields.model') }}</dt>
             <dd>{{ result.model }}</dd>
             <dt>{{ t('group.credentials.test.fields.protocol') }}</dt>
-            <dd>{{ protocolLabel }}</dd>
+            <dd>{{ result.protocol }}</dd>
             <dt>{{ t('group.credentials.test.fields.latency') }}</dt>
             <dd>{{ t('group.credentials.test.latency', { value: n(result.latency_ms) }) }}</dd>
             <dt>{{ t('group.credentials.test.fields.reason') }}</dt>

--- a/web/src/features/monitor/InspectorForm.vue
+++ b/web/src/features/monitor/InspectorForm.vue
@@ -20,7 +20,6 @@ interface SelectOption {
 
 const props = defineProps<{
   protocol: string
-  protocolDescription?: string
   model: string
   accessKeyId: string
   protocolOptions: SelectOption[]
@@ -95,7 +94,6 @@ function error(field: InspectorField): string | undefined {
           id="inspector-protocol"
           size="compact"
           :label="t('monitor.inspector.form.protocol')"
-          :description="protocolDescription"
           :error="error('protocol')"
           required
         >

--- a/web/src/features/monitor/InspectorTab.vue
+++ b/web/src/features/monitor/InspectorTab.vue
@@ -98,16 +98,8 @@ const groupOptionsQuery = useQuery(groupOptionsQueryOptions(client))
 const channelsQuery = useQuery(channelsQueryOptions(client, ''))
 const protocolOptions = computed(() => [
   { value: '', label: t('monitor.inspector.form.selectProtocol') },
-  ...enabledDataProtocols.map((value) => ({
-    value,
-    label: value === 'openai-embeddings' ? t('common.protocols.openaiEmbeddings.label') : value,
-  })),
+  ...enabledDataProtocols.map((value) => ({ value, label: value })),
 ])
-const protocolDescription = computed(() =>
-  draftProtocol.value === 'openai-embeddings'
-    ? t('common.protocols.openaiEmbeddings.description')
-    : undefined,
-)
 const configuredModels = computed(() =>
   [...new Set((groupOptionsQuery.data.value ?? []).flatMap((group) => group.models))].sort(
     (left, right) => left.localeCompare(right),
@@ -432,10 +424,6 @@ function modelLabel(value: string | null): string {
   return value ?? t('monitor.inspector.result.modelNotSpecified')
 }
 
-function protocolLabel(value: AccessProtocol): string {
-  return value === 'openai-embeddings' ? t('common.protocols.openaiEmbeddings.label') : value
-}
-
 function formattedInteger(value: number): string {
   return formatInteger(value, locale.value)
 }
@@ -552,7 +540,6 @@ onBeforeUnmount(() => {
   <div class="inspector-tab">
     <InspectorForm
       :protocol="draftProtocol"
-      :protocol-description="protocolDescription"
       :model="draftModel"
       :access-key-id="draftAccessKeyID"
       :protocol-options="protocolOptions"
@@ -696,9 +683,9 @@ onBeforeUnmount(() => {
               <OverflowTooltip
                 as="dd"
                 class="route-fact__mono"
-                :content="`${protocolLabel(observation.protocol)} · ${observation.operation}`"
+                :content="`${observation.protocol} · ${observation.operation}`"
               >
-                {{ protocolLabel(observation.protocol) }} · {{ observation.operation }}
+                {{ observation.protocol }} · {{ observation.operation }}
               </OverflowTooltip>
             </div>
             <div class="route-fact">

--- a/web/src/features/monitor/LogsAdvancedFilterDrawer.vue
+++ b/web/src/features/monitor/LogsAdvancedFilterDrawer.vue
@@ -45,12 +45,7 @@ const booleanOptions = () => [
 ]
 const protocolOptions = () => [
   option('', t('monitor.logs.filters.anyProtocol')),
-  ...enabledDataProtocols.map((value) =>
-    option(
-      value,
-      value === 'openai-embeddings' ? t('common.protocols.openaiEmbeddings.label') : value,
-    ),
-  ),
+  ...enabledDataProtocols.map((value) => option(value, value)),
 ]
 const usageOptions = () => [
   option('', t('monitor.logs.filters.any')),

--- a/web/src/i18n/locales/en-US/core.ts
+++ b/web/src/i18n/locales/en-US/core.ts
@@ -1,12 +1,6 @@
 export default {
   common: {
     appName: 'GPT-Load',
-    protocols: {
-      openaiEmbeddings: {
-        label: 'OpenAI Embeddings',
-        description: 'OpenAI-compatible text embeddings · POST /v1/embeddings',
-      },
-    },
     retry: 'Retry',
     modelDiscoveryFailed: 'Discovery failed; draft unchanged',
     changeKey: 'Change sign-in key',

--- a/web/src/i18n/locales/ja-JP/core.ts
+++ b/web/src/i18n/locales/ja-JP/core.ts
@@ -1,12 +1,6 @@
 export default {
   common: {
     appName: 'GPT-Load',
-    protocols: {
-      openaiEmbeddings: {
-        label: 'OpenAI Embeddings',
-        description: 'OpenAI 互換 Wire でテキスト埋め込みを作成 · POST /v1/embeddings',
-      },
-    },
     retry: '再試行',
     modelDiscoveryFailed: 'モデル取得に失敗しました。下書きは未変更です',
     changeKey: 'ログインキーを変更',

--- a/web/src/i18n/locales/zh-CN/core.ts
+++ b/web/src/i18n/locales/zh-CN/core.ts
@@ -1,12 +1,6 @@
 export default {
   common: {
     appName: 'GPT-Load',
-    protocols: {
-      openaiEmbeddings: {
-        label: 'OpenAI Embeddings',
-        description: '使用 OpenAI-compatible Wire 创建文本向量 · POST /v1/embeddings',
-      },
-    },
     retry: '重试',
     modelDiscoveryFailed: '模型发现失败，草稿未变',
     changeKey: '更换登录密钥',


### PR DESCRIPTION
### 关联 Issue / Related Issue
无

### 变更内容 / Change Content
- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

- 移除 `openai-embeddings` 在 AccessKey、路由检查、日志筛选和凭据测试中的专用友好名称与端点说明。
- 所有协议统一展示 canonical value，不新增统一展示层或其他抽象。
- 删除不再使用的三语专用协议文案，并同步更新正式 Embeddings 实施方案。

兼容性：仅调整前端展示；协议值、管理 API、数据面路由和持久化均不变，无数据迁移。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **体验改进**
  * 访问密钥、凭据测试、监控检查器及日志筛选中的协议名称统一显示原始协议值。
  * 移除协议选项和检查表单中的额外描述文字，界面展示更加一致简洁。
* **本地化**
  * 清理英语、日语和简体中文界面中不再使用的相关协议标签与描述翻译。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->