### PR TITLE
feat(release): 增加 Render 镜像部署

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
       image_minor: ${{ steps.tag.outputs.image_minor }}
       image_major: ${{ steps.tag.outputs.image_major }}
       beta: ${{ steps.tag.outputs.beta }}
+      channel_beta: ${{ steps.tag.outputs.channel_beta }}
       ci_verified: ${{ steps.ci.outputs.ci_verified }}
     steps:
       - name: Checkout tag commit
@@ -56,6 +57,7 @@ jobs:
           core="${version%%-*}"
           prerelease=false
           beta=false
+          channel_beta=false
           if [[ "${version}" == *-* ]]; then
             prerelease=true
             prerelease_value="${version#*-}"
@@ -74,6 +76,11 @@ jobs:
             done
           fi
 
+          channel_beta_regex='^v2\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-beta\.(0|[1-9][0-9]*)$'
+          if [[ "${tag}" =~ ${channel_beta_regex} ]]; then
+            channel_beta=true
+          fi
+
           IFS='.' read -r major minor _ <<<"${core}"
           {
             printf 'version=%s\n' "${tag}"
@@ -82,6 +89,7 @@ jobs:
             printf 'image_minor=%s.%s\n' "${major}" "${minor}"
             printf 'image_major=%s\n' "${major}"
             printf 'beta=%s\n' "${beta}"
+            printf 'channel_beta=%s\n' "${channel_beta}"
           } >>"${GITHUB_OUTPUT}"
           # release-tag-validation:end
 
@@ -1031,7 +1039,7 @@ jobs:
           test "${ghcr_exact_digest}" = "${dockerhub_exact_digest}"
 
       - name: Update beta channel alias
-        if: ${{ needs.publication-preflight.outputs.write_mode == 'publish' && needs.validate-tag.outputs.beta == 'true' }}
+        if: ${{ needs.publication-preflight.outputs.write_mode == 'publish' && needs.validate-tag.outputs.channel_beta == 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1289,7 +1297,7 @@ jobs:
             test "${latest_digest}" = "${expected_latest_digest}"
             test "${latest_digest}" != "${exact_digest}"
 
-            if [[ "${{ needs.validate-tag.outputs.beta }}" == "true" ]]; then
+            if [[ "${{ needs.validate-tag.outputs.channel_beta }}" == "true" ]]; then
               beta_digest="$(
                 .github/scripts/release-image-digest.sh \
                   "${repository}:v2beta"
@@ -1324,6 +1332,125 @@ jobs:
           test "$(
             docker image inspect -f '{{.Config.User}}' "${DOCKERHUB_EXACT_IMAGE}"
           )" = "10001:10001"
+
+  deploy-render:
+    name: Deploy Render
+    needs:
+      - validate-tag
+      - post-publish-image-smoke
+      - post-publish-verify
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.validate-tag.result == 'success' &&
+        needs.post-publish-image-smoke.result == 'success' &&
+        needs.post-publish-verify.result == 'success' &&
+        needs.validate-tag.outputs.channel_beta == 'true'
+      }}
+    concurrency:
+      group: gpt-load-render
+      cancel-in-progress: false
+    environment:
+      name: render
+      url: ${{ vars.RENDER_SERVICE_URL }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      RENDER_SERVICE_ID: ${{ vars.RENDER_SERVICE_ID }}
+      RENDER_SERVICE_URL: ${{ vars.RENDER_SERVICE_URL }}
+      RELEASE_VERSION: ${{ needs.validate-tag.outputs.image_exact }}
+      IMAGE: ghcr.io/tbphp/gpt-load:${{ needs.validate-tag.outputs.image_exact }}
+      RENDER_CLI_VERSION: "2.25.0"
+      RENDER_CLI_SHA256: "3b3f1f839ef36b81f12d84ac7288f1c96f9f7519b39c53fe6f866612f704e7cd"
+    steps:
+      - name: Validate deployment inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "${RENDER_SERVICE_ID}" =~ ^srv-[a-z0-9]+$ ]]
+          [[ "${RENDER_SERVICE_URL}" =~ ^https://[^/?#]+/?$ ]]
+          [[ "${RELEASE_VERSION}" =~ ^v2\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-beta\.(0|[1-9][0-9]*)$ ]]
+          [[ "${IMAGE}" == "ghcr.io/tbphp/gpt-load:${RELEASE_VERSION}" ]]
+
+      - name: Install pinned Render CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive="cli_${RENDER_CLI_VERSION}_linux_amd64.zip"
+          archive_path="${RUNNER_TEMP}/${archive}"
+          extract_dir="${RUNNER_TEMP}/render-cli-${RENDER_CLI_VERSION}"
+          url="https://github.com/render-oss/cli/releases/download/v${RENDER_CLI_VERSION}/${archive}"
+
+          curl \
+            --fail \
+            --silent \
+            --show-error \
+            --location \
+            --retry 3 \
+            --retry-all-errors \
+            "${url}" \
+            --output "${archive_path}"
+          printf '%s  %s\n' \
+            "${RENDER_CLI_SHA256}" \
+            "${archive_path}" | sha256sum --check
+          mkdir -p "${extract_dir}"
+          unzip -q "${archive_path}" -d "${extract_dir}"
+          install \
+            -m 0755 \
+            "${extract_dir}/cli_v${RENDER_CLI_VERSION}" \
+            "${RUNNER_TEMP}/render"
+          printf '%s\n' "${RUNNER_TEMP}" >>"${GITHUB_PATH}"
+          "${RUNNER_TEMP}/render" --version
+
+      - name: Deploy exact image and wait until live
+        shell: bash
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          CI: "true"
+        run: |
+          set -euo pipefail
+          test -n "${RENDER_API_KEY}"
+          render deploys create \
+            "${RENDER_SERVICE_ID}" \
+            --image "${IMAGE}" \
+            --wait \
+            --confirm \
+            --output text
+
+      - name: Verify public health endpoint
+        shell: bash
+        run: |
+          set -euo pipefail
+          health_response="$(
+            curl \
+              --fail \
+              --silent \
+              --show-error \
+              --retry 12 \
+              --retry-all-errors \
+              --retry-delay 5 \
+              --retry-max-time 180 \
+              --connect-timeout 5 \
+              --max-time 15 \
+              "${RENDER_SERVICE_URL%/}/health"
+          )"
+          jq -e \
+            --arg version "${RELEASE_VERSION}" \
+            '.status == "ok" and .version == $version' \
+            <<<"${health_response}" \
+            >/dev/null
+
+      - name: Summarize deployment
+        shell: bash
+        run: |
+          {
+            printf '## Render deployment\n\n'
+            printf -- '- Image: `%s`\n' "${IMAGE}"
+            printf -- '- Service: `%s`\n' "${RENDER_SERVICE_ID}"
+            printf -- '- URL: %s\n' "${RENDER_SERVICE_URL}"
+          } >>"${GITHUB_STEP_SUMMARY}"
 
   reconcile-publication:
     if: ${{ always() }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1423,24 +1423,35 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          health_response="$(
-            curl \
-              --fail \
-              --silent \
-              --show-error \
-              --retry 12 \
-              --retry-all-errors \
-              --retry-delay 5 \
-              --retry-max-time 180 \
-              --connect-timeout 5 \
-              --max-time 15 \
-              "${RENDER_SERVICE_URL%/}/health"
-          )"
-          jq -e \
-            --arg version "${RELEASE_VERSION}" \
-            '.status == "ok" and .version == $version' \
-            <<<"${health_response}" \
-            >/dev/null
+          # render-health-verification:start
+          health_url="${RENDER_SERVICE_URL%/}/health"
+          deadline=$((SECONDS + 180))
+          while true; do
+            health_response=
+            if health_response="$(
+              curl \
+                --fail \
+                --silent \
+                --show-error \
+                --connect-timeout 5 \
+                --max-time 15 \
+                "${health_url}"
+            )" &&
+              jq -e \
+                --arg version "${RELEASE_VERSION}" \
+                '.status == "ok" and .version == $version' \
+                <<<"${health_response}" \
+                >/dev/null; then
+              break
+            fi
+            if ((SECONDS >= deadline)); then
+              printf 'Render health did not report version %s within 180 seconds\n' \
+                "${RELEASE_VERSION}" >&2
+              exit 1
+            fi
+            sleep 5
+          done
+          # render-health-verification:end
 
       - name: Summarize deployment
         shell: bash

--- a/internal/webui/workflow_test.go
+++ b/internal/webui/workflow_test.go
@@ -1235,7 +1235,9 @@ func TestReleaseWorkflowDeploysFormalBetaToRenderAfterPublishedImageGates(t *tes
 	for _, required := range []string{
 		`"${RENDER_SERVICE_URL%/}/health"`,
 		"--fail",
-		"--retry-all-errors",
+		"deadline=$((SECONDS + 180))",
+		"while true",
+		"sleep 5",
 		"health_response",
 		`--arg version "${RELEASE_VERSION}"`,
 		`.status == "ok" and .version == $version`,
@@ -1243,6 +1245,88 @@ func TestReleaseWorkflowDeploysFormalBetaToRenderAfterPublishedImageGates(t *tes
 		if !strings.Contains(health, required) {
 			t.Fatalf("Render health verification does not contain %q:\n%s", required, health)
 		}
+	}
+}
+
+func TestReleaseWorkflowRetriesStaleRenderHealthVersion(t *testing.T) {
+	content := readRepositoryFile(t, ".github/workflows/release.yml")
+	health := workflowStepBlock(
+		t,
+		workflowJobBlock(t, content, "deploy-render"),
+		"Verify public health endpoint",
+	)
+	script := workflowMarkedScript(t, health, "render-health-verification")
+	scriptPath := filepath.Join(t.TempDir(), "verify-render-health.sh")
+	if err := os.WriteFile(
+		scriptPath,
+		[]byte("#!/usr/bin/env bash\nset -euo pipefail\n"+script),
+		0o700,
+	); err != nil {
+		t.Fatalf("write Render health verification script: %v", err)
+	}
+
+	fakeBin := t.TempDir()
+	statePath := filepath.Join(t.TempDir(), "curl-count")
+	fakeCurl := `#!/usr/bin/env bash
+set -euo pipefail
+count=0
+if [[ -f "${RENDER_HEALTH_TEST_STATE}" ]]; then
+  count="$(<"${RENDER_HEALTH_TEST_STATE}")"
+fi
+count=$((count + 1))
+printf '%s\n' "${count}" >"${RENDER_HEALTH_TEST_STATE}"
+if ((count == 1)); then
+  printf '{"status":"ok","version":"v2.0.0-beta.24"}\n'
+else
+  printf '{"status":"ok","version":"v2.0.0-beta.25"}\n'
+fi
+`
+	if err := os.WriteFile(filepath.Join(fakeBin, "curl"), []byte(fakeCurl), 0o700); err != nil {
+		t.Fatalf("write fake curl: %v", err)
+	}
+	fakeJQ := `#!/usr/bin/env bash
+set -euo pipefail
+expected=
+while (($# > 0)); do
+  if [[ "$1" == "--arg" && "$2" == "version" ]]; then
+    expected="$3"
+    shift 3
+    continue
+  fi
+  shift
+done
+body="$(cat)"
+[[ "${body}" == *'"status":"ok"'* ]]
+[[ "${body}" == *"\"version\":\"${expected}\""* ]]
+`
+	if err := os.WriteFile(filepath.Join(fakeBin, "jq"), []byte(fakeJQ), 0o700); err != nil {
+		t.Fatalf("write fake jq: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(fakeBin, "sleep"),
+		[]byte("#!/usr/bin/env bash\nexit 0\n"),
+		0o700,
+	); err != nil {
+		t.Fatalf("write fake sleep: %v", err)
+	}
+
+	command := exec.Command("bash", scriptPath)
+	command.Env = append(
+		os.Environ(),
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"RENDER_HEALTH_TEST_STATE="+statePath,
+		"RENDER_SERVICE_URL=https://gpt-load-example.onrender.com",
+		"RELEASE_VERSION=v2.0.0-beta.25",
+	)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("Render health verification failed: %v\n%s", err, output)
+	}
+	count, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read curl attempt count: %v", err)
+	}
+	if got := strings.TrimSpace(string(count)); got != "2" {
+		t.Fatalf("curl attempts = %s, want 2", got)
 	}
 }
 

--- a/internal/webui/workflow_test.go
+++ b/internal/webui/workflow_test.go
@@ -336,7 +336,7 @@ func TestReleaseWorkflowUsesTagOnlyTriggerAndStrictSemverGuard(t *testing.T) {
 			valid: true,
 			wantOutput: []string{
 				"version=v2.0.0", "prerelease=false", "image_exact=v2.0.0",
-				"image_minor=2.0", "image_major=2", "beta=false",
+				"image_minor=2.0", "image_major=2", "beta=false", "channel_beta=false",
 			},
 		},
 		{
@@ -344,7 +344,7 @@ func TestReleaseWorkflowUsesTagOnlyTriggerAndStrictSemverGuard(t *testing.T) {
 			valid: true,
 			wantOutput: []string{
 				"version=v2.0.0-rc.1", "prerelease=true", "image_exact=v2.0.0-rc.1",
-				"image_minor=2.0", "image_major=2", "beta=false",
+				"image_minor=2.0", "image_major=2", "beta=false", "channel_beta=false",
 			},
 		},
 		{
@@ -352,7 +352,37 @@ func TestReleaseWorkflowUsesTagOnlyTriggerAndStrictSemverGuard(t *testing.T) {
 			valid: true,
 			wantOutput: []string{
 				"version=v2.0.0-beta.1", "prerelease=true", "image_exact=v2.0.0-beta.1",
-				"image_minor=2.0", "image_major=2", "beta=true",
+				"image_minor=2.0", "image_major=2", "beta=true", "channel_beta=true",
+			},
+		},
+		{
+			tag:   "v2.0.0-beta.0",
+			valid: true,
+			wantOutput: []string{
+				"beta=true", "channel_beta=true",
+			},
+		},
+		{
+			tag:   "v2.0.0-beta",
+			valid: true,
+			wantOutput: []string{
+				"beta=true", "channel_beta=false",
+			},
+		},
+		{
+			tag:   "v2.0.0-beta.test-build-1",
+			valid: true,
+			wantOutput: []string{
+				"version=v2.0.0-beta.test-build-1", "prerelease=true",
+				"image_exact=v2.0.0-beta.test-build-1", "image_minor=2.0", "image_major=2",
+				"beta=true", "channel_beta=false",
+			},
+		},
+		{
+			tag:   "v2.0.0-beta.1.extra",
+			valid: true,
+			wantOutput: []string{
+				"beta=true", "channel_beta=false",
 			},
 		},
 		{
@@ -361,7 +391,7 @@ func TestReleaseWorkflowUsesTagOnlyTriggerAndStrictSemverGuard(t *testing.T) {
 			wantOutput: []string{
 				"version=v2.10.3-alpha-1.0", "prerelease=true",
 				"image_exact=v2.10.3-alpha-1.0", "image_minor=2.10", "image_major=2",
-				"beta=false",
+				"beta=false", "channel_beta=false",
 			},
 		},
 		{tag: "v2.0.0.1", valid: false},
@@ -393,9 +423,28 @@ func TestReleaseWorkflowUsesTagOnlyTriggerAndStrictSemverGuard(t *testing.T) {
 				if readErr != nil {
 					t.Fatalf("read tag outputs: %v", readErr)
 				}
+				gotOutput := make(map[string]string)
+				for _, line := range strings.Split(strings.TrimSpace(string(githubOutput)), "\n") {
+					key, value, found := strings.Cut(line, "=")
+					if !found {
+						t.Fatalf("tag %s emitted malformed output %q", test.tag, line)
+					}
+					gotOutput[key] = value
+				}
 				for _, expected := range test.wantOutput {
-					if !strings.Contains(string(githubOutput), expected+"\n") {
-						t.Fatalf("tag %s outputs do not contain %q:\n%s", test.tag, expected, githubOutput)
+					key, value, found := strings.Cut(expected, "=")
+					if !found {
+						t.Fatalf("test expectation %q is malformed", expected)
+					}
+					if gotOutput[key] != value {
+						t.Fatalf(
+							"tag %s output %s = %q, want %q:\n%s",
+							test.tag,
+							key,
+							gotOutput[key],
+							value,
+							githubOutput,
+						)
 					}
 				}
 			}
@@ -1055,7 +1104,7 @@ func TestReleaseWorkflowUpdatesAliasesOnlyAfterExactVerification(t *testing.T) {
 func TestReleaseWorkflowMaintainsBetaChannelAlias(t *testing.T) {
 	content := readRepositoryFile(t, ".github/workflows/release.yml")
 	validateJob := workflowJobBlock(t, content, "validate-tag")
-	if !strings.Contains(validateJob, "beta: ${{ steps.tag.outputs.beta }}") {
+	if !strings.Contains(validateJob, "channel_beta: ${{ steps.tag.outputs.channel_beta }}") {
 		t.Fatalf("tag validation does not expose the beta channel decision:\n%s", validateJob)
 	}
 
@@ -1073,7 +1122,7 @@ func TestReleaseWorkflowMaintainsBetaChannelAlias(t *testing.T) {
 	betaStep := workflowStepBlock(t, imageJob, "Update beta channel alias")
 	for _, required := range []string{
 		"needs.publication-preflight.outputs.write_mode == 'publish'",
-		"needs.validate-tag.outputs.beta == 'true'",
+		"needs.validate-tag.outputs.channel_beta == 'true'",
 		"docker buildx imagetools create",
 		`exact="${repository}:${{ needs.validate-tag.outputs.image_exact }}"`,
 		`--tag "${repository}:v2beta"`,
@@ -1082,6 +1131,9 @@ func TestReleaseWorkflowMaintainsBetaChannelAlias(t *testing.T) {
 			t.Fatalf("beta alias update does not contain %q:\n%s", required, betaStep)
 		}
 	}
+	if strings.Contains(betaStep, "needs.validate-tag.outputs.beta") {
+		t.Fatalf("beta alias update still uses the broad beta classification:\n%s", betaStep)
+	}
 
 	verification := workflowStepBlock(
 		t,
@@ -1089,7 +1141,7 @@ func TestReleaseWorkflowMaintainsBetaChannelAlias(t *testing.T) {
 		"Verify published image manifests",
 	)
 	for _, required := range []string{
-		`needs.validate-tag.outputs.beta`,
+		`needs.validate-tag.outputs.channel_beta`,
 		`"${repository}:v2beta"`,
 		"beta_digest",
 		`test "${beta_digest}" = "${exact_digest}"`,
@@ -1097,6 +1149,9 @@ func TestReleaseWorkflowMaintainsBetaChannelAlias(t *testing.T) {
 		if !strings.Contains(verification, required) {
 			t.Fatalf("beta alias verification does not contain %q:\n%s", required, verification)
 		}
+	}
+	if strings.Contains(verification, "needs.validate-tag.outputs.beta") {
+		t.Fatalf("beta alias verification still uses the broad beta classification:\n%s", verification)
 	}
 
 	reconciliation := workflowStepBlock(
@@ -1112,6 +1167,81 @@ func TestReleaseWorkflowMaintainsBetaChannelAlias(t *testing.T) {
 	} {
 		if !strings.Contains(reconciliation, required) {
 			t.Fatalf("publication reconciliation does not contain %q:\n%s", required, reconciliation)
+		}
+	}
+}
+
+func TestReleaseWorkflowDeploysFormalBetaToRenderAfterPublishedImageGates(t *testing.T) {
+	content := readRepositoryFile(t, ".github/workflows/release.yml")
+	job := workflowJobBlock(t, content, "deploy-render")
+
+	for _, required := range []string{
+		"- validate-tag",
+		"- post-publish-image-smoke",
+		"- post-publish-verify",
+		"needs.validate-tag.outputs.channel_beta == 'true'",
+		"needs.post-publish-image-smoke.result == 'success'",
+		"needs.post-publish-verify.result == 'success'",
+		"group: gpt-load-render",
+		"cancel-in-progress: false",
+		"name: render",
+		"url: ${{ vars.RENDER_SERVICE_URL }}",
+		"RENDER_SERVICE_ID: ${{ vars.RENDER_SERVICE_ID }}",
+		"RENDER_SERVICE_URL: ${{ vars.RENDER_SERVICE_URL }}",
+		"RELEASE_VERSION: ${{ needs.validate-tag.outputs.image_exact }}",
+		"IMAGE: ghcr.io/tbphp/gpt-load:${{ needs.validate-tag.outputs.image_exact }}",
+		`RENDER_CLI_VERSION: "2.25.0"`,
+		`RENDER_CLI_SHA256: "3b3f1f839ef36b81f12d84ac7288f1c96f9f7519b39c53fe6f866612f704e7cd"`,
+	} {
+		if !strings.Contains(job, required) {
+			t.Fatalf("Render deployment job does not contain %q:\n%s", required, job)
+		}
+	}
+	for _, forbidden := range []string{"v2beta", "RENDER_DEPLOY_HOOK_URL"} {
+		if strings.Contains(job, forbidden) {
+			t.Fatalf("Render deployment job contains forbidden %q:\n%s", forbidden, job)
+		}
+	}
+
+	install := workflowStepBlock(t, job, "Install pinned Render CLI")
+	for _, required := range []string{
+		"RENDER_CLI_VERSION",
+		"RENDER_CLI_SHA256",
+		"sha256sum --check",
+		"cli_${RENDER_CLI_VERSION}_linux_amd64.zip",
+		"--retry-all-errors",
+	} {
+		if !strings.Contains(install, required) {
+			t.Fatalf("Render CLI installation does not contain %q:\n%s", required, install)
+		}
+	}
+
+	deploy := workflowStepBlock(t, job, "Deploy exact image and wait until live")
+	for _, required := range []string{
+		"RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}",
+		"render deploys create",
+		`"${RENDER_SERVICE_ID}"`,
+		`--image "${IMAGE}"`,
+		"--wait",
+		"--confirm",
+		"--output text",
+	} {
+		if !strings.Contains(deploy, required) {
+			t.Fatalf("Render deployment step does not contain %q:\n%s", required, deploy)
+		}
+	}
+
+	health := workflowStepBlock(t, job, "Verify public health endpoint")
+	for _, required := range []string{
+		`"${RENDER_SERVICE_URL%/}/health"`,
+		"--fail",
+		"--retry-all-errors",
+		"health_response",
+		`--arg version "${RELEASE_VERSION}"`,
+		`.status == "ok" and .version == $version`,
+	} {
+		if !strings.Contains(health, required) {
+			t.Fatalf("Render health verification does not contain %q:\n%s", required, health)
 		}
 	}
 }


### PR DESCRIPTION
### 关联 Issue / Related Issue

无 / N/A

### 变更内容 / Change Content

- [ ] Bug 修复 / Bug fix
- [x] 新功能 / New feature
- [ ] 其他改动 / Other changes

- 新增严格的正式 beta channel，仅 `v2.x.y-beta.N` 更新 `v2beta` 并部署 Render，测试 beta tag 不再污染共享别名。
- 在发布镜像 smoke 与 manifest/Release 校验全部成功后，通过固定版本且校验 SHA-256 的 Render CLI 部署 GHCR 精确版本镜像。
- 使用 GitHub Environment `render` 关联 Deployment 状态；等待 Render 部署完成后，校验公开 `/health` 的 `status` 与精确版本。
- 增加发布工作流合同测试，覆盖正式/测试 beta 边界、部署门禁、精确镜像、CLI 等待与健康版本校验。

验证：

- `make check`
- `go test -count=1 ./internal/webui`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/release.yml`
- `git --no-pager diff --check`

兼容性与运维边界：

- 不修改应用 API、数据结构或数据库迁移。
- 继续遵守“上一个正式 beta Release 完整结束后，再创建下一个 beta tag”的发布约束。
- 本 PR 不创建 tag、不触发 Release，也不执行合并。

### 自查清单 / Checklist

- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 正式 Beta 版本发布后，系统会自动部署到 Render，并验证公开健康检查端点及版本信息。
  * 部署仅使用精确版本镜像，并在镜像发布、运行时检查和发布后验证均通过后执行。
* **改进**
  * 优化 Beta 版本识别规则，严格区分正式 Beta 标签与其他预发布标签。
  * Beta 通道别名仅在符合严格版本格式的标签发布时更新，避免误触发。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->