### PR TITLE
feat(home): 展示常用订阅账号

### DIFF
--- a/internal/control/home_subscription_accounts.go
+++ b/internal/control/home_subscription_accounts.go
@@ -1,0 +1,376 @@
+package control
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"gpt-load/internal/channel"
+	app_errors "gpt-load/internal/platform/errors"
+	"gpt-load/internal/platform/response"
+	"gpt-load/internal/state"
+	"gpt-load/internal/storage/models"
+)
+
+const (
+	homeSubscriptionAccountLimit    = 4
+	homeSubscriptionAccountWindow   = 24 * time.Hour
+	homeSubscriptionAccountCacheTTL = time.Minute
+)
+
+type HomeSubscriptionAccountsResponse struct {
+	ObservedAtMS int64                             `json:"observed_at_ms"`
+	Items        []HomeSubscriptionAccountResponse `json:"items"`
+}
+
+type HomeSubscriptionAccountResponse struct {
+	ChannelID           string                       `json:"channel_id"`
+	ChannelMark         string                       `json:"channel_mark"`
+	ChannelIcon         string                       `json:"channel_icon"`
+	Capabilities        channel.CapabilityDescriptor `json:"capabilities"`
+	GroupCount          int                          `json:"group_count"`
+	AvailableGroupCount int                          `json:"available_group_count"`
+	Credential          CredentialItemResponse       `json:"credential"`
+}
+
+type homeSubscriptionAccountsCache struct {
+	expiresAt time.Time
+	response  HomeSubscriptionAccountsResponse
+}
+
+type homeSubscriptionActivityRow struct {
+	IdentityFingerprint string `gorm:"column:identity_fingerprint"`
+	ChannelID           string `gorm:"column:channel_id"`
+	SuccessCount        int64  `gorm:"column:success_count"`
+	LastSuccessAtMS     int64  `gorm:"column:last_success_at_ms"`
+}
+
+type homeSubscriptionRows struct {
+	activity     []homeSubscriptionActivityRow
+	credentials  []models.Credential
+	observations []models.CredentialObservation
+}
+
+type homeSubscriptionMembership struct {
+	credential  models.Credential
+	observation models.CredentialObservation
+	view        state.CredentialRuntimeView
+	bucket      healthBucket
+}
+
+func (s *Service) ReadHomeSubscriptionAccounts(
+	ctx context.Context,
+) (HomeSubscriptionAccountsResponse, error) {
+	if s == nil || s.db == nil || s.registry == nil || s.registrySnapshot == nil ||
+		s.stats == nil || s.channelRegistry == nil || s.encryption == nil || s.now == nil {
+		return HomeSubscriptionAccountsResponse{}, app_errors.ErrInternalServer
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return HomeSubscriptionAccountsResponse{}, err
+	}
+	s.homeSubscriptionMu.Lock()
+	defer s.homeSubscriptionMu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return HomeSubscriptionAccountsResponse{}, err
+	}
+	now := s.now().UTC()
+	if cached := s.homeSubscriptionCache; cached != nil && now.Before(cached.expiresAt) {
+		return cloneHomeSubscriptionAccountsResponse(cached.response), nil
+	}
+
+	response, err := s.readHomeSubscriptionAccounts(ctx, now)
+	if err != nil {
+		return HomeSubscriptionAccountsResponse{}, err
+	}
+	s.homeSubscriptionCache = &homeSubscriptionAccountsCache{
+		expiresAt: now.Add(homeSubscriptionAccountCacheTTL),
+		response:  cloneHomeSubscriptionAccountsResponse(response),
+	}
+	return response, nil
+}
+
+func (s *Server) handleHomeSubscriptionAccounts(c *gin.Context) {
+	if c.Request.URL.RawQuery != "" || c.Request.URL.ForceQuery {
+		writeServiceError(c, "home_subscription_accounts", app_errors.ErrBadRequest)
+		return
+	}
+	result, err := s.service.ReadHomeSubscriptionAccounts(c.Request.Context())
+	if err != nil {
+		writeServiceError(c, "home_subscription_accounts", err)
+		return
+	}
+	response.SuccessI18n(c, "common.success", result)
+}
+
+func (s *Service) readHomeSubscriptionAccounts(
+	ctx context.Context,
+	observedAt time.Time,
+) (HomeSubscriptionAccountsResponse, error) {
+	observedAtMS, err := safeEpochMilliseconds(observedAt)
+	if err != nil {
+		return HomeSubscriptionAccountsResponse{}, err
+	}
+
+	s.writeMu.RLock()
+	defer s.writeMu.RUnlock()
+	rows, err := s.readHomeSubscriptionRows(ctx, observedAt)
+	if err != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return HomeSubscriptionAccountsResponse{}, contextErr
+		}
+		var apiErr *app_errors.APIError
+		if errors.As(err, &apiErr) {
+			return HomeSubscriptionAccountsResponse{}, err
+		}
+		return HomeSubscriptionAccountsResponse{}, app_errors.ParseDBError(err)
+	}
+	if len(rows.activity) == 0 {
+		return HomeSubscriptionAccountsResponse{
+			ObservedAtMS: observedAtMS,
+			Items:        []HomeSubscriptionAccountResponse{},
+		}, nil
+	}
+
+	runtimeByID := make(map[uint]state.CredentialRuntimeView)
+	for _, view := range s.registrySnapshot() {
+		runtimeByID[view.ID] = view
+	}
+	observationByID := make(map[uint]models.CredentialObservation, len(rows.observations))
+	for _, observation := range rows.observations {
+		observationByID[observation.CredentialID] = observation
+	}
+	memberships := make(map[string][]homeSubscriptionMembership, len(rows.activity))
+	for _, credential := range rows.credentials {
+		if credential.Group == nil ||
+			normalizeGroupConnectionType(credential.Group.ConnectionType) != models.ConnectionTypeSubscription {
+			return HomeSubscriptionAccountsResponse{}, app_errors.ErrInternalServer
+		}
+		view, exists := runtimeByID[credential.ID]
+		if !exists || view.GroupID != credential.GroupID ||
+			view.Status != state.CredentialStatus(credential.Status) ||
+			view.AuthState != normalizeRuntimeCredentialAuthState(credential.AuthState) ||
+			view.Version != groupCollectionCredentialVersion(credential.SecretVersion) ||
+			view.IdentityGeneration != groupCollectionCredentialIdentity(
+				credential.IdentityFingerprint,
+				*credential.Group,
+			) {
+			return HomeSubscriptionAccountsResponse{}, app_errors.ErrInternalServer
+		}
+		catalog := state.GroupCatalogView{
+			ID: credential.Group.ID, Name: credential.Group.Name,
+			Enabled: credential.Group.Enabled, WeightManual: cloneInt(credential.Group.WeightManual),
+		}
+		key := homeSubscriptionIdentityKey(
+			credential.Group.ChannelID,
+			credential.IdentityFingerprint,
+		)
+		memberships[key] = append(memberships[key], homeSubscriptionMembership{
+			credential:  credential,
+			observation: observationByID[credential.ID],
+			view:        view,
+			bucket:      classifyHealthKey(catalog, view, observedAt),
+		})
+	}
+
+	items := make([]HomeSubscriptionAccountResponse, 0, len(rows.activity))
+	for _, activity := range rows.activity {
+		key := homeSubscriptionIdentityKey(activity.ChannelID, activity.IdentityFingerprint)
+		accountMemberships := memberships[key]
+		if len(accountMemberships) == 0 || activity.SuccessCount < 1 {
+			return HomeSubscriptionAccountsResponse{}, app_errors.ErrInternalServer
+		}
+		item, err := s.mapHomeSubscriptionAccount(ctx, accountMemberships, observedAt)
+		if err != nil {
+			return HomeSubscriptionAccountsResponse{}, err
+		}
+		descriptor, exists := s.channelRegistry.Get(channel.ID(activity.ChannelID))
+		if !exists || descriptor.Connection.Type != string(models.ConnectionTypeSubscription) {
+			return HomeSubscriptionAccountsResponse{}, app_errors.ErrInternalServer
+		}
+		item.ChannelID = activity.ChannelID
+		item.ChannelMark = descriptor.Mark
+		item.ChannelIcon = descriptor.Icon
+		item.Capabilities = descriptor.Capabilities
+		items = append(items, item)
+	}
+	return HomeSubscriptionAccountsResponse{ObservedAtMS: observedAtMS, Items: items}, nil
+}
+
+func (s *Service) readHomeSubscriptionRows(
+	ctx context.Context,
+	observedAt time.Time,
+) (homeSubscriptionRows, error) {
+	rows := homeSubscriptionRows{}
+	err := s.withReadSnapshot(ctx, func(tx *gorm.DB) error {
+		activityScope := homeSubscriptionActivityScope(
+			tx,
+			observedAt.Add(-homeSubscriptionAccountWindow).UnixMilli(),
+			observedAt.UnixMilli(),
+		)
+		if err := activityScope.Find(&rows.activity).Error; err != nil {
+			return fmt.Errorf("query home subscription activity: %w", err)
+		}
+		if len(rows.activity) == 0 {
+			return nil
+		}
+		identities := make([]string, 0, len(rows.activity))
+		for _, activity := range rows.activity {
+			if activity.IdentityFingerprint == "" || activity.ChannelID == "" ||
+				activity.SuccessCount < 1 || validateSafeMilliseconds(activity.LastSuccessAtMS) != nil {
+				return fmt.Errorf("validate home subscription activity: %w", app_errors.ErrInternalServer)
+			}
+			identities = append(identities, activity.IdentityFingerprint)
+		}
+		subscriptionGroups := tx.Session(&gorm.Session{NewDB: true}).
+			Model(&models.Group{}).
+			Select("id").
+			Where("connection_type = ?", models.ConnectionTypeSubscription)
+		if err := tx.Preload("Group").
+			Where("identity_fingerprint IN ?", identities).
+			Where("group_id IN (?)", subscriptionGroups).
+			Order("id ASC").
+			Find(&rows.credentials).Error; err != nil {
+			return fmt.Errorf("query home subscription credentials: %w", err)
+		}
+		credentialIDs := make([]uint, 0, len(rows.credentials))
+		for _, credential := range rows.credentials {
+			credentialIDs = append(credentialIDs, credential.ID)
+		}
+		if len(credentialIDs) == 0 {
+			return nil
+		}
+		if err := tx.Where("credential_id IN ?", credentialIDs).
+			Find(&rows.observations).Error; err != nil {
+			return fmt.Errorf("query home subscription observations: %w", err)
+		}
+		return nil
+	})
+	return rows, err
+}
+
+func homeSubscriptionActivityScope(db *gorm.DB, fromMS, toMS int64) *gorm.DB {
+	subscriptionGroups := db.Session(&gorm.Session{NewDB: true}).
+		Model(&models.Group{}).
+		Select("id, channel_id").
+		Where("connection_type = ?", models.ConnectionTypeSubscription)
+	return db.Table("credential_attempt_stats").
+		Select(
+			"credentials.identity_fingerprint, subscription_groups.channel_id, "+
+				"SUM(credential_attempt_stats.success_count) AS success_count, "+
+				"MAX(credential_attempt_stats.bucket_start_ms) AS last_success_at_ms",
+		).
+		Joins("JOIN credentials ON credentials.id = credential_attempt_stats.credential_id").
+		Joins(
+			"JOIN (?) AS subscription_groups ON subscription_groups.id = credentials.group_id",
+			subscriptionGroups,
+		).
+		Where("credential_attempt_stats.bucket_start_ms >= ?", fromMS).
+		Where("credential_attempt_stats.bucket_start_ms < ?", toMS).
+		Where("credential_attempt_stats.success_count > 0").
+		Group("credentials.identity_fingerprint, subscription_groups.channel_id").
+		Order("success_count DESC, last_success_at_ms DESC, credentials.identity_fingerprint ASC").
+		Limit(homeSubscriptionAccountLimit)
+}
+
+func (s *Service) mapHomeSubscriptionAccount(
+	ctx context.Context,
+	memberships []homeSubscriptionMembership,
+	observedAt time.Time,
+) (HomeSubscriptionAccountResponse, error) {
+	representative := memberships[0]
+	available := 0
+	for _, membership := range memberships {
+		if membership.bucket == healthBucketAvailable {
+			available++
+		}
+		if homeSubscriptionRepresentativeLess(representative, membership) {
+			representative = membership
+		}
+	}
+	group := *representative.credential.Group
+	canonical, identity, err := s.decodeCredential(group, representative.credential)
+	if err != nil {
+		return HomeSubscriptionAccountResponse{}, err
+	}
+	mask, account, err := s.credentialPresentation(
+		group,
+		representative.credential,
+		canonical,
+		identity,
+	)
+	if err != nil {
+		return HomeSubscriptionAccountResponse{}, err
+	}
+	credential := representative.credential
+	item, err := mapCredentialRuntimeItem(
+		mask,
+		credential.ID,
+		representative.view,
+		representative.bucket,
+		s.stats.Snapshot(credential.ID, observedAt),
+		observedAt,
+	)
+	if err != nil {
+		return HomeSubscriptionAccountResponse{}, err
+	}
+	item.ConnectionType = string(models.ConnectionTypeSubscription)
+	item.SecretVersion = credential.SecretVersion
+	item.AuthState = string(credential.AuthState)
+	item.AuthErrorCode = safeInternalErrorCode(credential.AuthErrorCode)
+	item.Account = account
+	item.Observation = presentCredentialObservation(
+		representative.observation,
+		credential.IdentityFingerprint,
+	)
+	proxyViews, err := s.credentialProxyViews(ctx, s.db, group, []models.Credential{credential})
+	if err != nil {
+		return HomeSubscriptionAccountResponse{}, err
+	}
+	item.Proxy = proxyViews[credential.ID]
+	return HomeSubscriptionAccountResponse{
+		GroupCount:          len(memberships),
+		AvailableGroupCount: available,
+		Credential:          item,
+	}, nil
+}
+
+func homeSubscriptionRepresentativeLess(
+	current homeSubscriptionMembership,
+	candidate homeSubscriptionMembership,
+) bool {
+	currentObservedAt := int64(-1)
+	if current.observation.ObservedAtMS != nil &&
+		current.observation.IdentityFingerprint == current.credential.IdentityFingerprint {
+		currentObservedAt = *current.observation.ObservedAtMS
+	}
+	candidateObservedAt := int64(-1)
+	if candidate.observation.ObservedAtMS != nil &&
+		candidate.observation.IdentityFingerprint == candidate.credential.IdentityFingerprint {
+		candidateObservedAt = *candidate.observation.ObservedAtMS
+	}
+	if currentObservedAt != candidateObservedAt {
+		return candidateObservedAt > currentObservedAt
+	}
+	if (current.bucket == healthBucketAvailable) != (candidate.bucket == healthBucketAvailable) {
+		return candidate.bucket == healthBucketAvailable
+	}
+	return candidate.credential.ID < current.credential.ID
+}
+
+func homeSubscriptionIdentityKey(channelID, identityFingerprint string) string {
+	return channelID + "\x00" + identityFingerprint
+}
+
+func cloneHomeSubscriptionAccountsResponse(
+	value HomeSubscriptionAccountsResponse,
+) HomeSubscriptionAccountsResponse {
+	value.Items = append([]HomeSubscriptionAccountResponse(nil), value.Items...)
+	return value
+}

--- a/internal/control/home_subscription_accounts_test.go
+++ b/internal/control/home_subscription_accounts_test.go
@@ -1,0 +1,285 @@
+package control
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	gormmysql "gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/platform/config"
+	"gpt-load/internal/state"
+	"gpt-load/internal/storage/models"
+)
+
+func TestReadHomeSubscriptionAccountsUsesBoundedHourlyActivityAndDeduplicates(t *testing.T) {
+	t.Parallel()
+	fixture := newServiceFixture(t)
+	now := time.Date(2026, time.August, 31, 12, 30, 0, 0, time.UTC)
+	fixture.service.now = func() time.Time { return now }
+
+	sharedOneGroupID, sharedOne := createHomeSubscriptionCredential(
+		t, fixture, "shared-one", "shared-account", "shared@example.com",
+	)
+	sharedTwoGroupID, sharedTwo := createHomeSubscriptionCredential(
+		t, fixture, "shared-two", "shared-account", "shared@example.com",
+	)
+	_, other := createHomeSubscriptionCredential(
+		t, fixture, "other", "other-account", "other@example.com",
+	)
+	_, failureOnly := createHomeSubscriptionCredential(
+		t, fixture, "failure-only", "failure-account", "failure@example.com",
+	)
+	_, outsideWindow := createHomeSubscriptionCredential(
+		t, fixture, "outside-window", "old-account", "old@example.com",
+	)
+
+	if _, err := fixture.service.UpdateGroupCredential(
+		t.Context(), sharedTwoGroupID, sharedTwo.ID,
+		CredentialUpdateRequest{Status: optionalField[state.CredentialStatus]{
+			Set: true, Value: state.CredentialStatusDisabled,
+		}},
+	); err != nil {
+		t.Fatalf("disable duplicate subscription credential: %v", err)
+	}
+
+	createHomeCredentialObservation(t, fixture, sharedOne, now.Add(-10*time.Minute), "Old plan")
+	createHomeCredentialObservation(t, fixture, sharedTwo, now.Add(-time.Minute), "Pro 20x")
+	createHomeCredentialObservation(t, fixture, other, now.Add(-2*time.Minute), "Other plan")
+
+	recentBucket := now.Truncate(time.Hour).Add(-time.Hour).UnixMilli()
+	if err := fixture.db.Create(&[]models.CredentialAttemptStat{
+		{CredentialID: sharedOne.ID, BucketStartMS: recentBucket, SuccessCount: 3},
+		{CredentialID: sharedTwo.ID, BucketStartMS: recentBucket, SuccessCount: 4, FailureCount: 20},
+		{CredentialID: other.ID, BucketStartMS: recentBucket, SuccessCount: 6},
+		{CredentialID: failureOnly.ID, BucketStartMS: recentBucket, FailureCount: 100},
+		{CredentialID: outsideWindow.ID, BucketStartMS: now.Truncate(time.Hour).Add(-25 * time.Hour).UnixMilli(), SuccessCount: 100},
+	}).Error; err != nil {
+		t.Fatalf("create credential activity: %v", err)
+	}
+
+	apiGroupID := createGroupWithCredentials(t, fixture, "sk-api-key")
+	var apiCredential models.Credential
+	if err := fixture.db.Where("group_id = ?", apiGroupID).Take(&apiCredential).Error; err != nil {
+		t.Fatalf("query API-key credential: %v", err)
+	}
+	if err := fixture.db.Create(&models.CredentialAttemptStat{
+		CredentialID: apiCredential.ID, BucketStartMS: recentBucket, SuccessCount: 200,
+	}).Error; err != nil {
+		t.Fatalf("create API-key activity: %v", err)
+	}
+
+	result, err := fixture.service.ReadHomeSubscriptionAccounts(t.Context())
+	if err != nil {
+		t.Fatalf("ReadHomeSubscriptionAccounts() error = %v", err)
+	}
+	if result.ObservedAtMS != now.UnixMilli() || len(result.Items) != 2 {
+		t.Fatalf("ReadHomeSubscriptionAccounts() = %#v", result)
+	}
+	shared := result.Items[0]
+	if shared.ChannelID != string(channel.Codex) || shared.GroupCount != 2 ||
+		shared.AvailableGroupCount != 1 || shared.Credential.Account.Email != "shared@example.com" ||
+		shared.Credential.Observation == nil || shared.Credential.Observation.Snapshot == nil ||
+		shared.Credential.Observation.Snapshot.Plan.Name != "Pro 20x" {
+		t.Fatalf("deduplicated shared account = %#v", shared)
+	}
+	if result.Items[1].Credential.Account.Email != "other@example.com" ||
+		result.Items[1].GroupCount != 1 || result.Items[1].AvailableGroupCount != 1 {
+		t.Fatalf("second account = %#v", result.Items[1])
+	}
+	if sharedOneGroupID == sharedTwoGroupID {
+		t.Fatal("duplicate account fixture unexpectedly reused one group")
+	}
+}
+
+func TestReadHomeSubscriptionAccountsCachesRankingForOneMinute(t *testing.T) {
+	t.Parallel()
+	fixture := newServiceFixture(t)
+	now := time.Date(2026, time.August, 31, 12, 30, 0, 0, time.UTC)
+	fixture.service.now = func() time.Time { return now }
+	_, first := createHomeSubscriptionCredential(t, fixture, "cache-first", "cache-first", "first@example.com")
+	_, second := createHomeSubscriptionCredential(t, fixture, "cache-second", "cache-second", "second@example.com")
+	bucket := now.Truncate(time.Hour).UnixMilli()
+	if err := fixture.db.Create(&[]models.CredentialAttemptStat{
+		{CredentialID: first.ID, BucketStartMS: bucket, SuccessCount: 5},
+		{CredentialID: second.ID, BucketStartMS: bucket, SuccessCount: 1},
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	firstRead, err := fixture.service.ReadHomeSubscriptionAccounts(t.Context())
+	if err != nil || len(firstRead.Items) != 2 || firstRead.Items[0].Credential.Account.Email != "first@example.com" {
+		t.Fatalf("first read = %#v, %v", firstRead, err)
+	}
+	if err := fixture.db.Model(&models.CredentialAttemptStat{}).
+		Where("credential_id = ? AND bucket_start_ms = ?", second.ID, bucket).
+		Update("success_count", 50).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	cached, err := fixture.service.ReadHomeSubscriptionAccounts(t.Context())
+	if err != nil || cached.Items[0].Credential.Account.Email != "first@example.com" {
+		t.Fatalf("cached read = %#v, %v", cached, err)
+	}
+	now = now.Add(time.Minute)
+	refreshed, err := fixture.service.ReadHomeSubscriptionAccounts(t.Context())
+	if err != nil || refreshed.Items[0].Credential.Account.Email != "second@example.com" {
+		t.Fatalf("refreshed read = %#v, %v", refreshed, err)
+	}
+}
+
+func TestReadHomeSubscriptionAccountsLimitsTheHomepageToFourCards(t *testing.T) {
+	t.Parallel()
+	fixture := newServiceFixture(t)
+	now := time.Date(2026, time.August, 31, 12, 30, 0, 0, time.UTC)
+	fixture.service.now = func() time.Time { return now }
+	bucket := now.Truncate(time.Hour).UnixMilli()
+	for index := 0; index < 5; index++ {
+		_, credential := createHomeSubscriptionCredential(
+			t,
+			fixture,
+			fmt.Sprintf("limit-%d", index),
+			fmt.Sprintf("limit-account-%d", index),
+			fmt.Sprintf("limit-%d@example.com", index),
+		)
+		if err := fixture.db.Create(&models.CredentialAttemptStat{
+			CredentialID: credential.ID, BucketStartMS: bucket, SuccessCount: int64(10 - index),
+		}).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := fixture.service.ReadHomeSubscriptionAccounts(t.Context())
+	if err != nil || len(result.Items) != 4 {
+		t.Fatalf("ReadHomeSubscriptionAccounts() = %#v, %v", result, err)
+	}
+	for index, item := range result.Items {
+		want := fmt.Sprintf("limit-%d@example.com", index)
+		if item.Credential.Account.Email != want {
+			t.Fatalf("item %d email = %q, want %q", index, item.Credential.Account.Email, want)
+		}
+	}
+}
+
+func TestHomeSubscriptionAccountsRouteIsAdminOnly(t *testing.T) {
+	t.Parallel()
+	initControlI18n(t)
+	fixture := newServiceFixture(t)
+	accessKey, err := fixture.service.CreateAccessKey(t.Context(), AccessKeyCreateRequest{Name: "home readonly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	engine := gin.New()
+	NewServer(&config.Config{AuthKey: authTestKey}, fixture.service).RegisterRoutes(engine)
+
+	admin := performHomeRequest(engine, "/api/home/subscription-accounts", authTestKey)
+	if admin.Code != http.StatusOK {
+		t.Fatalf("admin response = %d %s", admin.Code, admin.Body.String())
+	}
+	unknownQuery := performHomeRequest(
+		engine,
+		"/api/home/subscription-accounts?unknown=1",
+		authTestKey,
+	)
+	if unknownQuery.Code != http.StatusBadRequest {
+		t.Fatalf("unknown query response = %d %s", unknownQuery.Code, unknownQuery.Body.String())
+	}
+	access := performHomeRequest(engine, "/api/home/subscription-accounts", accessKey.Key)
+	if access.Code != http.StatusForbidden {
+		t.Fatalf("AccessKey response = %d %s, want 403", access.Code, access.Body.String())
+	}
+}
+
+func TestHomeSubscriptionActivityScopeUsesOnlyHourlyAccountAggregatesAndQuotesGroups(t *testing.T) {
+	t.Parallel()
+	db, err := gorm.Open(gormmysql.New(gormmysql.Config{
+		DSN:                       "user:password@tcp(127.0.0.1:3306)/gpt_load",
+		SkipInitializeWithVersion: true,
+	}), &gorm.Config{
+		DryRun:                 true,
+		DisableAutomaticPing:   true,
+		SkipDefaultTransaction: true,
+		Logger:                 logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("gorm.Open() error = %v", err)
+	}
+
+	result := homeSubscriptionActivityScope(db, 1, 2).Find(&[]homeSubscriptionActivityRow{})
+	if result.Error != nil {
+		t.Fatalf("home subscription activity query error = %v", result.Error)
+	}
+	sql := result.Statement.SQL.String()
+	if strings.Contains(sql, "JOIN groups") || !strings.Contains(sql, "FROM `groups`") {
+		t.Fatalf("generated SQL = %q, want a quoted groups subquery", sql)
+	}
+	if !strings.Contains(sql, "credential_attempt_stats") || strings.Contains(sql, "request_log") {
+		t.Fatalf("generated SQL = %q, want hourly account aggregates only", sql)
+	}
+}
+
+func createHomeSubscriptionCredential(
+	t *testing.T,
+	fixture serviceFixture,
+	groupSuffix string,
+	accountID string,
+	email string,
+) (uint, models.Credential) {
+	t.Helper()
+	stage := mustImportSubscriptionStage(t, fixture, accountID, email)
+	name := fmt.Sprintf("home-subscription-%s", groupSuffix)
+	created, err := fixture.service.CreateGroup(t.Context(), GroupCreateRequest{
+		Name: stringPointer(name), ChannelID: channel.Codex,
+		ConnectionType:      models.ConnectionTypeSubscription,
+		Models:              optionalGroupModels{Set: true, Values: []GroupModel{{ID: "gpt-5.3-codex"}}},
+		StagedCredentialIDs: []string{stage.StageID},
+		ConfirmSameTarget:   true,
+	})
+	if err != nil {
+		t.Fatalf("create subscription group %q: %v", name, err)
+	}
+	var credential models.Credential
+	if err := fixture.db.Where("group_id = ?", created.GroupID).Take(&credential).Error; err != nil {
+		t.Fatalf("query subscription credential: %v", err)
+	}
+	return created.GroupID, credential
+}
+
+func createHomeCredentialObservation(
+	t *testing.T,
+	fixture serviceFixture,
+	credential models.Credential,
+	observedAt time.Time,
+	plan string,
+) {
+	t.Helper()
+	remaining := 0.75
+	resetAtMS := observedAt.Add(5 * time.Hour).UnixMilli()
+	snapshot, err := json.Marshal(CredentialObservationSnapshot{
+		Plan: ObservationPlanSummary{Name: plan, Level: "premium"},
+		QuotaWindows: []ObservationQuotaWindow{{
+			ID: "five-hour", Label: "5h", Scope: "account", Unit: "ratio",
+			Remaining: &remaining, ResetAtMS: &resetAtMS, State: "available",
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	observedAtMS := observedAt.UnixMilli()
+	row := models.CredentialObservation{
+		CredentialID: credential.ID, IdentityFingerprint: credential.IdentityFingerprint,
+		SchemaVersion: 1, ObservationVersion: 1, SnapshotJSON: snapshot,
+		State: models.CredentialObservationFresh, ObservedAtMS: &observedAtMS,
+		LastAttemptAtMS: &observedAtMS, UpdatedAtMS: observedAtMS,
+	}
+	if err := fixture.db.Create(&row).Error; err != nil {
+		t.Fatalf("create credential observation: %v", err)
+	}
+}

--- a/internal/control/http_routes.go
+++ b/internal/control/http_routes.go
@@ -139,6 +139,12 @@ func (s *Server) HTTPModule() httproute.Module {
 			),
 			controlRoute("control.home", http.MethodGet, "/home", s.handleHome),
 			controlRoute(
+				"control.home.subscription-accounts",
+				http.MethodGet,
+				"/home/subscription-accounts",
+				s.handleHomeSubscriptionAccounts,
+			),
+			controlRoute(
 				"control.home.statistics",
 				http.MethodGet,
 				"/home/statistics",

--- a/internal/control/server_test.go
+++ b/internal/control/server_test.go
@@ -49,6 +49,10 @@ func TestServerHomeAndSystemUpdateRoutesUseExactManagementContracts(t *testing.T
 			method: http.MethodGet,
 			path:   "/home/statistics",
 		},
+		"control.home.subscription-accounts": {
+			method: http.MethodGet,
+			path:   "/home/subscription-accounts",
+		},
 		"control.system.update": {
 			method: http.MethodGet,
 			path:   "/system/update",

--- a/internal/control/service.go
+++ b/internal/control/service.go
@@ -88,6 +88,8 @@ type Service struct {
 	observationMu         sync.Mutex
 	observationFlights    map[observationFlightKey]*observationFlight
 	observationSemaphore  chan struct{}
+	homeSubscriptionMu    sync.Mutex
+	homeSubscriptionCache *homeSubscriptionAccountsCache
 }
 
 type credentialRuntimeRetirer interface {

--- a/web/src/app/query-keys.ts
+++ b/web/src/app/query-keys.ts
@@ -107,6 +107,7 @@ export const controlQueryKeys = {
   home: {
     all: ['control', 'home'] as const,
     base: () => ['control', 'home', 'base'] as const,
+    subscriptionAccounts: () => ['control', 'home', 'subscription-accounts'] as const,
     statisticsAll: () => ['control', 'home', 'statistics'] as const,
     statistics: (range: HomeRange) => ['control', 'home', 'statistics', range] as const,
   },

--- a/web/src/app/resources/home.ts
+++ b/web/src/app/resources/home.ts
@@ -2,12 +2,18 @@ import { queryOptions } from '@tanstack/vue-query'
 import { computed, toValue, type MaybeRefOrGetter } from 'vue'
 
 import type { ApiClient } from '@/api/client'
-import type { AccessKeyCollectionItemDto, AccessProtocol } from '@/api/control/types'
+import type {
+  AccessKeyCollectionItemDto,
+  AccessProtocol,
+  CredentialItemDto,
+} from '@/api/control/types'
 import { knownAccessProtocols } from '@/api/control/protocols'
 import { InvalidResponseError } from '@/api/errors'
 import { controlQueryKeys } from '@/app/query-keys'
 
 import { projectAccessKeyCollectionItem } from './access-keys'
+import type { ChannelCapabilitiesDto } from './channels'
+import { projectCredentialItem } from './credentials'
 
 import {
   assertNoSecretLikeFields,
@@ -109,6 +115,21 @@ export interface HomeStatisticsDto {
   rankings: HomeRankings
 }
 
+export interface HomeSubscriptionAccountDto {
+  channel_id: string
+  channel_mark: string
+  channel_icon: string
+  capabilities: ChannelCapabilitiesDto
+  group_count: number
+  available_group_count: number
+  credential: CredentialItemDto
+}
+
+export interface HomeSubscriptionAccountsDto {
+  observed_at_ms: number
+  items: HomeSubscriptionAccountDto[]
+}
+
 const homeBaseFields = [
   'server_now_ms',
   'started_at_ms',
@@ -160,6 +181,22 @@ const rankingMetricFields = ['request_count', 'total_tokens', 'estimated_cost_na
 const modelRankingFields = ['model', ...rankingMetricFields] as const
 const groupRankingFields = ['group', ...rankingMetricFields] as const
 const accessKeyRankingFields = ['access_key', ...rankingMetricFields] as const
+const subscriptionAccountsFields = ['observed_at_ms', 'items'] as const
+const subscriptionAccountFields = [
+  'channel_id',
+  'channel_mark',
+  'channel_icon',
+  'capabilities',
+  'group_count',
+  'available_group_count',
+  'credential',
+] as const
+const subscriptionCapabilitiesFields = [
+  'model_discovery',
+  'quota_observation',
+  'credential_actions',
+  'outbound_proxy',
+] as const
 const hourMilliseconds = 3_600_000
 const dayMilliseconds = 86_400_000
 const rankingLimit = 5
@@ -228,6 +265,57 @@ export function projectHomeBase(value: unknown): HomeBaseDto {
       record.current_access_key === null
         ? null
         : projectAccessKeyCollectionItem(record.current_access_key),
+  }
+}
+
+function projectHomeSubscriptionCapabilities(value: unknown): ChannelCapabilitiesDto {
+  const record = projectRecord(value)
+  assertNoSecretLikeFields(record, subscriptionCapabilitiesFields)
+  const actions = projectArray(record.credential_actions, (action) =>
+    projectEnum(action, ['reset_credit'] as const),
+  )
+  if (new Set(actions).size !== actions.length) invalidResponse()
+  return {
+    model_discovery: projectBoolean(record.model_discovery),
+    quota_observation: projectBoolean(record.quota_observation),
+    credential_actions: actions,
+    outbound_proxy: projectBoolean(record.outbound_proxy),
+  }
+}
+
+function projectHomeSubscriptionAccount(value: unknown): HomeSubscriptionAccountDto {
+  const record = projectRecord(value)
+  assertNoSecretLikeFields(record, subscriptionAccountFields)
+  const groupCount = projectSafeInteger(record.group_count, { minimum: 1 })
+  const availableGroupCount = projectSafeInteger(record.available_group_count, { minimum: 0 })
+  const credential = projectCredentialItem(record.credential)
+  if (availableGroupCount > groupCount || credential.connection_type !== 'subscription') {
+    invalidResponse()
+  }
+  return {
+    channel_id: projectNonBlankTrimmedString(record.channel_id),
+    channel_mark: projectNonBlankTrimmedString(record.channel_mark),
+    channel_icon: projectNonBlankTrimmedString(record.channel_icon),
+    capabilities: projectHomeSubscriptionCapabilities(record.capabilities),
+    group_count: groupCount,
+    available_group_count: availableGroupCount,
+    credential,
+  }
+}
+
+export function projectHomeSubscriptionAccounts(value: unknown): HomeSubscriptionAccountsDto {
+  const record = projectRecord(value)
+  assertNoSecretLikeFields(record, subscriptionAccountsFields)
+  const items = projectArray(record.items, projectHomeSubscriptionAccount)
+  if (
+    items.length > 4 ||
+    new Set(items.map((item) => item.credential.credential_id)).size !== items.length
+  ) {
+    invalidResponse()
+  }
+  return {
+    observed_at_ms: projectEpochMilliseconds(record.observed_at_ms),
+    items,
   }
 }
 
@@ -549,11 +637,33 @@ export async function getHomeStatistics(
   )
 }
 
+export async function getHomeSubscriptionAccounts(
+  client: ApiClient,
+  signal?: AbortSignal,
+): Promise<HomeSubscriptionAccountsDto> {
+  return projectHomeSubscriptionAccounts(
+    await client.request('/api/home/subscription-accounts', { method: 'GET', signal }),
+  )
+}
+
 export function homeBaseQueryOptions(client: ApiClient) {
   return queryOptions({
     queryKey: controlQueryKeys.home.base(),
     queryFn: ({ signal }) => getHomeBase(client, signal),
     staleTime: Number.POSITIVE_INFINITY,
+    refetchOnMount: 'always',
+  })
+}
+
+export function homeSubscriptionAccountsQueryOptions(
+  client: ApiClient,
+  enabled: MaybeRefOrGetter<boolean>,
+) {
+  return queryOptions({
+    queryKey: controlQueryKeys.home.subscriptionAccounts(),
+    queryFn: ({ signal }) => getHomeSubscriptionAccounts(client, signal),
+    enabled: computed(() => toValue(enabled)),
+    staleTime: 60_000,
     refetchOnMount: 'always',
   })
 }

--- a/web/src/app/router.ts
+++ b/web/src/app/router.ts
@@ -29,7 +29,7 @@ const routes: RouteRecordRaw[] = [
       titleKey: 'home.ledger.title',
       requiresAuth: true,
       primaryNav: 'home',
-      messageNamespaces: ['access-keys'],
+      messageNamespaces: ['access-keys', 'group'],
     },
   }),
   pageRoute(pageRouteNames.login, {

--- a/web/src/features/groups/credentials/SubscriptionAccountCard.vue
+++ b/web/src/features/groups/credentials/SubscriptionAccountCard.vue
@@ -37,20 +37,32 @@ import { quotaProgressTone } from '@/lib/quota-progress'
 
 import { presentCredentialFailureCategory } from './credential-failure-presenter'
 
-const props = defineProps<{
-  item: CredentialItemDto
-  selected: boolean
-  busy: boolean
-  refreshingObservation: boolean
-  observationError: string
-  detailBusy: boolean
-  detailLoaded: boolean
-  detailError: string
-  channelIcon?: string
-  channelMark?: string
-  capabilities: ChannelCapabilitiesDto
-  saveProxy: (value: ProxyMutation) => Promise<void>
-}>()
+const props = withDefaults(
+  defineProps<{
+    item: CredentialItemDto
+    selected: boolean
+    busy: boolean
+    refreshingObservation: boolean
+    observationError: string
+    detailBusy: boolean
+    detailLoaded: boolean
+    detailError: string
+    channelIcon?: string
+    channelMark?: string
+    capabilities: ChannelCapabilitiesDto
+    saveProxy: (value: ProxyMutation) => Promise<void>
+    readonly?: boolean
+    groupCount?: number
+    availableGroupCount?: number
+  }>(),
+  {
+    channelIcon: undefined,
+    channelMark: undefined,
+    readonly: false,
+    groupCount: 1,
+    availableGroupCount: 1,
+  },
+)
 const emit = defineEmits<{
   'update:selected': [selected: boolean]
   toggle: [item: CredentialItemDto]
@@ -87,7 +99,7 @@ watch(
       props.busy,
     ] as const,
   ([expanded, loaded, detailBusy, error, busy]) => {
-    if (expanded && !loaded && !detailBusy && !error && !busy) {
+    if (!props.readonly && expanded && !loaded && !detailBusy && !error && !busy) {
       emit('load-details', props.item)
     }
   },
@@ -370,7 +382,17 @@ const unifiedStatus = computed<UnifiedStatus>(() => {
   }
   return 'available'
 })
+const showAggregateAvailability = computed(
+  () =>
+    props.readonly &&
+    props.groupCount > 1 &&
+    (props.availableGroupCount < props.groupCount || unifiedStatus.value === 'available'),
+)
 const statusTone = computed<'success' | 'warning' | 'danger' | 'neutral'>(() => {
+  if (showAggregateAvailability.value) {
+    if (props.availableGroupCount === props.groupCount) return 'success'
+    return props.availableGroupCount > 0 ? 'warning' : 'danger'
+  }
   const tones: Record<UnifiedStatus, 'success' | 'warning' | 'danger' | 'neutral'> = {
     available: 'success',
     quota_exhausted: 'warning',
@@ -383,6 +405,20 @@ const statusTone = computed<'success' | 'warning' | 'danger' | 'neutral'>(() => 
   }
   return tones[unifiedStatus.value]
 })
+const statusLabel = computed(() =>
+  showAggregateAvailability.value
+    ? t('home.ledger.subscriptionAccounts.availableGroups', {
+        available: n(props.availableGroupCount),
+        total: n(props.groupCount),
+      })
+    : t(`group.credentials.subscription.status.${unifiedStatus.value}`),
+)
+const groupCountLabel = computed(() =>
+  t('home.ledger.subscriptionAccounts.groupCount', { count: n(props.groupCount) }),
+)
+const displayDisabled = computed(
+  () => !showAggregateAvailability.value && unifiedStatus.value === 'disabled',
+)
 const authErrorKeys: Readonly<Record<string, string>> = {
   refresh_rejected: 'group.credentials.subscription.authError.refreshRejected',
   refresh_identity_changed: 'group.credentials.subscription.authError.identityChanged',
@@ -521,7 +557,7 @@ function quotaFillStyle(window: CredentialQuotaWindowDto): Record<string, string
 }
 
 function toggleDetails(): void {
-  if (props.detailBusy) return
+  if (props.readonly || props.detailBusy) return
   detailsExpanded.value = !detailsExpanded.value
 }
 
@@ -558,8 +594,9 @@ function runMenuAction(
     :class="[
       `subscription-account--${statusTone}`,
       {
-        'subscription-account--disabled': unifiedStatus === 'disabled',
+        'subscription-account--disabled': displayDisabled,
         'subscription-account--refreshing': refreshingObservation,
+        'subscription-account--readonly': readonly,
       },
     ]"
     :aria-busy="refreshingObservation ? 'true' : undefined"
@@ -662,7 +699,7 @@ function runMenuAction(
     <div class="subscription-account__main">
       <header class="subscription-account__top">
         <div class="subscription-account__top-row">
-          <label class="subscription-account__select">
+          <label v-if="!readonly" class="subscription-account__select">
             <span class="sr-only">{{
               t('group.credentials.subscription.selectAccount', { account: accountName })
             }}</span>
@@ -693,14 +730,23 @@ function runMenuAction(
             <StatusBadge
               class="subscription-account__status"
               :tone="statusTone"
-              :icon="unifiedStatus === 'disabled' ? 'off' : undefined"
+              :icon="displayDisabled ? 'off' : undefined"
               size="compact"
             >
-              {{ t(`group.credentials.subscription.status.${unifiedStatus}`) }}
+              {{ statusLabel }}
             </StatusBadge>
-            <ProxyScopeIndicator v-if="capabilities.outbound_proxy" :view="item.proxy" />
+            <span v-if="readonly" class="subscription-account__group-count">
+              {{ groupCountLabel }}
+            </span>
+            <ProxyScopeIndicator
+              v-if="!readonly && capabilities.outbound_proxy"
+              :view="item.proxy"
+            />
           </div>
-          <div class="subscription-account__actions">
+          <div
+            v-if="!readonly || (supportsQuotaObservation && observation?.observed_at_ms != null)"
+            class="subscription-account__actions"
+          >
             <span
               v-if="supportsQuotaObservation && observation?.observed_at_ms != null"
               class="subscription-account__sync-age"
@@ -714,7 +760,7 @@ function runMenuAction(
               />
             </span>
             <AppTooltip
-              v-if="supportsQuotaObservation"
+              v-if="supportsQuotaObservation && !readonly"
               :content="t('group.credentials.subscription.sync')"
             >
               <IconButton
@@ -734,6 +780,7 @@ function runMenuAction(
               </IconButton>
             </AppTooltip>
             <AppPopover
+              v-if="!readonly"
               v-model:open="menuOpen"
               align="end"
               content-class="app-popover__content--account-menu"
@@ -922,8 +969,11 @@ function runMenuAction(
             hint
           />
         </span>
-        <span class="subscription-account__spacer"></span>
-        <AppTooltip :content="t('group.credentials.subscription.resetCreditsActionTooltip')">
+        <span v-if="!readonly" class="subscription-account__spacer"></span>
+        <AppTooltip
+          v-if="!readonly"
+          :content="t('group.credentials.subscription.resetCreditsActionTooltip')"
+        >
           <AppButton
             class="subscription-account__credits-action"
             variant="ghost"
@@ -937,7 +987,7 @@ function runMenuAction(
         </AppTooltip>
       </div>
 
-      <div class="subscription-account__detail-control">
+      <div v-if="!readonly" class="subscription-account__detail-control">
         <AppTooltip
           :content="
             t(
@@ -993,7 +1043,7 @@ function runMenuAction(
     </div>
 
     <section
-      v-if="detailsExpanded"
+      v-if="!readonly && detailsExpanded"
       :id="`credential-detail-${item.credential_id}`"
       class="subscription-account__detail"
       aria-live="polite"
@@ -1343,6 +1393,9 @@ function runMenuAction(
   gap: var(--space-3);
   padding: var(--space-3) var(--space-4) 0;
 }
+.subscription-account--readonly .subscription-account__main {
+  padding-bottom: var(--space-3);
+}
 .subscription-account__top {
   display: grid;
   gap: var(--space-2);
@@ -1460,6 +1513,16 @@ function runMenuAction(
 }
 .subscription-account__status {
   flex: none;
+  white-space: nowrap;
+}
+.subscription-account__group-count {
+  flex: none;
+  border-radius: var(--radius-tag);
+  background: var(--color-surface-sunken);
+  padding: 3px 7px;
+  color: var(--color-text-muted);
+  font-size: var(--text-label-xs);
+  line-height: 1;
   white-space: nowrap;
 }
 .subscription-account__actions {

--- a/web/src/features/home/HomeSubscriptionAccounts.vue
+++ b/web/src/features/home/HomeSubscriptionAccounts.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+import type { HomeSubscriptionAccountsDto } from '@/app/resources/home'
+import SubscriptionAccountCard from '@/features/groups/credentials/SubscriptionAccountCard.vue'
+
+import HomeSectionHeading from './HomeSectionHeading.vue'
+
+defineProps<{ accounts: HomeSubscriptionAccountsDto }>()
+
+const { t } = useI18n()
+
+function ignoreReadonlyProxyMutation(): Promise<void> {
+  return Promise.resolve()
+}
+</script>
+
+<template>
+  <section
+    v-if="accounts.items.length > 0"
+    class="home-subscription-accounts"
+    aria-labelledby="home-subscription-accounts-title"
+  >
+    <HomeSectionHeading
+      id="home-subscription-accounts-title"
+      :title="t('home.ledger.subscriptionAccounts.title')"
+    />
+    <div class="home-subscription-accounts__grid">
+      <SubscriptionAccountCard
+        v-for="account in accounts.items"
+        :key="`${account.channel_id}-${account.credential.credential_id}`"
+        :item="account.credential"
+        :selected="false"
+        :busy="false"
+        :refreshing-observation="false"
+        observation-error=""
+        :detail-busy="false"
+        :detail-loaded="false"
+        detail-error=""
+        :channel-icon="account.channel_icon"
+        :channel-mark="account.channel_mark"
+        :capabilities="account.capabilities"
+        :save-proxy="ignoreReadonlyProxyMutation"
+        :group-count="account.group_count"
+        :available-group-count="account.available_group_count"
+        readonly
+      />
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.home-subscription-accounts {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.home-subscription-accounts__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(420px, 1fr));
+  align-items: start;
+  gap: var(--space-3);
+}
+
+@media (max-width: 680px) {
+  .home-subscription-accounts__grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+</style>

--- a/web/src/features/home/HomeView.vue
+++ b/web/src/features/home/HomeView.vue
@@ -7,7 +7,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { useApiClient } from '@/api/client-context'
 import { useStableLoading } from '@/app/loading-state'
 import { healthQueryOptions } from '@/app/resources/health'
-import { homeBaseQueryOptions } from '@/app/resources/home'
+import { homeBaseQueryOptions, homeSubscriptionAccountsQueryOptions } from '@/app/resources/home'
 import { systemUpdateQueryOptions } from '@/app/resources/system-update'
 import { homeLocation } from '@/app/route-locations'
 import LedgerSheet from '@/components/layout/LedgerSheet.vue'
@@ -21,6 +21,7 @@ import CurrentAccessKeyCard from './CurrentAccessKeyCard.vue'
 import GatewayConnection from './GatewayConnection.vue'
 import HomeAttention from './HomeAttention.vue'
 import HomeSpend from './HomeSpend.vue'
+import HomeSubscriptionAccounts from './HomeSubscriptionAccounts.vue'
 import HomeSummary from './HomeSummary.vue'
 import HomeWelcome from './HomeWelcome.vue'
 import { useHomeStatisticsPresenter } from './home-presenter'
@@ -38,7 +39,11 @@ const route = useRoute()
 const router = useRouter()
 const { t } = useI18n()
 const isAccessKey = computed(() => session.state.principalType === 'access_key')
+const isAdmin = computed(() => session.state.principalType === 'admin')
 const baseQuery = useQuery(homeBaseQueryOptions(client))
+// 订阅账号包含完整管理身份和额度，只允许管理员发起查询；模板仍二次 gate，
+// 防止会话切换时短暂复用旧 Query 缓存。
+const subscriptionAccountsQuery = useQuery(homeSubscriptionAccountsQueryOptions(client, isAdmin))
 // 更新检查与首页数据解耦，仅由管理员进入首页时按需触发一次。
 const updateQuery = useQuery(
   systemUpdateQueryOptions(client, () => session.state.principalType === 'admin'),
@@ -188,6 +193,11 @@ onBeforeUnmount(() => window.clearInterval(uptimeTimer))
 
         <!-- 紧贴事实行：它是那句「X/Y 个凭据可用」的注解，隔开就变成孤立的红条。 -->
         <HomeAttention v-if="!isAccessKey" :health="healthQuery.data.value ?? null" />
+
+        <HomeSubscriptionAccounts
+          v-if="isAdmin && subscriptionAccountsQuery.data.value?.items.length"
+          :accounts="subscriptionAccountsQuery.data.value"
+        />
 
         <CurrentAccessKeyCard
           v-if="baseQuery.data.value.current_access_key"

--- a/web/src/i18n/locales/en-US/core.ts
+++ b/web/src/i18n/locales/en-US/core.ts
@@ -289,6 +289,11 @@ export default {
         summary: '{count} items need your attention',
         action: 'Resolve',
       },
+      subscriptionAccounts: {
+        title: 'Recently used subscription accounts',
+        groupCount: '{count} Groups',
+        availableGroups: '{available}/{total} available',
+      },
       spend: {
         title: 'Estimated over 30 days',
         viewDetail: 'View details →',

--- a/web/src/i18n/locales/en-US/core.ts
+++ b/web/src/i18n/locales/en-US/core.ts
@@ -291,7 +291,7 @@ export default {
       },
       subscriptionAccounts: {
         title: 'Recently used subscription accounts',
-        groupCount: '{count} Groups',
+        groupCount: 'Groups: {count}',
         availableGroups: '{available}/{total} available',
       },
       spend: {

--- a/web/src/i18n/locales/ja-JP/core.ts
+++ b/web/src/i18n/locales/ja-JP/core.ts
@@ -287,6 +287,11 @@ export default {
         summary: '{count} 件の対応が必要です',
         action: '対応',
       },
+      subscriptionAccounts: {
+        title: '最近使用したサブスクリプションアカウント',
+        groupCount: '{count} グループ',
+        availableGroups: '{available}/{total} 利用可能',
+      },
       spend: {
         title: '直近 30 日間の概算',
         viewDetail: '詳細を見る →',

--- a/web/src/i18n/locales/zh-CN/core.ts
+++ b/web/src/i18n/locales/zh-CN/core.ts
@@ -274,6 +274,11 @@ export default {
         summary: '共有 {count} 项需要你处理',
         action: '处理',
       },
+      subscriptionAccounts: {
+        title: '最近常用订阅账号',
+        groupCount: '{count} 个分组',
+        availableGroups: '{available}/{total} 可用',
+      },
       spend: {
         title: '近 30 天估算',
         viewDetail: '查看明细 →',


### PR DESCRIPTION
### 关联 Issue / Related Issue
无 / None

### 变更内容 / Change Content
- [ ] Bug 修复 / Bug fix
- [x] 新功能 / New feature
- [ ] 其他改动 / Other changes

- 新增管理员首页活跃订阅账号接口，基于 credential_attempt_stats 最近 24 小时成功记录排序，跨分组按账号身份去重并限制最多 4 张卡片
- 使用一分钟进程缓存并批量读取持久化额度快照；不查询请求日志、不新增聚合表或数据库迁移，也不触发上游同步
- 首页复用现有订阅账号卡片的只读变体，保留主要信息与排版，隐藏多选、刷新、菜单、重置和展开详情；查询结果为空时不渲染板块
- AccessKey 登录前端不查询、不渲染，后端接口拒绝访问

### 自查清单 / Checklist
- [x] 我已运行 make check，或在说明中写明无法运行的原因和未验证范围。 / I ran make check, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.

验证：make check 已通过。

兼容性：新增只读管理接口，无数据库迁移；现有分组页订阅账号卡片交互保持不变。本次不需要公开文档或发布说明。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 首页新增“最近常用订阅账号”区域，仅管理员可查看。
  - 展示账号图标、能力、关联分组数量及可用状态，最多显示四个账号。
  - 账号卡片采用只读模式，不影响现有订阅账号管理操作。
- **体验优化**
  - 支持响应式布局，并新增中文、英文和日文界面文案。
  - 数据短暂缓存，减少重复加载并提升首页访问速度。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->