### PR TITLE
fix(home): 实时刷新常用订阅账号

### DIFF
--- a/internal/control/home_subscription_accounts.go
+++ b/internal/control/home_subscription_accounts.go
@@ -17,9 +17,8 @@ import (
 )
 
 const (
-	homeSubscriptionAccountLimit    = 4
-	homeSubscriptionAccountWindow   = 24 * time.Hour
-	homeSubscriptionAccountCacheTTL = time.Minute
+	homeSubscriptionAccountLimit  = 4
+	homeSubscriptionAccountWindow = 24 * time.Hour
 )
 
 type HomeSubscriptionAccountsResponse struct {
@@ -35,11 +34,6 @@ type HomeSubscriptionAccountResponse struct {
 	GroupCount          int                          `json:"group_count"`
 	AvailableGroupCount int                          `json:"available_group_count"`
 	Credential          CredentialItemResponse       `json:"credential"`
-}
-
-type homeSubscriptionAccountsCache struct {
-	expiresAt time.Time
-	response  HomeSubscriptionAccountsResponse
 }
 
 type homeSubscriptionActivityRow struct {
@@ -75,25 +69,7 @@ func (s *Service) ReadHomeSubscriptionAccounts(
 	if err := ctx.Err(); err != nil {
 		return HomeSubscriptionAccountsResponse{}, err
 	}
-	s.homeSubscriptionMu.Lock()
-	defer s.homeSubscriptionMu.Unlock()
-	if err := ctx.Err(); err != nil {
-		return HomeSubscriptionAccountsResponse{}, err
-	}
-	now := s.now().UTC()
-	if cached := s.homeSubscriptionCache; cached != nil && now.Before(cached.expiresAt) {
-		return cloneHomeSubscriptionAccountsResponse(cached.response), nil
-	}
-
-	response, err := s.readHomeSubscriptionAccounts(ctx, now)
-	if err != nil {
-		return HomeSubscriptionAccountsResponse{}, err
-	}
-	s.homeSubscriptionCache = &homeSubscriptionAccountsCache{
-		expiresAt: now.Add(homeSubscriptionAccountCacheTTL),
-		response:  cloneHomeSubscriptionAccountsResponse(response),
-	}
-	return response, nil
+	return s.readHomeSubscriptionAccounts(ctx, s.now().UTC())
 }
 
 func (s *Server) handleHomeSubscriptionAccounts(c *gin.Context) {
@@ -366,11 +342,4 @@ func homeSubscriptionRepresentativeLess(
 
 func homeSubscriptionIdentityKey(channelID, identityFingerprint string) string {
 	return channelID + "\x00" + identityFingerprint
-}
-
-func cloneHomeSubscriptionAccountsResponse(
-	value HomeSubscriptionAccountsResponse,
-) HomeSubscriptionAccountsResponse {
-	value.Items = append([]HomeSubscriptionAccountResponse(nil), value.Items...)
-	return value
 }

--- a/internal/control/home_subscription_accounts_test.go
+++ b/internal/control/home_subscription_accounts_test.go
@@ -99,7 +99,7 @@ func TestReadHomeSubscriptionAccountsUsesBoundedHourlyActivityAndDeduplicates(t 
 	}
 }
 
-func TestReadHomeSubscriptionAccountsCachesRankingForOneMinute(t *testing.T) {
+func TestReadHomeSubscriptionAccountsReflectsLatestRankingOnEveryRead(t *testing.T) {
 	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := time.Date(2026, time.August, 31, 12, 30, 0, 0, time.UTC)
@@ -124,14 +124,9 @@ func TestReadHomeSubscriptionAccountsCachesRankingForOneMinute(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cached, err := fixture.service.ReadHomeSubscriptionAccounts(t.Context())
-	if err != nil || cached.Items[0].Credential.Account.Email != "first@example.com" {
-		t.Fatalf("cached read = %#v, %v", cached, err)
-	}
-	now = now.Add(time.Minute)
-	refreshed, err := fixture.service.ReadHomeSubscriptionAccounts(t.Context())
-	if err != nil || refreshed.Items[0].Credential.Account.Email != "second@example.com" {
-		t.Fatalf("refreshed read = %#v, %v", refreshed, err)
+	latest, err := fixture.service.ReadHomeSubscriptionAccounts(t.Context())
+	if err != nil || latest.Items[0].Credential.Account.Email != "second@example.com" {
+		t.Fatalf("latest read = %#v, %v", latest, err)
 	}
 }
 

--- a/internal/control/service.go
+++ b/internal/control/service.go
@@ -88,8 +88,6 @@ type Service struct {
 	observationMu         sync.Mutex
 	observationFlights    map[observationFlightKey]*observationFlight
 	observationSemaphore  chan struct{}
-	homeSubscriptionMu    sync.Mutex
-	homeSubscriptionCache *homeSubscriptionAccountsCache
 }
 
 type credentialRuntimeRetirer interface {

--- a/web/src/app/resources/home.ts
+++ b/web/src/app/resources/home.ts
@@ -663,7 +663,6 @@ export function homeSubscriptionAccountsQueryOptions(
     queryKey: controlQueryKeys.home.subscriptionAccounts(),
     queryFn: ({ signal }) => getHomeSubscriptionAccounts(client, signal),
     enabled: computed(() => toValue(enabled)),
-    staleTime: 60_000,
     refetchOnMount: 'always',
   })
 }

--- a/web/src/features/home/HomeSubscriptionAccounts.vue
+++ b/web/src/features/home/HomeSubscriptionAccounts.vue
@@ -53,6 +53,9 @@ function ignoreReadonlyProxyMutation(): Promise<void> {
 .home-subscription-accounts {
   display: grid;
   gap: var(--space-3);
+  margin-top: 36px;
+  border-top: 1px solid var(--color-border-subtle);
+  padding-top: 20px;
 }
 
 .home-subscription-accounts__grid {


### PR DESCRIPTION
### 关联 Issue / Related Issue
无 / None

### 变更内容 / Change Content
- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

- 移除最近常用订阅账号接口的一分钟进程缓存、专用锁和响应复制代码，每次请求直接读取当前小时聚合数据
- 移除该前端查询的一分钟 staleTime，保留进入首页时主动请求
- 查询继续只使用 credential_attempt_stats，不扫描请求日志
- 为最近常用订阅账号板块补齐与连接到网关、近 30 天估算一致的顶部细线和垂直间距
- 更新回归测试，验证连续读取能够立即反映最新活跃排序

### 自查清单 / Checklist
- [x] 我已运行 make check，或在说明中写明无法运行的原因和未验证范围。 / I ran make check, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.

验证：make check 已通过。

兼容性：API 响应结构不变，无数据库迁移；本地 UI Mock 数据不包含在 PR 中。本次不需要公开文档或发布说明。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 首页订阅账户数据现在每次读取都会反映最新排名，减少过期信息。
  - 优化订阅账户区域的视觉层次，新增顶部间距与分隔线。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->