### PR TITLE
chore(ci): 移除 Dependabot target-branch 并更正版权年份

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,15 @@
 # 仓库已对所有 action 强制 SHA pin，上游补丁不会自动到达；由 Dependabot 提 PR
 # 更新 SHA 并同步刷新其后的版本注释，保持"可审计"与"能更新"同时成立。
 #
-# 生效前提是 GitHub 的两条硬限制，二者都只能靠切换默认分支根治：
-#   1. Dependabot 只从默认分支读取本文件。本文件位于 v2 而默认分支为 main 时，
-#      下面的 version update 规则不生效。
-#   2. security update 永远只针对默认分支，且一旦声明 target-branch，本文件对该
-#      ecosystem 的配置就不再作用于 security update。即只要默认分支还是 main，
-#      v2 的依赖漏洞就拿不到 Dependabot 的安全更新 PR，需要人工跟进。
-#      https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
+# 不要声明 target-branch。Dependabot 默认就针对默认分支（当前为 v2），而一旦声明
+# target-branch，本文件对该 ecosystem 的配置就不再作用于 security update，
+# groups、labels 与 commit-message 会对安全更新 PR 全部失效。
+# https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
 version: 2
 
 updates:
   - package-ecosystem: github-actions
     directory: /
-    target-branch: v2
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -32,7 +28,6 @@ updates:
 
   - package-ecosystem: gomod
     directory: /
-    target-branch: v2
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -53,7 +48,6 @@ updates:
   # 需显式声明；它经 replace 编译进主二进制，其依赖属于实际攻击面。
   - package-ecosystem: gomod
     directory: /third_party/cpaembedded
-    target-branch: v2
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -71,7 +65,6 @@ updates:
 
   - package-ecosystem: npm
     directory: /web
-    target-branch: v2
     schedule:
       interval: weekly
     open-pull-requests-limit: 5

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 GPT-Load Contributors
+Copyright (c) 2025-2026 GPT-Load Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
### 关联 Issue / Related Issue
无 / N/A — 默认分支切换到 `v2` 之后的配置跟进。

### 变更内容 / Change Content
- [ ] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [x] 其他改动 / Other changes

**1. `.github/dependabot.yml`：移除全部 4 处 `target-branch: v2`**

该配置写于默认分支还是 `main` 的时期。默认分支切到 `v2` 后它不仅冗余，而且有害：GitHub 的规则是**只要声明了 `target-branch`，该 ecosystem 的配置就不再作用于 security update**，哪怕它指向的就是默认分支。

移除后行为不变（Dependabot 默认即针对默认分支 `v2`），但 `groups`（minor/patch 合并、major 单独成 PR）、`labels`、`commit-message` 前缀开始同时覆盖 version update 与 security update。文件顶部注释同步重写，说明为什么不应该再加回 `target-branch`。

参考：[Dependabot options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference)

**2. `LICENSE`：版权年份 `2024` → `2025-2026`**

仓库最早提交为 2025-06-06（`git log --reverse`），原先的 2024 与项目实际起始年份不符。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.

<!-- 无代码行为变更，不涉及 API、配置、数据库或迁移兼容性影响。 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **配置**
  * 更新依赖更新配置，移除指定目标分支设置，保留现有更新计划与规则。
* **合规**
  * 将 MIT 许可证版权年份更新为 2025–2026。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->