### PR TITLE
fix(security): 收紧 OAuth 与数值边界

### DIFF
--- a/internal/control/model_prices_api.go
+++ b/internal/control/model_prices_api.go
@@ -335,11 +335,11 @@ func parseModelPriceListQuery(
 }
 
 func parseModelPriceRowID(value string) (uint, error) {
-	parsed, err := parseCanonicalSafeUint(value)
-	if err != nil || parsed == 0 || parsed > uint64(^uint(0)) {
+	parsed, err := parseCanonicalSafePlatformUint(value)
+	if err != nil || parsed == 0 {
 		return 0, fmt.Errorf("model price ID must be a canonical positive safe integer")
 	}
-	return uint(parsed), nil
+	return parsed, nil
 }
 
 func (s *Server) handleListModelPrices(c *gin.Context) {

--- a/internal/control/model_prices_api_test.go
+++ b/internal/control/model_prices_api_test.go
@@ -107,7 +107,11 @@ func TestParseModelPriceListQueryRejectsAmbiguousOrUnsafeInput(t *testing.T) {
 
 func TestParseModelPriceRowIDRequiresCanonicalPositiveSafeUint(t *testing.T) {
 	t.Parallel()
-	for _, value := range []string{"1", "9007199254740991"} {
+	valid := []string{"1"}
+	if uint64(math.MaxUint) >= uint64(maxSafeInteger) {
+		valid = append(valid, "9007199254740991")
+	}
+	for _, value := range valid {
 		got, err := parseModelPriceRowID(value)
 		if err != nil {
 			t.Fatalf("parseModelPriceRowID(%q) error = %v", value, err)

--- a/internal/control/request_logs.go
+++ b/internal/control/request_logs.go
@@ -588,17 +588,17 @@ func singleQueryValue(values url.Values, key string) (string, bool) {
 }
 
 func parseRequestLogID(value string) (uint, *app_errors.APIError) {
-	parsed, err := parseCanonicalSafeUint(value)
+	parsed, err := parseCanonicalSafePlatformUint(value)
 	if err != nil {
 		if errors.Is(err, errUnsafeCanonicalUint) {
 			return 0, app_errors.ErrValidation
 		}
 		return 0, app_errors.ErrBadRequest
 	}
-	if parsed == 0 || uint64(uint(parsed)) != parsed {
+	if parsed == 0 {
 		return 0, app_errors.ErrValidation
 	}
-	return uint(parsed), nil
+	return parsed, nil
 }
 
 func parseRequestLogChannelID(value string) (channel.ID, *app_errors.APIError) {

--- a/internal/control/server.go
+++ b/internal/control/server.go
@@ -242,13 +242,13 @@ func (s *Server) handleImportCredentialStage(c *gin.Context) {
 			groupCount++
 			value, readErr := io.ReadAll(io.LimitReader(part, maxCredentialStageGroupIDBytes+1))
 			_ = part.Close()
-			parsed, parseErr := strconv.ParseUint(strings.TrimSpace(string(value)), 10, 64)
+			parsed, parseErr := parseCanonicalSafePlatformUint(strings.TrimSpace(string(value)))
 			if readErr != nil || int64(len(value)) > maxCredentialStageGroupIDBytes ||
-				groupCount != 1 || parseErr != nil || parsed == 0 || uint64(uint(parsed)) != parsed {
+				groupCount != 1 || parseErr != nil || parsed == 0 {
 				writeServiceError(c, "import_credential_stage", app_errors.ErrOAuthFileInvalid)
 				return
 			}
-			groupID = uint(parsed)
+			groupID = parsed
 		default:
 			_ = part.Close()
 			writeServiceError(c, "import_credential_stage", app_errors.ErrOAuthFileInvalid)

--- a/internal/control/usage.go
+++ b/internal/control/usage.go
@@ -307,17 +307,17 @@ func validUsageModel(value string) bool {
 }
 
 func parseUsageGroupID(value string) (uint, *app_errors.APIError) {
-	parsed, err := parseCanonicalSafeUint(value)
+	parsed, err := parseCanonicalSafePlatformUint(value)
 	if err != nil {
 		if errors.Is(err, errUnsafeCanonicalUint) {
 			return 0, app_errors.ErrValidation
 		}
 		return 0, app_errors.ErrBadRequest
 	}
-	if parsed == 0 || uint64(uint(parsed)) != parsed {
+	if parsed == 0 {
 		return 0, app_errors.ErrValidation
 	}
-	return uint(parsed), nil
+	return parsed, nil
 }
 
 func (service *Service) mapUsageResponse(

--- a/internal/control/wire_contract.go
+++ b/internal/control/wire_contract.go
@@ -3,6 +3,7 @@ package control
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"time"
 
@@ -64,4 +65,15 @@ func parseCanonicalSafeUint(value string) (uint64, error) {
 		return 0, errUnsafeCanonicalUint
 	}
 	return parsed, nil
+}
+
+func parseCanonicalSafePlatformUint(value string) (uint, error) {
+	parsed, err := parseCanonicalSafeUint(value)
+	if err != nil {
+		return 0, err
+	}
+	if parsed > math.MaxUint {
+		return 0, errUnsafeCanonicalUint
+	}
+	return uint(parsed), nil
 }

--- a/internal/control/wire_contract_uint_test.go
+++ b/internal/control/wire_contract_uint_test.go
@@ -1,0 +1,49 @@
+package control
+
+import (
+	"errors"
+	"math"
+	"strconv"
+	"testing"
+)
+
+func TestParseCanonicalSafePlatformUint(t *testing.T) {
+	t.Parallel()
+	maxSupported := uint64(maxSafeInteger)
+	if uint64(math.MaxUint) < maxSupported {
+		maxSupported = uint64(math.MaxUint)
+	}
+	for _, value := range []string{"0", "1", strconv.FormatUint(maxSupported, 10)} {
+		got, err := parseCanonicalSafePlatformUint(value)
+		if err != nil || uint64(got) != mustParseUint(t, value) {
+			t.Fatalf("parseCanonicalSafePlatformUint(%q) = %d, %v", value, got, err)
+		}
+	}
+
+	for _, value := range []string{"", "00", "01", "+1", "-1", "18446744073709551616"} {
+		if _, err := parseCanonicalSafePlatformUint(value); err == nil || errors.Is(err, errUnsafeCanonicalUint) {
+			t.Fatalf("parseCanonicalSafePlatformUint(%q) error = %v, want canonical error", value, err)
+		}
+	}
+
+	for _, value := range []string{"9007199254740992"} {
+		if _, err := parseCanonicalSafePlatformUint(value); !errors.Is(err, errUnsafeCanonicalUint) {
+			t.Fatalf("parseCanonicalSafePlatformUint(%q) error = %v, want unsafe integer", value, err)
+		}
+	}
+	if strconv.IntSize == 32 {
+		value := "4294967296"
+		if _, err := parseCanonicalSafePlatformUint(value); !errors.Is(err, errUnsafeCanonicalUint) {
+			t.Fatalf("parseCanonicalSafePlatformUint(%q) error = %v, want platform overflow", value, err)
+		}
+	}
+}
+
+func mustParseUint(t *testing.T, value string) uint64 {
+	t.Helper()
+	parsed, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed
+}

--- a/third_party/cpaembedded/embedded/grok.go
+++ b/third_party/cpaembedded/embedded/grok.go
@@ -212,20 +212,16 @@ func validateGrokCredentialWithOptions(credential GrokCredential, options GrokOp
 	if _, err := validateGrokOAuthEndpoint(
 		credential.TokenEndpoint,
 		"token_endpoint",
-		grokAllowsTestEndpoints(options),
+		grokAllowsOAuthTestEndpoints(options),
 	); err != nil {
 		return err
 	}
 	return nil
 }
 
-func grokAllowsTestEndpoints(options GrokOptions) bool {
+func grokAllowsOAuthTestEndpoints(options GrokOptions) bool {
 	return strings.TrimSpace(options.DiscoveryURL) != "" ||
-		strings.TrimSpace(options.UserInfoURL) != "" ||
-		strings.TrimSpace(options.ModelsURL) != "" ||
-		strings.TrimSpace(options.BillingWeeklyURL) != "" ||
-		strings.TrimSpace(options.BillingMonthlyURL) != "" ||
-		options.HTTPClient != nil
+		strings.TrimSpace(options.UserInfoURL) != ""
 }
 
 func GrokCredentialExpiresAt(credential GrokCredential) (time.Time, bool) {
@@ -270,7 +266,7 @@ func grokHTTPClient(options GrokOptions) *http.Client {
 	return clientWithoutRedirects(http.DefaultClient)
 }
 
-func decodeGrokDeviceState(raw []byte) (GrokDeviceState, error) {
+func decodeGrokDeviceState(raw []byte, allowTestEndpoint bool) (GrokDeviceState, error) {
 	var state GrokDeviceState
 	decoder := json.NewDecoder(bytes.NewReader(raw))
 	decoder.DisallowUnknownFields()
@@ -281,5 +277,15 @@ func decodeGrokDeviceState(raw []byte) (GrokDeviceState, error) {
 		strings.TrimSpace(state.UserInfoEndpoint) == "" || state.PollIntervalSeconds < 1 || state.PollIntervalSeconds > 60 {
 		return GrokDeviceState{}, fmt.Errorf("Grok device authorization state is invalid")
 	}
+	tokenEndpoint, err := validateGrokOAuthEndpoint(state.TokenEndpoint, "token_endpoint", allowTestEndpoint)
+	if err != nil {
+		return GrokDeviceState{}, err
+	}
+	userInfoEndpoint, err := validateGrokOAuthEndpoint(state.UserInfoEndpoint, "userinfo_endpoint", allowTestEndpoint)
+	if err != nil {
+		return GrokDeviceState{}, err
+	}
+	state.TokenEndpoint = tokenEndpoint
+	state.UserInfoEndpoint = userInfoEndpoint
 	return state, nil
 }

--- a/third_party/cpaembedded/embedded/grok_oauth.go
+++ b/third_party/cpaembedded/embedded/grok_oauth.go
@@ -116,7 +116,7 @@ func pollGrokDeviceAuthorizationOnce(ctx context.Context, state GrokDeviceState,
 	if err != nil {
 		return GrokDevicePoll{}, err
 	}
-	state, err = decodeGrokDeviceState(raw)
+	state, err = decodeGrokDeviceState(raw, grokAllowsOAuthTestEndpoints(options))
 	clear(raw)
 	if err != nil {
 		return GrokDevicePoll{}, err
@@ -441,7 +441,7 @@ func discoverGrokOAuth(ctx context.Context, options GrokOptions) (grokDiscovery,
 
 func resolveGrokTokenAndUserInfo(ctx context.Context, tokenEndpoint string, options GrokOptions) (grokDiscovery, error) {
 	userInfo := strings.TrimSpace(options.UserInfoURL)
-	allowTestEndpoint := strings.TrimSpace(options.DiscoveryURL) != "" || userInfo != ""
+	allowTestEndpoint := grokAllowsOAuthTestEndpoints(options)
 	if strings.TrimSpace(tokenEndpoint) != "" && userInfo != "" {
 		validatedToken, err := validateGrokOAuthEndpoint(tokenEndpoint, "token_endpoint", allowTestEndpoint)
 		if err != nil {
@@ -528,7 +528,11 @@ func doGrokForm(
 	endpoint string,
 	form url.Values,
 ) ([]byte, int, time.Duration, error) {
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimSpace(endpoint), strings.NewReader(form.Encode()))
+	endpoint, err := validateGrokOAuthEndpoint(endpoint, "oauth_endpoint", grokAllowsOAuthTestEndpoints(options))
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/third_party/cpaembedded/embedded/grok_test.go
+++ b/third_party/cpaembedded/embedded/grok_test.go
@@ -12,6 +12,24 @@ import (
 	"time"
 )
 
+type grokRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (fn grokRoundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
+
+func grokTestClient(server *httptest.Server) *http.Client {
+	host := strings.TrimPrefix(server.URL, "http://")
+	transport := server.Client().Transport
+	return &http.Client{Transport: grokRoundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		request = request.Clone(request.Context())
+		request.URL.Scheme = "http"
+		request.URL.Host = host
+		request.Host = host
+		return transport.RoundTrip(request)
+	})}
+}
+
 func TestBeginGrokDeviceAuthorizationUsesDiscoveryAndReturnsOneChallenge(t *testing.T) {
 	now := time.Date(2026, time.August, 18, 8, 0, 0, 0, time.UTC)
 	var deviceCalls atomic.Int32
@@ -77,15 +95,75 @@ func TestPollGrokDeviceAuthorizationPerformsExactlyOneRequest(t *testing.T) {
 	defer server.Close()
 
 	result, err := PollGrokDeviceAuthorizationOnce(t.Context(), GrokDeviceState{
-		DeviceCode: "device-secret", TokenEndpoint: server.URL, UserInfoEndpoint: server.URL + "/userinfo",
+		DeviceCode: "device-secret", TokenEndpoint: server.URL + "/token",
+		UserInfoEndpoint:    server.URL + "/userinfo",
 		PollIntervalSeconds: 5,
-	}, GrokOptions{HTTPClient: server.Client()})
+	}, GrokOptions{DiscoveryURL: server.URL + "/discovery", HTTPClient: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if result.Status != GrokDevicePending || result.PollInterval != 10*time.Second ||
 		result.State.PollIntervalSeconds != 10 || calls.Load() != 1 {
 		t.Fatalf("poll = %#v, calls = %d", result, calls.Load())
+	}
+}
+
+func TestPollGrokDeviceAuthorizationRejectsUntrustedEndpointsBeforeRequest(t *testing.T) {
+	for _, test := range []struct {
+		name             string
+		tokenEndpoint    string
+		userInfoEndpoint string
+	}{
+		{
+			name:             "token endpoint",
+			tokenEndpoint:    "http://127.0.0.1/token",
+			userInfoEndpoint: "https://auth.x.ai/userinfo",
+		},
+		{
+			name:             "userinfo endpoint",
+			tokenEndpoint:    "https://auth.x.ai/token",
+			userInfoEndpoint: "http://127.0.0.1/userinfo",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var calls atomic.Int32
+			client := &http.Client{Transport: grokRoundTripperFunc(func(*http.Request) (*http.Response, error) {
+				calls.Add(1)
+				return nil, errors.New("unexpected request")
+			})}
+
+			_, err := PollGrokDeviceAuthorizationOnce(t.Context(), GrokDeviceState{
+				DeviceCode: "device-secret", TokenEndpoint: test.tokenEndpoint,
+				UserInfoEndpoint: test.userInfoEndpoint, PollIntervalSeconds: 5,
+			}, GrokOptions{HTTPClient: client})
+			if err == nil {
+				t.Fatal("untrusted endpoint was accepted")
+			}
+			if calls.Load() != 0 {
+				t.Fatalf("requests = %d, want 0", calls.Load())
+			}
+		})
+	}
+}
+
+func TestDoGrokFormRejectsUntrustedEndpointBeforeRequest(t *testing.T) {
+	var calls atomic.Int32
+	client := &http.Client{Transport: grokRoundTripperFunc(func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return nil, errors.New("unexpected request")
+	})}
+
+	_, _, _, err := doGrokForm(
+		t.Context(),
+		GrokOptions{HTTPClient: client},
+		"http://127.0.0.1/token",
+		nil,
+	)
+	if err == nil {
+		t.Fatal("untrusted endpoint was accepted")
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("requests = %d, want 0", calls.Load())
 	}
 }
 
@@ -106,9 +184,9 @@ func TestPollGrokDeviceAuthorizationMapsTerminalDeviceStates(t *testing.T) {
 			defer server.Close()
 
 			result, err := PollGrokDeviceAuthorizationOnce(t.Context(), GrokDeviceState{
-				DeviceCode: "device-secret", TokenEndpoint: server.URL,
-				UserInfoEndpoint: server.URL + "/userinfo", PollIntervalSeconds: 5,
-			}, GrokOptions{HTTPClient: server.Client()})
+				DeviceCode: "device-secret", TokenEndpoint: "https://auth.x.ai/token",
+				UserInfoEndpoint: "https://auth.x.ai/userinfo", PollIntervalSeconds: 5,
+			}, GrokOptions{HTTPClient: grokTestClient(server)})
 			if err != nil || result.Status != test.status {
 				t.Fatalf("poll = %#v, %v", result, err)
 			}
@@ -140,9 +218,9 @@ func TestPollGrokDeviceAuthorizationVerifiesUserInfoIdentity(t *testing.T) {
 	defer server.Close()
 
 	result, err := PollGrokDeviceAuthorizationOnce(t.Context(), GrokDeviceState{
-		DeviceCode: "device-secret", TokenEndpoint: server.URL + "/token",
-		UserInfoEndpoint: server.URL + "/userinfo", PollIntervalSeconds: 5,
-	}, GrokOptions{HTTPClient: server.Client(), Now: func() time.Time { return now }})
+		DeviceCode: "device-secret", TokenEndpoint: "https://auth.x.ai/token",
+		UserInfoEndpoint: "https://auth.x.ai/userinfo", PollIntervalSeconds: 5,
+	}, GrokOptions{HTTPClient: grokTestClient(server), Now: func() time.Time { return now }})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/third_party/cpaembedded/go.mod
+++ b/third_party/cpaembedded/go.mod
@@ -1,6 +1,6 @@
 module github.com/router-for-me/CLIProxyAPI/v7/gptload-embedded
 
-go 1.26.0
+go 1.26.6
 
 require (
 	github.com/andybalholm/brotli v1.2.3


### PR DESCRIPTION
### 关联 Issue / Related Issue
<!-- 请填写此 PR 关联的 issue 编号，例如：Closes #123 / Please link the issue number, e.g., Closes #123 -->
N/A

### 变更内容 / Change Content
<!-- 请简要描述本次变更的核心内容 / Please briefly describe the core changes of this PR -->
- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

<!-- 请在下方详细描述你的变更 / Please describe your changes in detail below -->

- 在恢复 Grok device state 以及统一 OAuth form 请求 sink 前复验端点，仅允许生产环境访问 HTTPS `x.ai` / `*.x.ai`，并禁止 `HTTPClient`、模型或计费测试配置放宽 OAuth 端点；保留显式 `DiscoveryURL` / `UserInfoURL` 测试 seam。
- 新增请求次数为 0 的回归测试，覆盖恶意 token endpoint、userinfo endpoint 和统一请求 sink。
- 统一管理面 ID 的 canonical、JSON-safe、platform-safe `uint` 解析，使用 CodeQL 可识别的 `math.MaxUint` 上界保护，修复 #11–#17；multipart `group_id` 现在也拒绝 `+1`、前导零及非安全整数。
- 将嵌入 CPA 模块最低 Go 补丁版本从 1.26.0 提升到 1.26.6，消除 `govulncheck` 检出的 17 条可达标准库漏洞。
- 经逐条复核，#4–#8、#10、#18 已以 false positive 关闭：前五条为 64 位地址空间下不可达的容量预分配溢出，#10 为 Bearer token 的临时定长摘要比较，#18 的导入路径已有生产 xAI HTTPS allowlist 且禁重定向。

验证：

- `make check`
- `go mod tidy -diff && go vet ./... && go test -mod=readonly -count=1 ./...`（`third_party/cpaembedded`）
- `govulncheck@v1.7.0 ./...`（根模块与嵌入模块均为 0 条可达漏洞）
- `pnpm --dir web audit --json`（0 条漏洞）

兼容性：无数据迁移；嵌入 CPA 模块最低 Go 版本变为 1.26.6，multipart `group_id` 输入收紧为 canonical positive safe integer。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **安全性改进**
  * 加强 OAuth 测试端点校验，拒绝不受信任的令牌和用户信息端点，并在发起请求前完成验证。
  * 统一数字标识解析规则，改进跨平台安全整数范围处理。

* **Bug 修复**
  * 修复不同平台下数字溢出及无效标识解析的一致性问题。

* **测试**
  * 新增数字边界、平台位宽及 OAuth 端点安全校验测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->