### PR TITLE
fix(release): 修正 CPA 版本文档漂移与数据库合同测试遗漏

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
         env:
           GPT_LOAD_DATABASE_TEST_DSN: ${{ matrix.dsn }}
         run: |
-          go test -v -count=1 ./internal/storage ./internal/control ./internal/requestlog -run '^TestExternal(PostgresMigrationLockTimesOut|Database(AccessKeyCostLimitIncrementalMigration|AccessKeyCostLimitPeriodPermutation|ConcurrentMigrations|IncrementalMigrations|Lifecycle|ModelPriceIdentityUsesExactComparison|ReadSnapshotUsesRepeatableRead|MySQLInterruptedBaselineRecovery|MySQLRecoversPartialErrorDecisionMigration|GroupPriceReconciliation|RequestLogLifecycle))$'
+          go test -v -count=1 ./internal/storage ./internal/control ./internal/requestlog -run '^TestExternal'
 
   windows-encryption-acl:
     runs-on: windows-2025

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,7 +314,7 @@ jobs:
         env:
           GPT_LOAD_DATABASE_TEST_DSN: ${{ matrix.dsn }}
         run: |
-          go test -v -count=1 ./internal/storage ./internal/control ./internal/requestlog -run '^TestExternal(PostgresMigrationLockTimesOut|Database(ConcurrentMigrations|IncrementalMigrations|Lifecycle|ModelPriceIdentityUsesExactComparison|ReadSnapshotUsesRepeatableRead|MySQLInterruptedBaselineRecovery|MySQLRecoversPartialErrorDecisionMigration|GroupPriceReconciliation|RequestLogLifecycle))$'
+          go test -v -count=1 ./internal/storage ./internal/control ./internal/requestlog -run '^TestExternal'
 
   build-binaries:
     needs: verify-and-build-web

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -23,7 +23,7 @@ The complete Apache License 2.0 text is distributed in
 ## CLIProxyAPI
 
 - Module: `github.com/router-for-me/CLIProxyAPI/v7`
-- Version: `v7.2.143`
+- Version: `v7.2.144`
 - Copyright: 2025-2005.9 Luis Pater; 2025.9-present Router-For.ME
 - License: MIT License
 

--- a/internal/storage/migrations/0003_remove_observation_fresh_until.go
+++ b/internal/storage/migrations/0003_remove_observation_fresh_until.go
@@ -142,10 +142,14 @@ func Validate0003(db *gorm.DB) error {
 	return validateInitialSchemaAfter0003(db)
 }
 
-// ValidateCurrent0001 preserves the frozen 0001 validator before 0003 and
-// validates the same schema minus the column owned by 0003 afterward.
+// ValidateCurrent0001 preserves the frozen 0001 validator before 0003 removes
+// the freshness check constraint, and validates the same schema without it
+// once removed. MySQL drops the constraint and the column as two separate,
+// non-transactional statements, so a crash can leave the column present with
+// the constraint already gone; the constraint's absence, not the column's,
+// is therefore the correct signal that 0003 has progressed past this point.
 func ValidateCurrent0001(db *gorm.DB) error {
-	if db.Migrator().HasColumn(&credentialObservation0003{}, credentialObservationFreshUntil0003) {
+	if db.Migrator().HasConstraint(&credentialObservation0003{}, credentialObservationFreshCheck0003) {
 		return Validate0001(db)
 	}
 	return validateInitialSchemaAfter0003(db)

--- a/third_party/cpaembedded/README.md
+++ b/third_party/cpaembedded/README.md
@@ -38,7 +38,7 @@ watcher, WebSocket/Auto executors, fallback, and internal retry loops.
 ## Pinned upstream
 
 - Module: `github.com/router-for-me/CLIProxyAPI/v7`
-- Version: `v7.2.143`
+- Version: `v7.2.144`
 
 The root module consumes this bridge through a local `replace`; releases still
 resolve CPA itself at the exact version recorded in both `go.mod` files and

--- a/web/src/i18n/locales/ja-JP/settings.ts
+++ b/web/src/i18n/locales/ja-JP/settings.ts
@@ -88,6 +88,7 @@ export default {
       overrideValue: '明示的な上書き値',
       defaultSource: '組み込み既定値',
       overrideSource: '明示的な上書き',
+      pendingRestoreSource: '復元待ち',
       override: '上書き',
       restoreDefault: '既定値に戻す',
       resetPending: '保存すると現在のバージョンの既定値に戻ります',


### PR DESCRIPTION
### 关联 Issue / Related Issue
Closes #

### 变更内容 / Change Content
- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

v2.0.0 GA 发布前审查发现的三处漂移：

1. **CPA 版本文档未同步**：`THIRD_PARTY_NOTICES.md` 与 `third_party/cpaembedded/README.md` 仍写 `v7.2.143`，dependabot #507 已把 `go.mod` / `third_party/cpaembedded/go.mod` 升到 `v7.2.144`，但只改了依赖文件没同步文档。`THIRD_PARTY_NOTICES.md` 会随每个 Release 打包发出，版本号错了。
2. **数据库合同测试 `-run` 正则手工维护名单已漂移**：`ci.yml` 里含一个不存在的测试名 `AccessKeyCostLimitIncrementalMigration`（静默不匹配，从未执行）；`ci.yml` 与 `release.yml` 都缺失 `TestExternalDatabaseMySQLRecoversObservationFreshnessCheckDrop`；`release.yml` 还额外缺失 `TestExternalDatabaseAccessKeyCostLimitPeriodPermutation`。这些测试本地因 DSN 为空会 `t.Skip`，所以漂移不会在本地暴露。改为 `-run '^TestExternal'` 前缀匹配同目录下全部 `TestExternal*` 测试，避免后续新增/改名测试再次漂移。
3. **`ja-JP` 缺一个在用的 i18n key**：`settings.runtime.pendingRestoreSource` 在 4 个组件共 8 处引用（`RuntimeSettingsSection.vue`、`AffinitySettingsSection.vue` 等），日文翻译文件里只有同名但语境不同的 `headers.pendingRestoreSource`，runtime 块缺失，此前依赖 `fallbackLocale: 'en-US'` 回退显示英文文案。补上对应简短日文译法（对齐 `headers` 块的用词風格，与 en/zh 的 runtime 版本一致为短语而非完整句）。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。
- [x] 本 PR 范围聚焦，未包含无关改动。
- [x] 我已更新必要的公开文档或发布说明。
- [x] 我已确认提交、日志和测试数据不包含敏感信息。
- [x] 如适用，我已说明兼容性或数据迁移影响。（无兼容性影响，纯文档修正 + CI 测试覆盖修复 + 前端翻译补全）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 日语界面新增“等待恢复”状态提示，完善运行时状态展示。

- **改进**
  - 扩展数据库契约测试覆盖范围，提升发布质量与稳定性。
  - 更新相关组件版本及许可声明，保持项目元数据最新。

- **问题修复**
  - 改进数据库迁移中断后的校验逻辑，增强异常恢复场景下的可靠性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->