### PR TITLE
重做首页常用订阅账号卡片视觉设计

### DIFF
--- a/internal/control/home_subscription_accounts.go
+++ b/internal/control/home_subscription_accounts.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	homeSubscriptionAccountLimit  = 6
+	homeSubscriptionAccountLimit  = 4
 	homeSubscriptionAccountWindow = 24 * time.Hour
 )
 

--- a/internal/control/home_subscription_accounts.go
+++ b/internal/control/home_subscription_accounts.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	homeSubscriptionAccountLimit  = 4
+	homeSubscriptionAccountLimit  = 6
 	homeSubscriptionAccountWindow = 24 * time.Hour
 )
 
@@ -28,6 +28,7 @@ type HomeSubscriptionAccountsResponse struct {
 
 type HomeSubscriptionAccountResponse struct {
 	ChannelID           string                       `json:"channel_id"`
+	ChannelName         string                       `json:"channel_name"`
 	ChannelMark         string                       `json:"channel_mark"`
 	ChannelIcon         string                       `json:"channel_icon"`
 	Capabilities        channel.CapabilityDescriptor `json:"capabilities"`
@@ -171,6 +172,7 @@ func (s *Service) readHomeSubscriptionAccounts(
 			return HomeSubscriptionAccountsResponse{}, app_errors.ErrInternalServer
 		}
 		item.ChannelID = activity.ChannelID
+		item.ChannelName = descriptor.Name
 		item.ChannelMark = descriptor.Mark
 		item.ChannelIcon = descriptor.Icon
 		item.Capabilities = descriptor.Capabilities

--- a/internal/control/home_subscription_accounts_test.go
+++ b/internal/control/home_subscription_accounts_test.go
@@ -130,13 +130,13 @@ func TestReadHomeSubscriptionAccountsReflectsLatestRankingOnEveryRead(t *testing
 	}
 }
 
-func TestReadHomeSubscriptionAccountsLimitsTheHomepageToSixCards(t *testing.T) {
+func TestReadHomeSubscriptionAccountsLimitsTheHomepageToFourCards(t *testing.T) {
 	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := time.Date(2026, time.August, 31, 12, 30, 0, 0, time.UTC)
 	fixture.service.now = func() time.Time { return now }
 	bucket := now.Truncate(time.Hour).UnixMilli()
-	for index := 0; index < 7; index++ {
+	for index := 0; index < 5; index++ {
 		_, credential := createHomeSubscriptionCredential(
 			t,
 			fixture,
@@ -152,7 +152,7 @@ func TestReadHomeSubscriptionAccountsLimitsTheHomepageToSixCards(t *testing.T) {
 	}
 
 	result, err := fixture.service.ReadHomeSubscriptionAccounts(t.Context())
-	if err != nil || len(result.Items) != 6 {
+	if err != nil || len(result.Items) != 4 {
 		t.Fatalf("ReadHomeSubscriptionAccounts() = %#v, %v", result, err)
 	}
 	for index, item := range result.Items {

--- a/internal/control/home_subscription_accounts_test.go
+++ b/internal/control/home_subscription_accounts_test.go
@@ -130,13 +130,13 @@ func TestReadHomeSubscriptionAccountsReflectsLatestRankingOnEveryRead(t *testing
 	}
 }
 
-func TestReadHomeSubscriptionAccountsLimitsTheHomepageToFourCards(t *testing.T) {
+func TestReadHomeSubscriptionAccountsLimitsTheHomepageToSixCards(t *testing.T) {
 	t.Parallel()
 	fixture := newServiceFixture(t)
 	now := time.Date(2026, time.August, 31, 12, 30, 0, 0, time.UTC)
 	fixture.service.now = func() time.Time { return now }
 	bucket := now.Truncate(time.Hour).UnixMilli()
-	for index := 0; index < 5; index++ {
+	for index := 0; index < 7; index++ {
 		_, credential := createHomeSubscriptionCredential(
 			t,
 			fixture,
@@ -152,13 +152,16 @@ func TestReadHomeSubscriptionAccountsLimitsTheHomepageToFourCards(t *testing.T) 
 	}
 
 	result, err := fixture.service.ReadHomeSubscriptionAccounts(t.Context())
-	if err != nil || len(result.Items) != 4 {
+	if err != nil || len(result.Items) != 6 {
 		t.Fatalf("ReadHomeSubscriptionAccounts() = %#v, %v", result, err)
 	}
 	for index, item := range result.Items {
 		want := fmt.Sprintf("limit-%d@example.com", index)
 		if item.Credential.Account.Email != want {
 			t.Fatalf("item %d email = %q, want %q", index, item.Credential.Account.Email, want)
+		}
+		if item.ChannelName != "Codex" {
+			t.Fatalf("item %d channel name = %q, want Codex", index, item.ChannelName)
 		}
 	}
 }

--- a/web/src/app/resources/home.ts
+++ b/web/src/app/resources/home.ts
@@ -311,7 +311,7 @@ export function projectHomeSubscriptionAccounts(value: unknown): HomeSubscriptio
   assertNoSecretLikeFields(record, subscriptionAccountsFields)
   const items = projectArray(record.items, projectHomeSubscriptionAccount)
   if (
-    items.length > 6 ||
+    items.length > 4 ||
     new Set(items.map((item) => item.credential.credential_id)).size !== items.length
   ) {
     invalidResponse()

--- a/web/src/app/resources/home.ts
+++ b/web/src/app/resources/home.ts
@@ -117,6 +117,7 @@ export interface HomeStatisticsDto {
 
 export interface HomeSubscriptionAccountDto {
   channel_id: string
+  channel_name: string
   channel_mark: string
   channel_icon: string
   capabilities: ChannelCapabilitiesDto
@@ -184,6 +185,7 @@ const accessKeyRankingFields = ['access_key', ...rankingMetricFields] as const
 const subscriptionAccountsFields = ['observed_at_ms', 'items'] as const
 const subscriptionAccountFields = [
   'channel_id',
+  'channel_name',
   'channel_mark',
   'channel_icon',
   'capabilities',
@@ -294,6 +296,7 @@ function projectHomeSubscriptionAccount(value: unknown): HomeSubscriptionAccount
   }
   return {
     channel_id: projectNonBlankTrimmedString(record.channel_id),
+    channel_name: projectNonBlankTrimmedString(record.channel_name),
     channel_mark: projectNonBlankTrimmedString(record.channel_mark),
     channel_icon: projectNonBlankTrimmedString(record.channel_icon),
     capabilities: projectHomeSubscriptionCapabilities(record.capabilities),
@@ -308,7 +311,7 @@ export function projectHomeSubscriptionAccounts(value: unknown): HomeSubscriptio
   assertNoSecretLikeFields(record, subscriptionAccountsFields)
   const items = projectArray(record.items, projectHomeSubscriptionAccount)
   if (
-    items.length > 4 ||
+    items.length > 6 ||
     new Set(items.map((item) => item.credential.credential_id)).size !== items.length
   ) {
     invalidResponse()

--- a/web/src/features/groups/credentials/SubscriptionAccountCard.vue
+++ b/web/src/features/groups/credentials/SubscriptionAccountCard.vue
@@ -51,16 +51,10 @@ const props = withDefaults(
     channelMark?: string
     capabilities: ChannelCapabilitiesDto
     saveProxy: (value: ProxyMutation) => Promise<void>
-    readonly?: boolean
-    groupCount?: number
-    availableGroupCount?: number
   }>(),
   {
     channelIcon: undefined,
     channelMark: undefined,
-    readonly: false,
-    groupCount: 1,
-    availableGroupCount: 1,
   },
 )
 const emit = defineEmits<{
@@ -99,7 +93,7 @@ watch(
       props.busy,
     ] as const,
   ([expanded, loaded, detailBusy, error, busy]) => {
-    if (!props.readonly && expanded && !loaded && !detailBusy && !error && !busy) {
+    if (expanded && !loaded && !detailBusy && !error && !busy) {
       emit('load-details', props.item)
     }
   },
@@ -382,17 +376,7 @@ const unifiedStatus = computed<UnifiedStatus>(() => {
   }
   return 'available'
 })
-const showAggregateAvailability = computed(
-  () =>
-    props.readonly &&
-    props.groupCount > 1 &&
-    (props.availableGroupCount < props.groupCount || unifiedStatus.value === 'available'),
-)
 const statusTone = computed<'success' | 'warning' | 'danger' | 'neutral'>(() => {
-  if (showAggregateAvailability.value) {
-    if (props.availableGroupCount === props.groupCount) return 'success'
-    return props.availableGroupCount > 0 ? 'warning' : 'danger'
-  }
   const tones: Record<UnifiedStatus, 'success' | 'warning' | 'danger' | 'neutral'> = {
     available: 'success',
     quota_exhausted: 'warning',
@@ -406,19 +390,9 @@ const statusTone = computed<'success' | 'warning' | 'danger' | 'neutral'>(() => 
   return tones[unifiedStatus.value]
 })
 const statusLabel = computed(() =>
-  showAggregateAvailability.value
-    ? t('home.ledger.subscriptionAccounts.availableGroups', {
-        available: n(props.availableGroupCount),
-        total: n(props.groupCount),
-      })
-    : t(`group.credentials.subscription.status.${unifiedStatus.value}`),
+  t(`group.credentials.subscription.status.${unifiedStatus.value}`),
 )
-const groupCountLabel = computed(() =>
-  t('home.ledger.subscriptionAccounts.groupCount', { count: n(props.groupCount) }),
-)
-const displayDisabled = computed(
-  () => !showAggregateAvailability.value && unifiedStatus.value === 'disabled',
-)
+const displayDisabled = computed(() => unifiedStatus.value === 'disabled')
 const authErrorKeys: Readonly<Record<string, string>> = {
   refresh_rejected: 'group.credentials.subscription.authError.refreshRejected',
   refresh_identity_changed: 'group.credentials.subscription.authError.identityChanged',
@@ -557,7 +531,7 @@ function quotaFillStyle(window: CredentialQuotaWindowDto): Record<string, string
 }
 
 function toggleDetails(): void {
-  if (props.readonly || props.detailBusy) return
+  if (props.detailBusy) return
   detailsExpanded.value = !detailsExpanded.value
 }
 
@@ -596,7 +570,6 @@ function runMenuAction(
       {
         'subscription-account--disabled': displayDisabled,
         'subscription-account--refreshing': refreshingObservation,
-        'subscription-account--readonly': readonly,
       },
     ]"
     :aria-busy="refreshingObservation ? 'true' : undefined"
@@ -699,7 +672,7 @@ function runMenuAction(
     <div class="subscription-account__main">
       <header class="subscription-account__top">
         <div class="subscription-account__top-row">
-          <label v-if="!readonly" class="subscription-account__select">
+          <label class="subscription-account__select">
             <span class="sr-only">{{
               t('group.credentials.subscription.selectAccount', { account: accountName })
             }}</span>
@@ -735,18 +708,9 @@ function runMenuAction(
             >
               {{ statusLabel }}
             </StatusBadge>
-            <span v-if="readonly" class="subscription-account__group-count">
-              {{ groupCountLabel }}
-            </span>
-            <ProxyScopeIndicator
-              v-if="!readonly && capabilities.outbound_proxy"
-              :view="item.proxy"
-            />
+            <ProxyScopeIndicator v-if="capabilities.outbound_proxy" :view="item.proxy" />
           </div>
-          <div
-            v-if="!readonly || (supportsQuotaObservation && observation?.observed_at_ms != null)"
-            class="subscription-account__actions"
-          >
+          <div class="subscription-account__actions">
             <span
               v-if="supportsQuotaObservation && observation?.observed_at_ms != null"
               class="subscription-account__sync-age"
@@ -760,7 +724,7 @@ function runMenuAction(
               />
             </span>
             <AppTooltip
-              v-if="supportsQuotaObservation && !readonly"
+              v-if="supportsQuotaObservation"
               :content="t('group.credentials.subscription.sync')"
             >
               <IconButton
@@ -780,7 +744,6 @@ function runMenuAction(
               </IconButton>
             </AppTooltip>
             <AppPopover
-              v-if="!readonly"
               v-model:open="menuOpen"
               align="end"
               content-class="app-popover__content--account-menu"
@@ -969,11 +932,8 @@ function runMenuAction(
             hint
           />
         </span>
-        <span v-if="!readonly" class="subscription-account__spacer"></span>
-        <AppTooltip
-          v-if="!readonly"
-          :content="t('group.credentials.subscription.resetCreditsActionTooltip')"
-        >
+        <span class="subscription-account__spacer"></span>
+        <AppTooltip :content="t('group.credentials.subscription.resetCreditsActionTooltip')">
           <AppButton
             class="subscription-account__credits-action"
             variant="ghost"
@@ -987,7 +947,7 @@ function runMenuAction(
         </AppTooltip>
       </div>
 
-      <div v-if="!readonly" class="subscription-account__detail-control">
+      <div class="subscription-account__detail-control">
         <AppTooltip
           :content="
             t(
@@ -1043,7 +1003,7 @@ function runMenuAction(
     </div>
 
     <section
-      v-if="!readonly && detailsExpanded"
+      v-if="detailsExpanded"
       :id="`credential-detail-${item.credential_id}`"
       class="subscription-account__detail"
       aria-live="polite"
@@ -1393,9 +1353,6 @@ function runMenuAction(
   gap: var(--space-3);
   padding: var(--space-3) var(--space-4) 0;
 }
-.subscription-account--readonly .subscription-account__main {
-  padding-bottom: var(--space-3);
-}
 .subscription-account__top {
   display: grid;
   gap: var(--space-2);
@@ -1513,16 +1470,6 @@ function runMenuAction(
 }
 .subscription-account__status {
   flex: none;
-  white-space: nowrap;
-}
-.subscription-account__group-count {
-  flex: none;
-  border-radius: var(--radius-tag);
-  background: var(--color-surface-sunken);
-  padding: 3px 7px;
-  color: var(--color-text-muted);
-  font-size: var(--text-label-xs);
-  line-height: 1;
   white-space: nowrap;
 }
 .subscription-account__actions {

--- a/web/src/features/home/HomeSubscriptionAccountMiniCard.vue
+++ b/web/src/features/home/HomeSubscriptionAccountMiniCard.vue
@@ -65,18 +65,28 @@ function quotaWindowDuration(window: CredentialQuotaWindowDto): number {
     : Number.MAX_SAFE_INTEGER
 }
 
-// 首页摘要只展示上游返回的至多四个额度窗口；完整窗口信息保留在分组卡片中。
-const quotaWindows = computed(() =>
-  [...(snapshot.value?.quota_windows ?? [])]
-    .sort((left, right) => {
-      const scopeDifference =
-        Number(!isAccountWideQuotaWindow(left)) - Number(!isAccountWideQuotaWindow(right))
-      return scopeDifference !== 0
-        ? scopeDifference
-        : quotaWindowDuration(left) - quotaWindowDuration(right)
-    })
-    .slice(0, 4),
+// 按 scope + 周期排序全部窗口；焦点数字与状态判断都必须看完整列表，
+// 只有底部分段带需要限制展示数量（见下方 quotaWindows）。
+const sortedQuotaWindows = computed(() =>
+  [...(snapshot.value?.quota_windows ?? [])].sort((left, right) => {
+    const scopeDifference =
+      Number(!isAccountWideQuotaWindow(left)) - Number(!isAccountWideQuotaWindow(right))
+    return scopeDifference !== 0
+      ? scopeDifference
+      : quotaWindowDuration(left) - quotaWindowDuration(right)
+  }),
 )
+
+// 分段带最多展示 4 条；若焦点窗口（见下方 lead）因排序被挤到第 5 位之后，
+// 仍强制并入前排，保证大号数字与分段带指向同一个窗口，而不是各说各话。
+const quotaWindows = computed(() => {
+  const capped = sortedQuotaWindows.value.slice(0, 4)
+  const leadWindow = lead.value?.window
+  if (leadWindow && !capped.some((window) => window.id === leadWindow.id)) {
+    return [leadWindow, ...capped.slice(0, 3)]
+  }
+  return capped
+})
 
 const unifiedStatus = computed<UnifiedStatus>(() => {
   const item = credential.value
@@ -88,7 +98,9 @@ const unifiedStatus = computed<UnifiedStatus>(() => {
   if (item.effective_status === 'cooldown') return 'cooldown'
   if (
     props.account.capabilities.quota_observation &&
-    quotaWindows.value.some((window) => window.scope === 'account' && window.state === 'exhausted')
+    sortedQuotaWindows.value.some(
+      (window) => window.scope === 'account' && window.state === 'exhausted',
+    )
   ) {
     return 'quota_exhausted'
   }
@@ -160,13 +172,17 @@ function quotaFillStyle(window: CredentialQuotaWindowDto): Record<string, string
   return value === undefined ? {} : { width: `${value}%` }
 }
 
-function quotaPeriodLabel(seconds: number | undefined): string {
+// 与分组详情页 quotaWindowPeriodLabel 完全一致：日/时之外还兜底分钟与秒，
+// 避免非整日整时的窗口（例如 30 分钟）拿不到任何周期文案。
+function quotaWindowPeriodLabel(seconds: number | undefined): string {
   if (seconds === undefined || !Number.isSafeInteger(seconds) || seconds <= 0) return ''
   const day = 24 * 60 * 60
   const hour = 60 * 60
+  const minute = 60
   if (seconds % day === 0) return `${seconds / day}d`
   if (seconds % hour === 0) return `${seconds / hour}h`
-  return ''
+  if (seconds % minute === 0) return `${seconds / minute}min`
+  return `${seconds}s`
 }
 
 const quotaSubjectKeys: Readonly<Record<string, CredentialQuotaLabelKey>> = {
@@ -182,23 +198,35 @@ function normalizedQuotaLabelPart(value: string): string {
   return value.trim().toLowerCase().replaceAll('_', ' ').replaceAll('-', ' ')
 }
 
+function translatedQuotaLabel(labelKey: CredentialQuotaLabelKey, fallback: string): string {
+  const key = `group.credentials.subscription.quotaLabels.${labelKey}`
+  return te(key) ? t(key) : fallback
+}
+
+// 与分组详情页 quotaWindowLabel 完全一致：label_key 为 oauth_apps 时保留周期后缀
+// （例如「OAuth 应用 · 7d」），否则不同周期的同类窗口会显示成完全相同的文案。
 function quotaWindowLabel(window: CredentialQuotaWindowDto): string {
-  const period = quotaPeriodLabel(window.window_seconds)
+  const period = quotaWindowPeriodLabel(window.window_seconds)
   if (period && window.scope === 'account') return period
+
   if (window.label_key) {
-    const key = `group.credentials.subscription.quotaLabels.${window.label_key}`
-    return te(key) ? t(key) : window.label
+    const subject = translatedQuotaLabel(window.label_key, window.label)
+    return window.label_key === 'oauth_apps' && period ? `${subject} · ${period}` : subject
   }
+
   const parts = window.label
     .split('·')
     .map((part) => part.trim())
     .filter(Boolean)
-  if (parts.length === 0) return period || window.id
+  if (parts.length === 0) return period
+
+  const firstPart = normalizedQuotaLabelPart(parts[0] ?? '')
+  if (period && (firstPart === 'session' || firstPart === 'weekly')) return period
+
   return parts
     .map((part) => {
-      const key = quotaSubjectKeys[normalizedQuotaLabelPart(part)]
-      const translationKey = key ? `group.credentials.subscription.quotaLabels.${key}` : ''
-      return translationKey && te(translationKey) ? t(translationKey) : part
+      const labelKey = quotaSubjectKeys[normalizedQuotaLabelPart(part)]
+      return labelKey ? translatedQuotaLabel(labelKey, part) : part
     })
     .join(' · ')
 }
@@ -274,15 +302,22 @@ function quotaTooltip(window: CredentialQuotaWindowDto): string {
 const quotaResetPrefix = computed(() => t('group.credentials.subscription.quotaResetPrefix'))
 const quotaResetSuffix = computed(() => t('group.credentials.subscription.quotaResetSuffix'))
 
-// 焦点数字：取当前最紧张的窗口，作为「这个账号现在最该关心的一件事」。
-const lead = computed<{ window: CredentialQuotaWindowDto; percent: number } | undefined>(() => {
+// 焦点窗口：额度百分比已知的窗口里剩余最少的那个，在全部窗口（而非展示截断后
+// 的 quotaWindows）中查找，避免真正最紧张的窗口因排序被截断而漏判。上游只给出
+// state、没有具体数值的窗口（Codex/Claude 都存在）仍要退回展示，只是百分比留空，
+// 不能因为找不到数值就当成完全没有额度窗口。
+const lead = computed<
+  { window: CredentialQuotaWindowDto; percent: number | undefined } | undefined
+>(() => {
   let best: { window: CredentialQuotaWindowDto; percent: number } | undefined
-  for (const window of quotaWindows.value) {
+  for (const window of sortedQuotaWindows.value) {
     const percent = remainingPercent(window)
     if (percent === undefined) continue
     if (best === undefined || percent < best.percent) best = { window, percent }
   }
-  return best
+  if (best) return best
+  const [first] = sortedQuotaWindows.value
+  return first ? { window: first, percent: undefined } : undefined
 })
 const leadTone = computed(() => (lead.value ? quotaTone(lead.value.window) : undefined))
 
@@ -376,7 +411,7 @@ const resetCreditsTooltip = computed(() => {
         {{ statusLabel }}
       </StatusBadge>
       <span
-        v-else-if="lead"
+        v-else-if="lead && lead.percent !== undefined"
         class="home-subscription-mini__num"
         :class="`home-subscription-mini__num--${leadTone ?? 'unknown'}`"
       >

--- a/web/src/features/home/HomeSubscriptionAccountMiniCard.vue
+++ b/web/src/features/home/HomeSubscriptionAccountMiniCard.vue
@@ -1,0 +1,725 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import type {
+  CredentialItemDto,
+  CredentialQuotaLabelKey,
+  CredentialQuotaWindowDto,
+} from '@/api/control/types'
+import type { HomeSubscriptionAccountDto } from '@/app/resources/home'
+import ChannelIcon from '@/components/brand/ChannelIcon.vue'
+import AppRelativeTime from '@/components/ui/AppRelativeTime.vue'
+import AppTooltip from '@/components/ui/AppTooltip.vue'
+import OverflowTooltip from '@/components/ui/OverflowTooltip.vue'
+import StatusBadge from '@/components/ui/StatusBadge.vue'
+import { formatLocalInstant } from '@/lib/format'
+import { quotaProgressTone, type QuotaProgressTone } from '@/lib/quota-progress'
+
+const props = defineProps<{ account: HomeSubscriptionAccountDto }>()
+
+const { locale, n, t, te } = useI18n()
+
+type UnifiedStatus =
+  | 'available'
+  | 'quota_exhausted'
+  | 'cooldown'
+  | 'blacklisted'
+  | 'refreshing'
+  | 'needs_reauth'
+  | 'outcome_unknown'
+  | 'disabled'
+type CardTone = 'success' | 'warning' | 'danger' | 'neutral'
+type ResetCreditDotTone = 'default' | 'warning' | 'danger'
+
+// 与分组详情页 SubscriptionAccountCard 同步：重置卡到期档位用真实时钟而非一次性
+// Date.now()，避免首页长时间停留在前台时点阵颜色停留在打开时刻。
+const nowMs = ref(Date.now())
+let clockTimer: number | undefined
+
+onMounted(() => {
+  clockTimer = window.setInterval(() => {
+    nowMs.value = Date.now()
+  }, 30_000)
+})
+onBeforeUnmount(() => {
+  if (clockTimer !== undefined) window.clearInterval(clockTimer)
+})
+
+const credential = computed<CredentialItemDto>(() => props.account.credential)
+const snapshot = computed(() => credential.value.observation?.snapshot)
+const accountName = computed(() => credential.value.account.email ?? credential.value.mask)
+const planLabel = computed(() => snapshot.value?.plan_summary.name?.trim() ?? '')
+const channelTooltip = computed(() =>
+  [props.account.channel_name, planLabel.value].filter(Boolean).join(' · '),
+)
+
+function isAccountWideQuotaWindow(window: CredentialQuotaWindowDto): boolean {
+  return window.scope === 'account'
+}
+
+function quotaWindowDuration(window: CredentialQuotaWindowDto): number {
+  const seconds = window.window_seconds
+  return seconds !== undefined && Number.isFinite(seconds) && seconds > 0
+    ? seconds
+    : Number.MAX_SAFE_INTEGER
+}
+
+// 首页摘要只展示上游返回的至多四个额度窗口；完整窗口信息保留在分组卡片中。
+const quotaWindows = computed(() =>
+  [...(snapshot.value?.quota_windows ?? [])]
+    .sort((left, right) => {
+      const scopeDifference =
+        Number(!isAccountWideQuotaWindow(left)) - Number(!isAccountWideQuotaWindow(right))
+      return scopeDifference !== 0
+        ? scopeDifference
+        : quotaWindowDuration(left) - quotaWindowDuration(right)
+    })
+    .slice(0, 4),
+)
+
+const unifiedStatus = computed<UnifiedStatus>(() => {
+  const item = credential.value
+  if (item.configured_status === 'disabled') return 'disabled'
+  if (item.auth_state === 'refreshing') return 'refreshing'
+  if (item.auth_state === 'reauthorization_required') return 'needs_reauth'
+  if (item.auth_state === 'outcome_unknown') return 'outcome_unknown'
+  if (item.effective_status === 'blacklisted') return 'blacklisted'
+  if (item.effective_status === 'cooldown') return 'cooldown'
+  if (
+    props.account.capabilities.quota_observation &&
+    quotaWindows.value.some((window) => window.scope === 'account' && window.state === 'exhausted')
+  ) {
+    return 'quota_exhausted'
+  }
+  return 'available'
+})
+
+// 同一账号可能被多个分组共用；分组数 > 1 时可用性以「当前有几个分组能调度到它」为准。
+// 分组详情页 SubscriptionAccountCard 原本也有同名聚合口径，但那条路径只在 readonly
+// 模式下触发，首页改用本组件后已成为死代码并被清理，这里是唯一仍生效的实现。
+const showAggregateAvailability = computed(
+  () =>
+    props.account.group_count > 1 &&
+    (props.account.available_group_count < props.account.group_count ||
+      unifiedStatus.value === 'available'),
+)
+
+const cardTone = computed<CardTone>(() => {
+  if (showAggregateAvailability.value) {
+    if (props.account.available_group_count === props.account.group_count) return 'success'
+    return props.account.available_group_count > 0 ? 'warning' : 'danger'
+  }
+  const tones: Record<UnifiedStatus, CardTone> = {
+    available: 'success',
+    quota_exhausted: 'warning',
+    cooldown: 'warning',
+    blacklisted: 'danger',
+    refreshing: 'neutral',
+    needs_reauth: 'danger',
+    outcome_unknown: 'danger',
+    disabled: 'neutral',
+  }
+  return tones[unifiedStatus.value]
+})
+
+const statusLabel = computed(() =>
+  showAggregateAvailability.value
+    ? t('home.ledger.subscriptionAccounts.availableGroups', {
+        available: n(props.account.available_group_count),
+        total: n(props.account.group_count),
+      })
+    : t(`group.credentials.subscription.status.${unifiedStatus.value}`),
+)
+
+const displayDisabled = computed(
+  () => !showAggregateAvailability.value && unifiedStatus.value === 'disabled',
+)
+
+// 单分组且状态正常时不显示状态角标：首页只在有异常，或聚合可用性值得一提时才发声，
+// 呼应 HomeAttention「没有要处理的事就整块不渲染」的克制原则。
+const showStatusChip = computed(
+  () => showAggregateAvailability.value || unifiedStatus.value !== 'available',
+)
+
+function remainingPercent(window: CredentialQuotaWindowDto): number | undefined {
+  if (window.utilization !== undefined) return Math.round((1 - window.utilization) * 100)
+  if (window.remaining !== undefined && window.limit && window.limit > 0) {
+    return Math.max(0, Math.min(100, Math.round((window.remaining / window.limit) * 100)))
+  }
+  return undefined
+}
+
+function quotaTone(window: CredentialQuotaWindowDto): QuotaProgressTone | undefined {
+  const value = remainingPercent(window)
+  return value === undefined ? undefined : quotaProgressTone(value, window.state === 'exhausted')
+}
+
+function quotaFillStyle(window: CredentialQuotaWindowDto): Record<string, string> {
+  const value = remainingPercent(window)
+  return value === undefined ? {} : { width: `${value}%` }
+}
+
+function quotaPeriodLabel(seconds: number | undefined): string {
+  if (seconds === undefined || !Number.isSafeInteger(seconds) || seconds <= 0) return ''
+  const day = 24 * 60 * 60
+  const hour = 60 * 60
+  if (seconds % day === 0) return `${seconds / day}d`
+  if (seconds % hour === 0) return `${seconds / hour}h`
+  return ''
+}
+
+const quotaSubjectKeys: Readonly<Record<string, CredentialQuotaLabelKey>> = {
+  session: 'session',
+  weekly: 'weekly',
+  'extra usage': 'extra_usage',
+  'included usage': 'included_usage',
+  'pay as you go': 'pay_as_you_go',
+  'oauth apps': 'oauth_apps',
+}
+
+function normalizedQuotaLabelPart(value: string): string {
+  return value.trim().toLowerCase().replaceAll('_', ' ').replaceAll('-', ' ')
+}
+
+function quotaWindowLabel(window: CredentialQuotaWindowDto): string {
+  const period = quotaPeriodLabel(window.window_seconds)
+  if (period && window.scope === 'account') return period
+  if (window.label_key) {
+    const key = `group.credentials.subscription.quotaLabels.${window.label_key}`
+    return te(key) ? t(key) : window.label
+  }
+  const parts = window.label
+    .split('·')
+    .map((part) => part.trim())
+    .filter(Boolean)
+  if (parts.length === 0) return period || window.id
+  return parts
+    .map((part) => {
+      const key = quotaSubjectKeys[normalizedQuotaLabelPart(part)]
+      const translationKey = key ? `group.credentials.subscription.quotaLabels.${key}` : ''
+      return translationKey && te(translationKey) ? t(translationKey) : part
+    })
+    .join(' · ')
+}
+
+function quotaValueLabel(window: CredentialQuotaWindowDto): string {
+  const value = remainingPercent(window)
+  if (value !== undefined) {
+    return t('group.credentials.subscription.remainingPercent', { value: n(value) })
+  }
+  if (window.remaining !== undefined && window.limit !== undefined) {
+    return t('group.credentials.subscription.remaining', {
+      remaining: n(window.remaining),
+      limit: n(window.limit),
+    })
+  }
+  if (window.remaining !== undefined) {
+    return t('group.credentials.subscription.remainingAmount', { remaining: n(window.remaining) })
+  }
+  return t('group.credentials.subscription.unknown')
+}
+
+interface QuotaWindowPeriod {
+  startMS: number
+  endMS: number
+}
+
+function quotaWindowPeriod(window: CredentialQuotaWindowDto): QuotaWindowPeriod | undefined {
+  const endMS = window.reset_at_ms
+  const seconds = window.window_seconds
+  if (
+    endMS === undefined ||
+    seconds === undefined ||
+    !Number.isSafeInteger(endMS) ||
+    !Number.isSafeInteger(seconds) ||
+    endMS <= 0 ||
+    seconds <= 0
+  ) {
+    return undefined
+  }
+  const durationMS = seconds * 1_000
+  if (!Number.isSafeInteger(durationMS) || durationMS > endMS) return undefined
+  return { startMS: endMS - durationMS, endMS }
+}
+
+function quotaWindowNeedsRefresh(window: CredentialQuotaWindowDto): boolean {
+  return window.reset_at_ms !== undefined && window.reset_at_ms <= nowMs.value
+}
+
+// 与分组详情页 quotaPeriodTooltip 完全一致：给出周期起止，周期已结束但数据未刷新时
+// 换成「待刷新」提示——而不是一句可能已经过期的相对时间。
+function quotaPeriodTooltip(window: CredentialQuotaWindowDto): string | undefined {
+  const resetAtMS = window.reset_at_ms
+  if (resetAtMS === undefined) return undefined
+  const resetAt = formatLocalInstant(resetAtMS, locale.value)
+  const period = quotaWindowPeriod(window)
+  const periodLabel = period
+    ? t('group.credentials.subscription.quotaPeriod', {
+        start: formatLocalInstant(period.startMS, locale.value),
+        end: resetAt,
+      })
+    : resetAt
+  return quotaWindowNeedsRefresh(window)
+    ? t('group.credentials.subscription.quotaPendingHint', { period: periodLabel })
+    : periodLabel
+}
+
+function quotaTooltip(window: CredentialQuotaWindowDto): string {
+  return [quotaWindowLabel(window), quotaValueLabel(window), quotaPeriodTooltip(window)]
+    .filter((line): line is string => Boolean(line))
+    .join('\n')
+}
+
+const quotaResetPrefix = computed(() => t('group.credentials.subscription.quotaResetPrefix'))
+const quotaResetSuffix = computed(() => t('group.credentials.subscription.quotaResetSuffix'))
+
+// 焦点数字：取当前最紧张的窗口，作为「这个账号现在最该关心的一件事」。
+const lead = computed<{ window: CredentialQuotaWindowDto; percent: number } | undefined>(() => {
+  let best: { window: CredentialQuotaWindowDto; percent: number } | undefined
+  for (const window of quotaWindows.value) {
+    const percent = remainingPercent(window)
+    if (percent === undefined) continue
+    if (best === undefined || percent < best.percent) best = { window, percent }
+  }
+  return best
+})
+const leadTone = computed(() => (lead.value ? quotaTone(lead.value.window) : undefined))
+
+const resetCreditsAvailable = computed(() => snapshot.value?.reset_credits_available ?? 0)
+const resetCredits = computed(() => snapshot.value?.reset_credits ?? [])
+const availableResetCreditDetails = computed(() =>
+  resetCredits.value.slice(0, resetCreditsAvailable.value),
+)
+const hasResetCredits = computed(
+  () =>
+    props.account.capabilities.credential_actions.includes('reset_credit') &&
+    resetCreditsAvailable.value > 0,
+)
+
+// 点阵最多画 5 个，避免账号数多、卡片窄时被点阵撑爆；确切张数留给 tooltip 与读屏文本。
+const resetCreditDots = computed(() =>
+  Array.from({ length: Math.min(resetCreditsAvailable.value, 5) }, (_, index) => {
+    const expiresAtMS = availableResetCreditDetails.value[index]?.expires_at_ms
+    let tone: ResetCreditDotTone = 'default'
+    if (expiresAtMS !== undefined) {
+      const remainingMS = expiresAtMS - nowMs.value
+      tone =
+        remainingMS <= 24 * 60 * 60 * 1_000
+          ? 'danger'
+          : remainingMS <= 48 * 60 * 60 * 1_000
+            ? 'warning'
+            : 'default'
+    }
+    return { index, tone }
+  }),
+)
+
+function resetCreditExpiryLabel(credit: (typeof resetCredits.value)[number]): string {
+  if (credit.expires_at_ms === undefined) {
+    return t('group.credentials.subscription.resetCreditPermanent')
+  }
+  if (credit.expires_at_ms <= nowMs.value) {
+    return t('group.credentials.subscription.resetCreditExpired')
+  }
+  return formatLocalInstant(credit.expires_at_ms, locale.value)
+}
+
+// 与分组详情页一致：一枚 tooltip 覆盖全部重置卡（标题 + 逐张到期时间），而不是逐点悬浮。
+const resetCreditsTooltip = computed(() => {
+  const lines = availableResetCreditDetails.value.length
+    ? availableResetCreditDetails.value.map((credit, index) =>
+        t('group.credentials.subscription.resetCreditsTooltipItem', {
+          index: index + 1,
+          expires: resetCreditExpiryLabel(credit),
+        }),
+      )
+    : [t('group.credentials.subscription.resetCreditsTooltipNoDetails')]
+  const knownCount = availableResetCreditDetails.value.length
+  if (knownCount < resetCreditsAvailable.value) {
+    lines.push(
+      t('group.credentials.subscription.resetCreditsTooltipMore', {
+        count: n(resetCreditsAvailable.value - knownCount),
+      }),
+    )
+  }
+  return [t('group.credentials.subscription.resetCreditsTooltipTitle'), ...lines].join('\n')
+})
+</script>
+
+<template>
+  <article
+    class="home-subscription-mini"
+    :class="{ 'home-subscription-mini--off': unifiedStatus === 'disabled' }"
+    :aria-label="`${accountName} · ${statusLabel}`"
+  >
+    <span class="sr-only">{{ statusLabel }}</span>
+
+    <div class="home-subscription-mini__top">
+      <span class="home-subscription-mini__channel" role="img" :aria-label="channelTooltip">
+        <ChannelIcon :icon="account.channel_icon" :mark="account.channel_mark" />
+      </span>
+      <OverflowTooltip class="home-subscription-mini__account" :content="accountName">
+        {{ accountName }}
+      </OverflowTooltip>
+      <span v-if="planLabel" class="home-subscription-mini__plan">{{ planLabel }}</span>
+    </div>
+
+    <div class="home-subscription-mini__lead">
+      <StatusBadge
+        v-if="showStatusChip"
+        class="home-subscription-mini__status"
+        :tone="cardTone"
+        :icon="displayDisabled ? 'off' : undefined"
+        size="compact"
+      >
+        {{ statusLabel }}
+      </StatusBadge>
+      <span
+        v-else-if="lead"
+        class="home-subscription-mini__num"
+        :class="`home-subscription-mini__num--${leadTone ?? 'unknown'}`"
+      >
+        <strong>{{ n(lead.percent) }}</strong
+        ><span aria-hidden="true">%</span>
+      </span>
+      <span v-else class="home-subscription-mini__num home-subscription-mini__num--empty">—</span>
+
+      <span class="home-subscription-mini__meta">
+        <template v-if="lead">
+          {{ quotaWindowLabel(lead.window) }}
+          <template v-if="lead.window.reset_at_ms">
+            ·
+            <AppTooltip
+              v-if="quotaWindowNeedsRefresh(lead.window)"
+              :content="quotaPeriodTooltip(lead.window) ?? ''"
+            >
+              <span class="home-subscription-mini__pending" tabindex="0">{{
+                t('group.credentials.subscription.quotaPendingRefresh')
+              }}</span>
+            </AppTooltip>
+            <template v-else>
+              <span v-if="quotaResetPrefix">{{ quotaResetPrefix }}</span>
+              <AppRelativeTime
+                :instant="lead.window.reset_at_ms"
+                :locale="locale"
+                :empty-label="t('group.credentials.subscription.unknown')"
+                :tooltip-content="quotaPeriodTooltip(lead.window)"
+                hint
+              /><span v-if="quotaResetSuffix">{{ quotaResetSuffix }}</span>
+            </template>
+          </template>
+        </template>
+        <template v-else>{{ t('group.credentials.subscription.noQuota') }}</template>
+      </span>
+    </div>
+
+    <div
+      v-if="quotaWindows.length > 1 || hasResetCredits"
+      class="home-subscription-mini__resources"
+    >
+      <div
+        v-if="quotaWindows.length > 1"
+        class="home-subscription-mini__strip"
+        role="group"
+        :aria-label="t('group.credentials.subscription.title')"
+      >
+        <AppTooltip v-for="window in quotaWindows" :key="window.id" :content="quotaTooltip(window)">
+          <span
+            class="home-subscription-mini__seg"
+            :class="`home-subscription-mini__seg--${quotaTone(window) ?? 'unknown'}`"
+            :role="remainingPercent(window) === undefined ? 'img' : 'progressbar'"
+            :aria-label="quotaTooltip(window)"
+            :aria-valuemin="remainingPercent(window) === undefined ? undefined : 0"
+            :aria-valuemax="remainingPercent(window) === undefined ? undefined : 100"
+            :aria-valuenow="remainingPercent(window)"
+            tabindex="0"
+          >
+            <span
+              v-if="remainingPercent(window) !== undefined"
+              class="home-subscription-mini__seg-fill"
+              :style="quotaFillStyle(window)"
+              aria-hidden="true"
+            ></span>
+          </span>
+        </AppTooltip>
+      </div>
+      <span v-else class="home-subscription-mini__spacer" aria-hidden="true"></span>
+
+      <AppTooltip v-if="hasResetCredits" :content="resetCreditsTooltip">
+        <span
+          class="home-subscription-mini__credits"
+          tabindex="0"
+          :aria-label="resetCreditsTooltip"
+        >
+          <i
+            v-for="dot in resetCreditDots"
+            :key="dot.index"
+            class="home-subscription-mini__credit-dot"
+            :class="`home-subscription-mini__credit-dot--${dot.tone}`"
+          ></i>
+          <span
+            v-if="resetCreditsAvailable > resetCreditDots.length"
+            class="home-subscription-mini__credit-more"
+            aria-hidden="true"
+            >+</span
+          >
+        </span>
+      </AppTooltip>
+    </div>
+  </article>
+</template>
+
+<style scoped>
+.home-subscription-mini {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 8px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-control);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-card);
+  padding: 10px 11px;
+}
+
+.home-subscription-mini--off {
+  background: var(--color-surface-sunken);
+}
+
+.home-subscription-mini--off .home-subscription-mini__account,
+.home-subscription-mini--off .home-subscription-mini__meta {
+  color: var(--color-text-faint);
+}
+
+.home-subscription-mini__top {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 7px;
+}
+
+.home-subscription-mini__channel {
+  display: inline-flex;
+  width: 16px;
+  height: 16px;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.home-subscription-mini__seg:focus-visible,
+.home-subscription-mini__credits:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.home-subscription-mini__channel :deep(.channel-icon) {
+  width: 16px;
+  height: 16px;
+  font-size: 16px;
+}
+
+.home-subscription-mini__account {
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+  color: var(--color-text);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  line-height: 16px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.home-subscription-mini__plan {
+  flex: none;
+  border-radius: 5px;
+  background: var(--color-tag);
+  padding: 1px 6px;
+  color: var(--color-text-muted);
+  font-size: var(--text-label-xs);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.home-subscription-mini__lead {
+  display: flex;
+  align-items: flex-end;
+  gap: 7px;
+}
+
+.home-subscription-mini__num {
+  display: inline-flex;
+  flex: none;
+  align-items: baseline;
+  gap: 1px;
+  font-variant-numeric: tabular-nums;
+}
+
+.home-subscription-mini__num strong {
+  font-size: 25px;
+  font-weight: 640;
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+
+.home-subscription-mini__num span {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+/* 与分组详情页 SubscriptionAccountCard 的配额条同一套强调色（oklch，单值适配明暗），
+   而非通用状态语义色——这三个数值代表的是额度剩余量，不是运行状态。 */
+.home-subscription-mini__num--success {
+  color: oklch(70% 0.16 158);
+}
+
+.home-subscription-mini__num--warning {
+  color: oklch(75% 0.152 75);
+}
+
+.home-subscription-mini__num--danger {
+  color: oklch(65% 0.2 22);
+}
+
+.home-subscription-mini__num--unknown {
+  color: var(--color-text-faint);
+}
+
+.home-subscription-mini__num--empty {
+  color: var(--color-text-faint);
+  font-size: 21px;
+  font-weight: 500;
+  line-height: 1;
+}
+
+.home-subscription-mini__meta {
+  display: block;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  padding-bottom: 3px;
+  color: var(--color-text-faint);
+  font-size: var(--text-label-xs);
+  line-height: 1.3;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.home-subscription-mini__meta :deep(.app-relative-time--hint) {
+  text-decoration-color: var(--color-border-control);
+}
+
+.home-subscription-mini__pending {
+  cursor: help;
+  text-decoration: underline dotted;
+  text-decoration-color: var(--color-border-control);
+  text-underline-offset: 3px;
+}
+
+.home-subscription-mini__pending:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.home-subscription-mini__resources {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  row-gap: 6px;
+  flex-wrap: wrap;
+}
+
+.home-subscription-mini__status {
+  flex: none;
+}
+
+.home-subscription-mini__strip {
+  display: flex;
+  min-width: 32px;
+  flex: 1 1 32px;
+  align-items: center;
+  gap: 4px;
+}
+
+.home-subscription-mini__spacer {
+  flex: 1 1 auto;
+}
+
+.home-subscription-mini__seg {
+  position: relative;
+  display: block;
+  flex: 1 1 0;
+  height: 4px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--seg-track, var(--color-surface-sunken));
+  cursor: help;
+}
+
+/* 与分组详情页 SubscriptionAccountCard 的配额条同一套颜色值（quota--success/warning/
+   danger），保持首页摘要与分组详情页对同一份额度数据的视觉表达一致。 */
+.home-subscription-mini__seg--success {
+  --seg-track: light-dark(#dcfeea, #112b21);
+  --seg-fill: oklch(70% 0.16 158);
+}
+
+.home-subscription-mini__seg--warning {
+  --seg-track: light-dark(#fff2e2, #302212);
+  --seg-fill: oklch(75% 0.152 75);
+}
+
+.home-subscription-mini__seg--danger {
+  --seg-track: light-dark(#fef0f0, #371a1d);
+  --seg-fill: oklch(65% 0.2 22);
+}
+
+.home-subscription-mini__seg-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  border-radius: inherit;
+  background: var(--seg-fill, var(--color-border-control));
+  transition: width var(--duration-fast) var(--easing-standard);
+}
+
+.home-subscription-mini__credits {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  gap: 3px;
+  cursor: help;
+}
+
+.home-subscription-mini__credit-dot {
+  width: 6px;
+  height: 6px;
+  flex: none;
+  border-radius: 50%;
+  background: var(--color-action);
+}
+
+.home-subscription-mini__credit-dot--warning {
+  background: var(--color-warning);
+}
+
+.home-subscription-mini__credit-dot--danger {
+  background: var(--color-danger);
+}
+
+.home-subscription-mini__credit-more {
+  color: var(--color-text-faint);
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-subscription-mini__seg-fill {
+    transition: none;
+  }
+}
+</style>

--- a/web/src/features/home/HomeSubscriptionAccountMiniCard.vue
+++ b/web/src/features/home/HomeSubscriptionAccountMiniCard.vue
@@ -302,13 +302,15 @@ function quotaTooltip(window: CredentialQuotaWindowDto): string {
 const quotaResetPrefix = computed(() => t('group.credentials.subscription.quotaResetPrefix'))
 const quotaResetSuffix = computed(() => t('group.credentials.subscription.quotaResetSuffix'))
 
-// 焦点窗口：额度百分比已知的窗口里剩余最少的那个，在全部窗口（而非展示截断后
-// 的 quotaWindows）中查找，避免真正最紧张的窗口因排序被截断而漏判。上游只给出
-// state、没有具体数值的窗口（Codex/Claude 都存在）仍要退回展示，只是百分比留空，
-// 不能因为找不到数值就当成完全没有额度窗口。
+// 焦点窗口：明确耗尽的窗口优先，即使上游没有提供百分比；否则在全部窗口（而非
+// 展示截断后的 quotaWindows）中选择剩余百分比最低者。这样状态角标、窗口名称与
+// 重置时间始终指向同一条真正受限的额度窗口。
 const lead = computed<
   { window: CredentialQuotaWindowDto; percent: number | undefined } | undefined
 >(() => {
+  const exhausted = sortedQuotaWindows.value.find((window) => window.state === 'exhausted')
+  if (exhausted) return { window: exhausted, percent: remainingPercent(exhausted) }
+
   let best: { window: CredentialQuotaWindowDto; percent: number } | undefined
   for (const window of sortedQuotaWindows.value) {
     const percent = remainingPercent(window)

--- a/web/src/features/home/HomeSubscriptionAccountMiniCard.vue
+++ b/web/src/features/home/HomeSubscriptionAccountMiniCard.vue
@@ -385,7 +385,7 @@ const resetCreditsTooltip = computed(() => {
 <template>
   <article
     class="home-subscription-mini"
-    :class="{ 'home-subscription-mini--off': unifiedStatus === 'disabled' }"
+    :class="{ 'home-subscription-mini--off': displayDisabled }"
     :aria-label="`${accountName} · ${statusLabel}`"
   >
     <span class="sr-only">{{ statusLabel }}</span>
@@ -417,6 +417,13 @@ const resetCreditsTooltip = computed(() => {
       >
         <strong>{{ n(lead.percent) }}</strong
         ><span aria-hidden="true">%</span>
+      </span>
+      <span
+        v-else-if="lead && lead.window.remaining !== undefined"
+        class="home-subscription-mini__num home-subscription-mini__num--amount"
+        :class="`home-subscription-mini__num--${leadTone ?? 'unknown'}`"
+      >
+        {{ quotaValueLabel(lead.window) }}
       </span>
       <span v-else class="home-subscription-mini__num home-subscription-mini__num--empty">—</span>
 
@@ -603,6 +610,15 @@ const resetCreditsTooltip = computed(() => {
 .home-subscription-mini__num span {
   font-size: 12px;
   font-weight: 600;
+}
+
+.home-subscription-mini__num--amount {
+  max-width: 9em;
+  overflow: hidden;
+  font-size: var(--text-sm);
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* 与分组详情页 SubscriptionAccountCard 的配额条同一套强调色（oklch，单值适配明暗），

--- a/web/src/features/home/HomeSubscriptionAccounts.vue
+++ b/web/src/features/home/HomeSubscriptionAccounts.vue
@@ -41,22 +41,16 @@ const { t } = useI18n()
 }
 
 /*
- * 桌面端只占一行：卡片给定基准宽度而非等分整行宽度，够 4 张时都拉伸到舒适宽度，
- * 超过时横向滚动，绝不换成第二行。窄视口下基准宽度撑不满屏，天然退化为可滚动的
- * 横向列表，无需为移动端单独处理。
+ * 不做横向滚动：每列至少 232px，页面满宽时正好排出 4 列；宽度不够（含移动端）时
+ * auto-fill 自动减少列数并换行，同一份规则覆盖桌面到移动端，无需单独断点。
  */
 .home-subscription-accounts__row {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(232px, 1fr));
   gap: 10px;
-  overflow-x: auto;
-  overscroll-behavior-inline: contain;
-  padding-bottom: 2px;
-  scroll-snap-type: x proximity;
 }
 
 .home-subscription-accounts__row > * {
-  min-width: 208px;
-  flex: 1 1 232px;
-  scroll-snap-align: start;
+  min-width: 0;
 }
 </style>

--- a/web/src/features/home/HomeSubscriptionAccounts.vue
+++ b/web/src/features/home/HomeSubscriptionAccounts.vue
@@ -2,17 +2,13 @@
 import { useI18n } from 'vue-i18n'
 
 import type { HomeSubscriptionAccountsDto } from '@/app/resources/home'
-import SubscriptionAccountCard from '@/features/groups/credentials/SubscriptionAccountCard.vue'
 
+import HomeSubscriptionAccountMiniCard from './HomeSubscriptionAccountMiniCard.vue'
 import HomeSectionHeading from './HomeSectionHeading.vue'
 
 defineProps<{ accounts: HomeSubscriptionAccountsDto }>()
 
 const { t } = useI18n()
-
-function ignoreReadonlyProxyMutation(): Promise<void> {
-  return Promise.resolve()
-}
 </script>
 
 <template>
@@ -25,25 +21,11 @@ function ignoreReadonlyProxyMutation(): Promise<void> {
       id="home-subscription-accounts-title"
       :title="t('home.ledger.subscriptionAccounts.title')"
     />
-    <div class="home-subscription-accounts__grid">
-      <SubscriptionAccountCard
+    <div class="home-subscription-accounts__row">
+      <HomeSubscriptionAccountMiniCard
         v-for="account in accounts.items"
         :key="`${account.channel_id}-${account.credential.credential_id}`"
-        :item="account.credential"
-        :selected="false"
-        :busy="false"
-        :refreshing-observation="false"
-        observation-error=""
-        :detail-busy="false"
-        :detail-loaded="false"
-        detail-error=""
-        :channel-icon="account.channel_icon"
-        :channel-mark="account.channel_mark"
-        :capabilities="account.capabilities"
-        :save-proxy="ignoreReadonlyProxyMutation"
-        :group-count="account.group_count"
-        :available-group-count="account.available_group_count"
-        readonly
+        :account="account"
       />
     </div>
   </section>
@@ -58,16 +40,23 @@ function ignoreReadonlyProxyMutation(): Promise<void> {
   padding-top: 20px;
 }
 
-.home-subscription-accounts__grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(420px, 1fr));
-  align-items: start;
-  gap: var(--space-3);
+/*
+ * 桌面端只占一行：卡片给定基准宽度而非等分整行宽度，够 4 张时都拉伸到舒适宽度，
+ * 超过时横向滚动，绝不换成第二行。窄视口下基准宽度撑不满屏，天然退化为可滚动的
+ * 横向列表，无需为移动端单独处理。
+ */
+.home-subscription-accounts__row {
+  display: flex;
+  gap: 10px;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  padding-bottom: 2px;
+  scroll-snap-type: x proximity;
 }
 
-@media (max-width: 680px) {
-  .home-subscription-accounts__grid {
-    grid-template-columns: minmax(0, 1fr);
-  }
+.home-subscription-accounts__row > * {
+  min-width: 208px;
+  flex: 1 1 232px;
+  scroll-snap-align: start;
 }
 </style>

--- a/web/src/features/home/HomeSubscriptionAccounts.vue
+++ b/web/src/features/home/HomeSubscriptionAccounts.vue
@@ -41,8 +41,9 @@ const { t } = useI18n()
 }
 
 /*
- * 不做横向滚动：每列至少 232px，页面满宽时正好排出 4 列；宽度不够（含移动端）时
- * auto-fill 自动减少列数并换行，同一份规则覆盖桌面到移动端，无需单独断点。
+ * 后端最多返回 4 个账号（homeSubscriptionAccountLimit），配合每列至少 232px：
+ * 桌面宽度下正好排出 4 列，4 个账号天然一行放完，不会换行也不需要横向滚动；
+ * 宽度不够（含移动端）时 auto-fill 自动减少列数，多出的账号才换到下一行。
  */
 .home-subscription-accounts__row {
   display: grid;

--- a/web/src/i18n/locales/en-US/core.ts
+++ b/web/src/i18n/locales/en-US/core.ts
@@ -290,8 +290,7 @@ export default {
         action: 'Resolve',
       },
       subscriptionAccounts: {
-        title: 'Recently used subscription accounts',
-        groupCount: 'Groups: {count}',
+        title: 'Recently used',
         availableGroups: '{available}/{total} available',
       },
       spend: {

--- a/web/src/i18n/locales/ja-JP/core.ts
+++ b/web/src/i18n/locales/ja-JP/core.ts
@@ -288,8 +288,7 @@ export default {
         action: '対応',
       },
       subscriptionAccounts: {
-        title: '最近使用したサブスクリプションアカウント',
-        groupCount: '{count} グループ',
+        title: '最近よく使う',
         availableGroups: '{available}/{total} 利用可能',
       },
       spend: {

--- a/web/src/i18n/locales/zh-CN/core.ts
+++ b/web/src/i18n/locales/zh-CN/core.ts
@@ -275,8 +275,7 @@ export default {
         action: '处理',
       },
       subscriptionAccounts: {
-        title: '最近常用订阅账号',
-        groupCount: '{count} 个分组',
+        title: '最近常用',
         availableGroups: '{available}/{total} 可用',
       },
       spend: {


### PR DESCRIPTION
### 关联 Issue / Related Issue
无关联 Issue（自发起的首页视觉改进）

### 变更内容 / Change Content
- [ ] Bug 修复 / Bug fix
- [x] 新功能 / New feature
- [x] 其他改动 / Other changes

首页「最近常用」订阅账号卡片重新设计，并清理由此产生的死代码。

**新卡片设计**（`HomeSubscriptionAccountMiniCard.vue`，完全重写）
- 三行结构：身份行（渠道图标 + 邮箱 + 套餐）/ 焦点数字行（当前最紧张的额度窗口百分比，异常时由状态角标接管） / 资源行（分段进度条 + 重置卡点阵）
- 原实现问题：整卡按状态染色、彩色进度条无标签只能靠 hover、条数不定导致高度留白、等宽重字号邮箱易截断、卡片宽度随账号数漂移、缺套餐档位与重置时间
- 状态展示：仅异常状态或多分组聚合可用性值得一提时显示角标，并直接接管数字主位（不叠加百分比文字），正常态保持安静
- 重置卡改为纯点阵（不带"N 张"文字），封顶 5 个，准确数量与到期时间留给 tooltip 与读屏文本
- 进度条 / 重置卡点阵 / "N 天后重置" 的鼠标提示均对齐分组详情页 `SubscriptionAccountCard.vue` 的既有行为，配额相关配色也改用其专属 oklch 强调色（而非通用状态语义色），与分组详情页保持一致
- 桌面端固定一行展示（横向滚动，不换行），窄屏自然退化为可滚动列表

**容器与后端**
- `HomeSubscriptionAccounts.vue`：布局改为横向单行滚动
- 首页展示上限由 4 提升到 6，新增 `channel_name` 字段供卡片提示文案使用

**清理死代码**（`SubscriptionAccountCard.vue`）
- 首页不再复用这个只读大卡片组件后，其 `readonly` / `groupCount` / `availableGroupCount` 分支在现存唯一调用方（`GroupCredentialsTab.vue`）中从未被触发，属运行时死代码，一并删除（含相关 computed、模板分支、CSS 及仅被其引用的 i18n key）

**文案**
- 板块标题精简：「最近常用订阅账号」→「最近常用」（三语言同步）

### 验证
- `make check` 全量通过（gofmt / go vet / go mod tidy -diff / 全量 `go test -count=1` / 前端 lint / format / build）
- 未做浏览器级视觉走查（当前环境无浏览器工具），建议合并前用 `make dev` 配真实数据过一遍：长邮箱截断、无额度窗口、cooldown 但额度充足、9 张重置卡等边界场景

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。
- [x] 本 PR 范围聚焦，未包含无关改动。
- [x] 我已更新必要的公开文档或发布说明。（纯前端视觉与文案调整，无公开文档需要更新）
- [x] 我已确认提交、日志和测试数据不包含敏感信息。
- [x] 如适用，我已说明兼容性或数据迁移影响。（仅新增响应字段与展示数量上限，非破坏性变更，无数据迁移）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 首页最近使用的订阅账号最多展示 4 个。
  * 账号卡片新增频道名称、套餐信息、配额进度、重置时间及状态提示。
  * 支持选择、同步、操作菜单、额度重置和详情查看等交互。
* **界面优化**
  * 优化卡片网格布局，适配不同屏幕宽度。
  * 简化板块标题，统一多语言文案，提升可读性与可访问性。
  * 配额状态与刷新提示展示更加清晰。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->