### PR TITLE
fix(home): 同步套餐徽标等级配色

### DIFF
--- a/web/src/features/home/HomeSubscriptionAccountMiniCard.vue
+++ b/web/src/features/home/HomeSubscriptionAccountMiniCard.vue
@@ -50,6 +50,7 @@ const credential = computed<CredentialItemDto>(() => props.account.credential)
 const snapshot = computed(() => credential.value.observation?.snapshot)
 const accountName = computed(() => credential.value.account.email ?? credential.value.mask)
 const planLabel = computed(() => snapshot.value?.plan_summary.name?.trim() ?? '')
+const planLevel = computed(() => snapshot.value?.plan_summary.level ?? 'unknown')
 const channelTooltip = computed(() =>
   [props.account.channel_name, planLabel.value].filter(Boolean).join(' · '),
 )
@@ -399,7 +400,13 @@ const resetCreditsTooltip = computed(() => {
       <OverflowTooltip class="home-subscription-mini__account" :content="accountName">
         {{ accountName }}
       </OverflowTooltip>
-      <span v-if="planLabel" class="home-subscription-mini__plan">{{ planLabel }}</span>
+      <span
+        v-if="planLabel"
+        class="home-subscription-mini__plan"
+        :class="`home-subscription-mini__plan--${planLevel}`"
+      >
+        {{ planLabel }}
+      </span>
     </div>
 
     <div class="home-subscription-mini__lead">
@@ -580,12 +587,32 @@ const resetCreditsTooltip = computed(() => {
 .home-subscription-mini__plan {
   flex: none;
   border-radius: 5px;
-  background: var(--color-tag);
+  background: var(--color-neutral-bg);
   padding: 1px 6px;
-  color: var(--color-text-muted);
+  color: var(--color-neutral);
   font-size: var(--text-label-xs);
   font-weight: 600;
   white-space: nowrap;
+}
+
+.home-subscription-mini__plan--free {
+  background: var(--color-neutral-bg);
+  color: var(--color-neutral);
+}
+
+.home-subscription-mini__plan--standard {
+  background: var(--color-success-bg);
+  color: var(--color-success);
+}
+
+.home-subscription-mini__plan--premium {
+  background: var(--color-action-soft);
+  color: var(--color-action);
+}
+
+.home-subscription-mini__plan--elite {
+  background: var(--color-warning-bg);
+  color: var(--color-warning);
 }
 
 .home-subscription-mini__lead {


### PR DESCRIPTION
### 关联 Issue / Related Issue
<!-- 请填写此 PR 关联的 issue 编号，例如：Closes #123 / Please link the issue number, e.g., Closes #123 -->
Closes #

### 变更内容 / Change Content
<!-- 请简要描述本次变更的核心内容 / Please briefly describe the core changes of this PR -->
- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

统一首页“最近常用”订阅账号卡片的套餐徽标配色。首页按 plan_summary.level 使用与分组账号卡片相同的 free、standard、premium、elite 配色；保留原有排版、尺寸和文案。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [ ] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive information.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented any compatibility or data-migration impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式**
  - 优化首页订阅账户卡片的套餐标签样式。
  - 根据免费版、标准版、高级版和尊享版显示不同的语义颜色。
  - 对未知套餐等级提供默认样式，提升信息识别度。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->