### PR TITLE
feat(group): 增加模型同步与清理

### DIFF
--- a/web/src/features/groups/models/GroupModelSyncDialog.vue
+++ b/web/src/features/groups/models/GroupModelSyncDialog.vue
@@ -1,0 +1,238 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import type { ModelCandidate } from '@/app/resources/providers'
+import AppConfirmDialog from '@/components/ui/AppConfirmDialog.vue'
+import InlineFeedback from '@/components/ui/InlineFeedback.vue'
+import SegmentedControl, { type SegmentedControlOption } from '@/components/ui/SegmentedControl.vue'
+
+import type { ModelDraftItem, ModelNameConflict, ModelSyncMode } from './model-diff'
+
+const props = defineProps<{
+  open: boolean
+  mode: ModelSyncMode
+  additions: readonly ModelCandidate[]
+  removals: readonly ModelDraftItem[]
+  conflicts: readonly ModelNameConflict[]
+  pending: boolean
+  error: string
+}>()
+const emit = defineEmits<{
+  'update:open': [open: boolean]
+  'update:mode': [mode: ModelSyncMode]
+  confirm: []
+}>()
+const { t } = useI18n()
+const previewLimit = 40
+
+const modeOptions = computed<SegmentedControlOption[]>(() =>
+  (['full', 'cleanup', 'add'] as const).map((value) => ({
+    value,
+    label: t(`group.modelEditor.sync.mode.${value}`),
+    disabled: props.pending,
+  })),
+)
+const showAdditions = computed(() => props.mode === 'add' || props.mode === 'full')
+const showRemovals = computed(() => props.mode === 'cleanup' || props.mode === 'full')
+const activeAdditions = computed(() => (showAdditions.value ? props.additions : []))
+const activeRemovals = computed(() => (showRemovals.value ? props.removals : []))
+const additionPreview = computed(() => activeAdditions.value.slice(0, previewLimit))
+const removalPreview = computed(() => activeRemovals.value.slice(0, previewLimit))
+const additionRemainder = computed(
+  () => activeAdditions.value.length - additionPreview.value.length,
+)
+const removalRemainder = computed(() => activeRemovals.value.length - removalPreview.value.length)
+const changeCount = computed(() => activeAdditions.value.length + activeRemovals.value.length)
+const conflictNames = computed(() =>
+  props.conflicts.map(({ client_model }) => client_model).join(', '),
+)
+
+function setMode(value: string): void {
+  if (value === 'cleanup' || value === 'add' || value === 'full') emit('update:mode', value)
+}
+</script>
+
+<template>
+  <AppConfirmDialog
+    appearance="ledger"
+    :open="open"
+    :title="t('group.modelEditor.sync.title')"
+    :description="t('group.modelEditor.sync.description')"
+    :close-label="t('group.modelEditor.sync.close')"
+    :cancel-label="t('common.cancel')"
+    :confirm-label="t('group.modelEditor.sync.confirm')"
+    description-tone="warning"
+    :tone="activeRemovals.length ? 'danger' : 'default'"
+    :pending="pending"
+    :confirm-disabled="changeCount === 0 || conflicts.length > 0"
+    @update:open="emit('update:open', $event)"
+    @confirm="emit('confirm')"
+  >
+    <div class="group-model-sync">
+      <SegmentedControl
+        :class="['group-model-sync__modes', `group-model-sync__modes--${mode}`]"
+        :model-value="mode"
+        :label="t('group.modelEditor.sync.modeLabel')"
+        :options="modeOptions"
+        controls-id="group-model-sync-changes"
+        id-prefix="group-model-sync-mode"
+        appearance="drawer"
+        size="sm"
+        @update:model-value="setMode"
+      />
+
+      <div
+        id="group-model-sync-changes"
+        class="group-model-sync__changes"
+        role="tabpanel"
+        :aria-labelledby="`group-model-sync-mode-${mode}`"
+      >
+        <section
+          v-if="showAdditions"
+          class="group-model-sync__section group-model-sync__section--addition"
+        >
+          <strong>{{
+            t('group.modelEditor.sync.additions', { count: activeAdditions.length })
+          }}</strong>
+          <ul v-if="additionPreview.length">
+            <li v-for="candidate in additionPreview" :key="candidate.id">
+              <code>{{ candidate.id }}</code>
+            </li>
+          </ul>
+          <span v-else class="group-model-sync__empty">{{
+            t('group.modelEditor.sync.noAdditions')
+          }}</span>
+          <span v-if="additionRemainder" class="group-model-sync__remainder">{{
+            t('group.modelEditor.sync.more', { count: additionRemainder })
+          }}</span>
+        </section>
+
+        <section
+          v-if="showRemovals"
+          class="group-model-sync__section group-model-sync__section--removal"
+        >
+          <strong>{{
+            t('group.modelEditor.sync.removals', { count: activeRemovals.length })
+          }}</strong>
+          <ul v-if="removalPreview.length">
+            <li v-for="model in removalPreview" :key="model.key">
+              <code>{{ model.id }}</code>
+              <template v-if="model.alias_enabled">
+                <span aria-hidden="true">→</span>
+                <code>{{ model.alias }}</code>
+              </template>
+            </li>
+          </ul>
+          <span v-else class="group-model-sync__empty">{{
+            t('group.modelEditor.sync.noRemovals')
+          }}</span>
+          <span v-if="removalRemainder" class="group-model-sync__remainder">{{
+            t('group.modelEditor.sync.more', { count: removalRemainder })
+          }}</span>
+        </section>
+      </div>
+
+      <InlineFeedback v-if="conflicts.length" tone="danger">
+        {{ t('group.modelEditor.sync.conflict', { names: conflictNames }) }}
+      </InlineFeedback>
+      <InlineFeedback v-if="error" tone="danger">{{ error }}</InlineFeedback>
+    </div>
+  </AppConfirmDialog>
+</template>
+
+<style scoped>
+.group-model-sync,
+.group-model-sync__changes {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.group-model-sync__modes {
+  width: 100%;
+}
+
+.group-model-sync__modes :deep(.segmented-control__list) {
+  width: 100%;
+}
+
+.group-model-sync__modes :deep(.segmented-control__trigger) {
+  min-width: 0;
+  flex: 1;
+}
+
+.group-model-sync__modes--cleanup :deep(.segmented-control__trigger[data-state='active']) {
+  background: var(--color-danger-bg);
+  color: var(--color-danger);
+}
+
+.group-model-sync__modes--add :deep(.segmented-control__trigger[data-state='active']) {
+  background: var(--color-success-bg);
+  color: var(--color-success);
+}
+
+.group-model-sync__section {
+  display: grid;
+  gap: var(--space-2);
+  overflow: hidden;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-control);
+  padding: 10px 11px;
+}
+
+.group-model-sync__section--addition {
+  border-color: color-mix(in srgb, var(--color-success) 32%, var(--color-border-subtle));
+  border-left-width: 3px;
+  background: color-mix(in srgb, var(--color-success-bg) 72%, var(--color-surface));
+}
+
+.group-model-sync__section--removal {
+  border-color: color-mix(in srgb, var(--color-danger) 32%, var(--color-border-subtle));
+  border-left-width: 3px;
+  background: color-mix(in srgb, var(--color-danger-bg) 72%, var(--color-surface));
+}
+
+.group-model-sync__section > strong {
+  font-size: var(--text-sm);
+}
+
+.group-model-sync__section--addition > strong {
+  color: var(--color-success);
+}
+
+.group-model-sync__section--removal > strong {
+  color: var(--color-danger);
+}
+
+.group-model-sync__section ul {
+  display: grid;
+  max-height: 150px;
+  gap: 5px;
+  margin: 0;
+  overflow-y: auto;
+  padding: 0;
+  list-style: none;
+}
+
+.group-model-sync__section li {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+  color: var(--color-text);
+  font-size: var(--text-sm);
+}
+
+.group-model-sync__section code {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.group-model-sync__empty,
+.group-model-sync__remainder {
+  color: var(--color-text-faint);
+  font-size: var(--text-sm);
+}
+</style>

--- a/web/src/features/groups/models/GroupModelsTab.vue
+++ b/web/src/features/groups/models/GroupModelsTab.vue
@@ -15,6 +15,7 @@ import {
   groupModelsQueryOptions,
   invalidateGroupModelDependents,
   replaceGroupModelsResource,
+  type GroupModelsDto,
 } from '@/app/resources/groups'
 import type { ModelCandidate } from '@/app/resources/providers'
 import { useUnsavedChanges } from '@/app/unsaved-changes'
@@ -39,13 +40,17 @@ import {
 } from '@/features/models/model-draft'
 import ModelPricingStatus from '@/features/models/ModelPricingStatus.vue'
 
+import GroupModelSyncDialog from './GroupModelSyncDialog.vue'
 import {
+  createModelSyncDiff,
   createModelDraft,
   findModelNameConflicts,
   normalizedModels,
   sameModels,
+  syncedModels,
   type ModelDraftItem,
   type ModelNameConflict,
+  type ModelSyncMode,
 } from './model-diff'
 import {
   parseGroupModelsRouteQuery,
@@ -74,8 +79,9 @@ const initialLoading = useStableLoading(
 const queryRefreshing = computed(() => query.data.value !== undefined && query.isFetching.value)
 const saved = ref<ModelDraftItem[]>([])
 const draft = ref<ModelDraftItem[]>([])
-const pending = ref<'discover' | 'save' | null>(null)
+const pending = ref<'discover' | 'save' | 'sync' | null>(null)
 const discoveryError = ref('')
+const discoveryReady = ref(false)
 const saveError = ref('')
 const serverConflicts = ref<ModelNameConflict[]>([])
 const drawerOpen = computed(() => routeState.value.discoveryOpen)
@@ -85,6 +91,9 @@ const modelEditor = ref<{
 }>()
 const emptyConfirmOpen = ref(false)
 const candidates = ref<ModelCandidate[]>([])
+const syncDialogOpen = ref(false)
+const syncMode = ref<ModelSyncMode>('full')
+const syncError = ref('')
 const {
   value: savedFeedback,
   clear: clearSavedFeedback,
@@ -132,6 +141,7 @@ const dirty = computed(
     !sameModels(saved.value, draft.value) ||
     draft.value.some((item) => item.editable_id && !item.id.trim()),
 )
+const savePending = computed(() => pending.value === 'save' || pending.value === 'sync')
 const empty = computed(() => normalizedModels(draft.value).length === 0)
 const canSave = computed(
   () =>
@@ -147,6 +157,18 @@ const pendingPricingCount = computed(
 const currentModelIDs = computed(() => draft.value.map((item) => item.id.trim()).filter(Boolean))
 const knownPricingStatusByID = computed(
   () => new Map(saved.value.map((item) => [item.id, item.pricing_status] as const)),
+)
+const syncDiff = computed(() => createModelSyncDiff(saved.value, candidates.value))
+const syncRequestModels = computed(() => syncedModels(saved.value, syncDiff.value, syncMode.value))
+const syncConflicts = computed(() => findModelNameConflicts(syncRequestModels.value))
+const syncChangeCount = computed(() => {
+  const additions = syncMode.value === 'cleanup' ? 0 : syncDiff.value.additions.length
+  const removals = syncMode.value === 'add' ? 0 : syncDiff.value.removals.length
+  return additions + removals
+})
+const syncDisabled = computed(() => !discoveryReady.value || dirty.value || pending.value !== null)
+const syncDisabledReason = computed(() =>
+  dirty.value ? t('group.modelEditor.sync.dirty') : undefined,
 )
 const aliasEditorLabels = computed<ModelAliasEditorLabels>(() => ({
   tableLabel: t('group.modelEditor.tableLabel'),
@@ -218,6 +240,16 @@ watch(dirty, (isDirty) => {
 })
 
 watch(
+  () => props.groupId,
+  () => {
+    candidates.value = []
+    discoveryReady.value = false
+    syncDialogOpen.value = false
+    syncError.value = ''
+  },
+)
+
+watch(
   () => query.data.value,
   (models) => {
     if (!models || dirty.value || pending.value) return
@@ -237,8 +269,7 @@ watch(
       if (pending.value === 'discover') controller?.abort()
       return
     }
-    if (supported && models && pending.value === null && candidates.value.length === 0)
-      void runDiscovery()
+    if (supported && models && pending.value === null && !discoveryReady.value) void runDiscovery()
   },
   { immediate: true },
 )
@@ -316,6 +347,7 @@ function addManual(): void {
 function requestDiscovery(): void {
   if (!supportsModelDiscovery.value || pending.value) return
   candidates.value = []
+  discoveryReady.value = false
   discoveryError.value = ''
   if (drawerOpen.value) void runDiscovery()
   else setDiscoveryOpen(true)
@@ -324,6 +356,7 @@ function requestDiscovery(): void {
 async function runDiscovery(): Promise<void> {
   if (!supportsModelDiscovery.value || pending.value !== null) return
   controller?.abort()
+  discoveryReady.value = false
   const active = new AbortController()
   controller = active
   pending.value = 'discover'
@@ -332,8 +365,10 @@ async function runDiscovery(): Promise<void> {
     if (controller !== active) return
     candidates.value = result.models
     draft.value = mergeCandidateMetadata(draft.value, result.models)
+    discoveryReady.value = true
   } catch (cause: unknown) {
     if (cause instanceof RequestCancelledError || controller !== active) return
+    discoveryReady.value = false
     discoveryError.value =
       cause instanceof ApiError && cause.code === 'NO_ACTIVE_CREDENTIAL'
         ? t('group.modelEditor.noActiveCredential.title')
@@ -359,6 +394,65 @@ function confirmCandidates(selectedCandidates: ModelCandidate[]): void {
   serverConflicts.value = []
   saveError.value = ''
   setDiscoveryOpen(false)
+}
+
+function setSyncMode(mode: ModelSyncMode): void {
+  syncMode.value = mode
+  syncError.value = ''
+}
+
+function setSyncDialogOpen(open: boolean): void {
+  if (!open && pending.value === 'sync') return
+  syncDialogOpen.value = open
+  if (!open) syncError.value = ''
+}
+
+function requestSync(): void {
+  if (syncDisabled.value) return
+  syncMode.value = 'full'
+  syncError.value = ''
+  syncDialogOpen.value = true
+}
+
+function acceptSavedModels(result: GroupModelsDto): void {
+  const next = createModelDraft(result.items).map((item) => ({ ...item, key: nextKey++ }))
+  saved.value = next
+  draft.value = next.map((item) => ({ ...item, sources: [...item.sources] }))
+  serverConflicts.value = []
+  cacheGroupModels(queryClient, props.groupId, result)
+}
+
+async function confirmSync(): Promise<void> {
+  if (pending.value !== null || syncChangeCount.value === 0 || syncConflicts.value.length) return
+  const active = new AbortController()
+  const models = syncRequestModels.value
+  controller = active
+  pending.value = 'sync'
+  clearSavedFeedback()
+  syncError.value = ''
+  try {
+    const result = await replaceGroupModelsResource(
+      client,
+      props.groupId,
+      { models },
+      active.signal,
+    )
+    if (controller !== active) return
+    acceptSavedModels(result)
+    discoveryReady.value = false
+    syncDialogOpen.value = false
+    setDiscoveryOpen(false)
+    await invalidateGroupModelDependents(queryClient, props.groupId)
+    showSavedFeedback()
+  } catch (cause: unknown) {
+    if (cause instanceof RequestCancelledError || controller !== active) return
+    syncError.value = t('group.modelEditor.sync.saveFailed')
+  } finally {
+    if (controller === active) {
+      controller = undefined
+      pending.value = null
+    }
+  }
 }
 
 function requestSave(): void {
@@ -388,12 +482,8 @@ async function save(): Promise<void> {
       active.signal,
     )
     if (controller !== active) return
-    const next = createModelDraft(result.items).map((item) => ({ ...item, key: nextKey++ }))
-    saved.value = next
-    draft.value = next.map((item) => ({ ...item, sources: [...item.sources] }))
-    serverConflicts.value = []
+    acceptSavedModels(result)
     emptyConfirmOpen.value = false
-    cacheGroupModels(queryClient, props.groupId, result)
     await invalidateGroupModelDependents(queryClient, props.groupId)
     showSavedFeedback()
   } catch (cause: unknown) {
@@ -502,7 +592,7 @@ onBeforeUnmount(() => {
         :loading="pending === 'discover'"
         :error="discoveryError"
         :labels="discoveryDrawerLabels"
-        :dismissible="pending !== 'discover'"
+        :dismissible="pending === null"
         :search="routeState.discoverySearch ?? ''"
         :filter="routeState.discoveryFilter"
         @update:open="setDiscoveryOpen"
@@ -510,6 +600,31 @@ onBeforeUnmount(() => {
         @update:filter="setDiscoveryFilter"
         @retry="requestDiscovery"
         @confirm="confirmCandidates"
+      >
+        <template #footer-actions>
+          <AppButton
+            variant="secondary"
+            size="compact"
+            :disabled="syncDisabled"
+            :title="syncDisabledReason"
+            @click="requestSync"
+          >
+            {{ t('group.modelEditor.sync.action') }}
+          </AppButton>
+        </template>
+      </ModelDiscoveryDrawer>
+
+      <GroupModelSyncDialog
+        :open="syncDialogOpen"
+        :mode="syncMode"
+        :additions="syncDiff.additions"
+        :removals="syncDiff.removals"
+        :conflicts="syncConflicts"
+        :pending="pending === 'sync'"
+        :error="syncError"
+        @update:open="setSyncDialogOpen"
+        @update:mode="setSyncMode"
+        @confirm="confirmSync"
       />
 
       <AppConfirmDialog
@@ -531,7 +646,7 @@ onBeforeUnmount(() => {
         error-placement="floating"
         always-visible
         :dirty="dirty"
-        :pending="pending === 'save'"
+        :pending="savePending"
         :status="saveBarError ? 'error' : savedFeedback ? 'saved' : 'idle'"
         :error="saveBarError"
         :error-action-label="invalidRowCount ? t('group.modelEditor.locateFirstInvalid') : ''"
@@ -540,7 +655,7 @@ onBeforeUnmount(() => {
           ><div>
             <strong>
               {{
-                pending === 'save'
+                savePending
                   ? t('group.modelEditor.saving')
                   : savedFeedback
                     ? t('group.modelEditor.savedFeedback')
@@ -551,7 +666,7 @@ onBeforeUnmount(() => {
             </strong>
             <span>
               {{
-                pending === 'save'
+                savePending
                   ? t('group.modelEditor.savingNote')
                   : savedFeedback
                     ? t('group.modelEditor.savedFeedbackNote')

--- a/web/src/features/groups/models/model-diff.ts
+++ b/web/src/features/groups/models/model-diff.ts
@@ -1,4 +1,5 @@
 import type { GroupModelItemDto } from '@/api/control/types'
+import type { ModelCandidate } from '@/app/resources/providers'
 import {
   findModelNameConflicts,
   normalizedModels as normalizeSharedModels,
@@ -9,6 +10,13 @@ import {
 
 export interface ModelDraftItem extends ModelDraftValue {
   key: number
+}
+
+export type ModelSyncMode = 'cleanup' | 'add' | 'full'
+
+export interface ModelSyncDiff {
+  additions: ModelCandidate[]
+  removals: ModelDraftItem[]
 }
 
 export type { ModelNameConflict }
@@ -35,4 +43,31 @@ export function sameModels(
   right: readonly ModelDraftItem[],
 ): boolean {
   return sameSharedModels(left, right)
+}
+
+export function createModelSyncDiff(
+  current: readonly ModelDraftItem[],
+  candidates: readonly ModelCandidate[],
+): ModelSyncDiff {
+  const liveCandidates = candidates.filter(({ sources }) => sources.includes('live'))
+  const liveIDs = new Set(liveCandidates.map(({ id }) => id))
+  const currentIDs = new Set(current.map(({ id }) => id.trim()).filter(Boolean))
+  return {
+    additions: liveCandidates.filter(({ id }) => !currentIDs.has(id)),
+    removals: current.filter(({ id }) => !liveIDs.has(id.trim())),
+  }
+}
+
+export function syncedModels(
+  current: readonly ModelDraftItem[],
+  diff: ModelSyncDiff,
+  mode: ModelSyncMode,
+) {
+  const removalKeys = new Set(diff.removals.map(({ key }) => key))
+  const retained = mode === 'add' ? current : current.filter(({ key }) => !removalKeys.has(key))
+  const additions =
+    mode === 'cleanup'
+      ? []
+      : diff.additions.map(({ id }) => ({ id, alias: '', alias_enabled: false }))
+  return normalizeSharedModels([...retained, ...additions])
 }

--- a/web/src/features/models/ModelDiscoveryDrawer.vue
+++ b/web/src/features/models/ModelDiscoveryDrawer.vue
@@ -281,6 +281,7 @@ function confirm(): void {
           <span aria-live="polite">{{ labels.selected(selectedCandidates.length) }}</span>
         </div>
         <div class="model-discovery-drawer__actions">
+          <slot name="footer-actions" />
           <AppButton
             variant="secondary"
             size="compact"

--- a/web/src/i18n/locales/en-US/group.ts
+++ b/web/src/i18n/locales/en-US/group.ts
@@ -146,6 +146,28 @@ export default {
         empty: 'The upstream returned no models to add',
         confirm: 'Add to current list',
       },
+      sync: {
+        action: 'Sync',
+        title: 'Sync models',
+        description:
+          'The list combines live discovery and the pricing catalog. Sync uses only live discovery, so catalog-only models may appear in the removal list.',
+        close: 'Close model sync',
+        modeLabel: 'Sync mode',
+        mode: {
+          cleanup: 'Clean up',
+          add: 'Add',
+          full: 'Full sync',
+        },
+        additions: 'Add {count}',
+        removals: 'Remove {count}',
+        noAdditions: 'No models to add',
+        noRemovals: 'No models to remove',
+        more: '{count} more',
+        conflict: 'New models conflict with existing client aliases: {names}',
+        dirty: 'Save or discard the current changes first.',
+        confirm: 'Confirm',
+        saveFailed: 'Unable to sync the Group model list.',
+      },
       saveFailed: 'Unable to replace the Group model list.',
       noActiveCredential: {
         title: 'No active channel credential is available for discovery.',

--- a/web/src/i18n/locales/ja-JP/group.ts
+++ b/web/src/i18n/locales/ja-JP/group.ts
@@ -146,6 +146,28 @@ export default {
         empty: '追加できるモデルが返されませんでした',
         confirm: '現在の一覧に追加',
       },
+      sync: {
+        action: '同期',
+        title: 'モデルを同期',
+        description:
+          'モデル一覧にはアップストリーム検出と価格カタログが含まれます。同期はアップストリーム検出結果のみを使用するため、価格カタログだけのモデルは削除一覧に表示される場合があります。',
+        close: 'モデル同期を閉じる',
+        modeLabel: '同期方法',
+        mode: {
+          cleanup: '整理',
+          add: '追加',
+          full: '完全同期',
+        },
+        additions: '{count} 件を追加',
+        removals: '{count} 件を削除',
+        noAdditions: '追加するモデルはありません',
+        noRemovals: '削除するモデルはありません',
+        more: 'ほか {count} 件',
+        conflict: '新しいモデルが既存のクライアント別名と競合しています：{names}',
+        dirty: '現在の変更を保存または破棄してください。',
+        confirm: '確認',
+        saveFailed: 'グループのモデル一覧を同期できません。',
+      },
       saveFailed: 'グループのモデル一覧を置き換えられません。',
       noActiveCredential: {
         title: '検出に使用できる有効なチャネル認証情報がありません。',

--- a/web/src/i18n/locales/zh-CN/group.ts
+++ b/web/src/i18n/locales/zh-CN/group.ts
@@ -145,6 +145,28 @@ export default {
         empty: '上游未返回可添加模型',
         confirm: '添加到当前列表',
       },
+      sync: {
+        action: '同步',
+        title: '同步模型',
+        description:
+          '模型列表包含上游发现和价格目录；同步只以上游发现结果为准。仅存在于价格目录的模型不会被识别为上游模型，可能出现在移除清单。',
+        close: '关闭模型同步',
+        modeLabel: '同步方式',
+        mode: {
+          cleanup: '清理',
+          add: '添加',
+          full: '完全同步',
+        },
+        additions: '新增 {count} 个',
+        removals: '移除 {count} 个',
+        noAdditions: '没有新增模型',
+        noRemovals: '没有需要移除的模型',
+        more: '另有 {count} 个',
+        conflict: '新增模型与现有对外别名冲突：{names}',
+        dirty: '请先保存或放弃当前修改。',
+        confirm: '确认',
+        saveFailed: '无法同步分组模型列表。',
+      },
       saveFailed: '无法替换分组模型列表。',
       noActiveCredential: {
         title: '没有可用于发现的活跃渠道凭据。',


### PR DESCRIPTION
### 关联 Issue / Related Issue
Closes #516

### 变更内容 / Change Content
- [ ] Bug 修复 / Bug fix
- [x] 新功能 / New feature
- [ ] 其他改动 / Other changes

- 在获取上游模型侧边栏增加同步入口，提供完全同步、清理和添加三种方式。
- 同步差异只依据上游发现结果；价格目录候选不参与上游模型比对，并在确认弹窗中明确提示。
- 保留仍存在模型的别名，清理时展示并移除对应别名，新增模型默认不设置别名。
- 新增与移除清单分别使用成功与危险语义色，并在确认后直接保存及刷新关联缓存。
- 兼容性：不修改管理 API、数据结构或持久化格式，无数据迁移。
- 文档：无需更新公开文档或发布说明。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增模型同步功能，支持添加、清理和完全同步三种模式。
  - 同步前可预览将新增或移除的模型及数量。
  - 检测模型冲突、未保存变更和同步错误，并提供相应提示。
  - 同步进行时锁定模式切换，避免误操作。
  - 模型发现完成后才启用同步操作。

- **改进**
  - 支持在模型发现抽屉中扩展自定义操作。
  - 新增英文、日文和简体中文同步相关界面文案。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->