### PR TITLE
fix(import): 无匹配渠道时回退兼容渠道

### DIFF
--- a/web/src/features/import/ChannelPresetPicker.vue
+++ b/web/src/features/import/ChannelPresetPicker.vue
@@ -150,11 +150,17 @@ const rankedMatches = computed<ChannelMatch[]>(() => {
   if (!normalizedQuery) {
     return otherChannels.value.map((channel) => ({ channel, rank: 0, reason: '' }))
   }
-  return activeChannels.value
+  const matches = activeChannels.value
     .map((channel, index) => ({ index, match: matchChannel(channel, normalizedQuery) }))
     .filter((row): row is { index: number; match: ChannelMatch } => row.match !== null)
     .sort((a, b) => b.match.rank - a.match.rank || a.index - b.index)
     .map((row) => row.match)
+  if (matches.length > 0) return matches
+
+  const compatible = activeChannels.value.find(
+    (channel) => channel.channel_id === 'openai_compatible',
+  )
+  return compatible ? [{ channel: compatible, rank: 0, reason: '' }] : []
 })
 
 watch(rankedMatches, () => {


### PR DESCRIPTION
### 关联 Issue / Related Issue
Refs #521

### 变更内容 / Change Content
- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

- 保持渠道名称、ID、搜索词和描述的现有匹配及排序逻辑。
- 当搜索没有真实匹配时，回退展示 `OpenAI Compatible` 渠道。
- 不新增第三方关键词、渠道类型或额外提示。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.

本次仅调整管理端渠道搜索的空结果行为，不涉及数据结构、持久化格式或迁移。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化频道预设搜索：当搜索无匹配结果时，将优先显示 OpenAI 兼容频道（如可用），帮助用户继续完成选择。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

