### PR TITLE
feat(channel): 增加 New API 多协议渠道

### DIFF
--- a/internal/channel/builtins.go
+++ b/internal/channel/builtins.go
@@ -28,6 +28,7 @@ func builtInModules() []spec.Module {
 		modules.OpenRouter(),
 		modules.Groq(),
 		modules.XAI(),
+		modules.NewAPI(),
 		modules.OpenAICompatible(),
 	}
 }

--- a/internal/channel/channel.go
+++ b/internal/channel/channel.go
@@ -31,6 +31,7 @@ const (
 	AzureOpenAI      = spec.AzureOpenAI
 	AWSBedrock       = spec.AWSBedrock
 	GoogleVertex     = spec.GoogleVertex
+	NewAPI           = spec.NewAPI
 	OpenAICompatible = spec.OpenAICompatible
 	DeepSeek         = spec.DeepSeek
 	MoonshotAI       = spec.MoonshotAI
@@ -191,6 +192,7 @@ const (
 	ProviderGrok             = spec.ProviderGrok
 	ProviderAnthropic        = spec.ProviderAnthropic
 	ProviderGemini           = spec.ProviderGemini
+	ProviderNewAPI           = spec.ProviderNewAPI
 	ProviderOpenAICompatible = spec.ProviderOpenAICompatible
 	ProviderAzureOpenAI      = spec.ProviderAzureOpenAI
 	ProviderAWSBedrock       = spec.ProviderAWSBedrock

--- a/internal/channel/embeddings_module_test.go
+++ b/internal/channel/embeddings_module_test.go
@@ -12,7 +12,7 @@ func TestOpenAIEmbeddingsNativeRouteIsLimitedToSupportedAPIKeyChannels(t *testin
 
 	registry := NewRegistry()
 	supported := map[ID]struct{}{
-		OpenAI: {}, OpenRouter: {}, OpenAICompatible: {},
+		OpenAI: {}, OpenRouter: {}, NewAPI: {}, OpenAICompatible: {},
 	}
 	for _, descriptor := range registry.List() {
 		definition, ok := registry.lookup(descriptor.ID)

--- a/internal/channel/final_provider_contract_test.go
+++ b/internal/channel/final_provider_contract_test.go
@@ -31,6 +31,7 @@ func TestFinalRegistryContainsOnlyApprovedChannels(t *testing.T) {
 		OpenRouter,
 		Groq,
 		XAI,
+		NewAPI,
 		OpenAICompatible,
 	}
 	if got := descriptorIDs(registry.List()); !reflect.DeepEqual(got, want) {

--- a/internal/channel/modules/newapi.go
+++ b/internal/channel/modules/newapi.go
@@ -1,0 +1,48 @@
+package modules
+
+import (
+	"gpt-load/internal/channel/spec"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+)
+
+func NewAPI() spec.Module {
+	return spec.Module{
+		Definition: spec.Definition{
+			ID:          spec.NewAPI,
+			Name:        "New API",
+			Mark:        "NA",
+			Icon:        "new-api",
+			Description: "New API multi-protocol gateway",
+			Connection: spec.Connection{
+				Type:            spec.ConnectionAPIKey,
+				CredentialInput: "batch_text",
+			},
+			Params: []spec.Field{{
+				Key: "base_url", Label: "Base URL", InputKind: spec.InputURL,
+				Required: true, Normalizer: spec.NormalizeBaseURL,
+			}},
+			Credentials: []spec.Field{{
+				Key: "api_key", Label: "API Key", InputKind: spec.InputSecret,
+				Required: true, Sensitive: true, Normalizer: spec.NormalizeNonEmpty,
+			}},
+			Provider: spec.ProviderBinding{
+				ProviderKind:   spec.ProviderNewAPI,
+				EndpointPolicy: spec.EndpointRequiredBaseURL,
+			},
+			Routes: []spec.Route{
+				spec.NewRoute(protocol.OpenAICompletions, execution.OperationChatCompletion, execution.RouteNative),
+				spec.NewRoute(protocol.OpenAICompletions, execution.OperationListModels, execution.RouteNative),
+				spec.NewRoute(protocol.OpenAICompletions, execution.OperationProbe, execution.RouteNative),
+				spec.NewRoute(protocol.OpenAIResponses, execution.OperationResponsesCreate, execution.RouteNative),
+				spec.NewRoute(protocol.OpenAIResponses, execution.OperationResponsesCompact, execution.RouteNative),
+				spec.NewRoute(protocol.OpenAIImages, execution.OperationImagesGenerate, execution.RouteNative),
+				spec.NewRoute(protocol.OpenAIImages, execution.OperationImagesEdit, execution.RouteNative),
+				spec.NewRoute(protocol.OpenAIEmbeddings, execution.OperationEmbeddingsCreate, execution.RouteNative),
+				spec.NewRoute(protocol.OpenAIEmbeddings, execution.OperationProbe, execution.RouteNative),
+				spec.NewRoute(protocol.Anthropic, execution.OperationChatCompletion, execution.RouteNative),
+				spec.NewRoute(protocol.Gemini, execution.OperationChatCompletion, execution.RouteNative),
+			},
+		},
+	}
+}

--- a/internal/channel/newapi_module_test.go
+++ b/internal/channel/newapi_module_test.go
@@ -1,0 +1,92 @@
+package channel
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+)
+
+func TestNewAPIChannelContract(t *testing.T) {
+	t.Parallel()
+
+	const newAPI = ID("newapi")
+	registry := NewRegistry()
+	descriptor, ok := registry.Get(newAPI)
+	if !ok {
+		t.Fatal("New API channel is not registered")
+	}
+	if descriptor.Name != "New API" || descriptor.Mark != "NA" || descriptor.Icon != "new-api" {
+		t.Fatalf("New API identity = %#v", descriptor)
+	}
+	if descriptor.Connection.Type != "api_key" || descriptor.Connection.CredentialInput != "batch_text" {
+		t.Fatalf("New API connection = %#v", descriptor.Connection)
+	}
+	if len(descriptor.ParamFields) != 1 {
+		t.Fatalf("New API params = %#v", descriptor.ParamFields)
+	}
+	if field := descriptor.ParamFields[0]; field.Key != "base_url" || field.InputKind != InputURL || !field.Required || field.Sensitive {
+		t.Fatalf("New API base_url field = %#v", field)
+	}
+	if len(descriptor.CredentialFields) != 1 {
+		t.Fatalf("New API credentials = %#v", descriptor.CredentialFields)
+	}
+	if field := descriptor.CredentialFields[0]; field.Key != "api_key" || field.InputKind != InputSecret || !field.Required || !field.Sensitive {
+		t.Fatalf("New API api_key field = %#v", field)
+	}
+	if !descriptor.Capabilities.ModelDiscovery || !descriptor.Capabilities.OutboundProxy {
+		t.Fatalf("New API capabilities = %#v", descriptor.Capabilities)
+	}
+
+	target, err := registry.Resolve(newAPI, json.RawMessage(`{"base_url":"HTTPS://RELAY.EXAMPLE:443/team-a/"}`))
+	if err != nil {
+		t.Fatalf("Resolve(New API) error = %v", err)
+	}
+	if target.ProviderKind != ProviderKind("newapi") || target.CatalogProviderID != "" {
+		t.Fatalf("New API target = %#v", target)
+	}
+	if got := string(target.TargetConfig); got != `{"base_url":"https://relay.example/team-a"}` {
+		t.Fatalf("New API target config = %s", got)
+	}
+	if target.SupportsResponsesLifecycle() {
+		t.Fatal("New API must not advertise a complete Responses lifecycle")
+	}
+
+	wantRoutes := map[protocol.Protocol]map[execution.Operation]RouteMode{
+		protocol.OpenAICompletions: {
+			execution.OperationChatCompletion: RouteNative,
+			execution.OperationListModels:     RouteNative,
+			execution.OperationProbe:          RouteNative,
+		},
+		protocol.OpenAIResponses: {
+			execution.OperationResponsesCreate:  RouteNative,
+			execution.OperationResponsesCompact: RouteNative,
+		},
+		protocol.OpenAIImages: {
+			execution.OperationImagesGenerate: RouteNative,
+			execution.OperationImagesEdit:     RouteNative,
+		},
+		protocol.OpenAIEmbeddings: {
+			execution.OperationEmbeddingsCreate: RouteNative,
+			execution.OperationProbe:            RouteNative,
+		},
+		protocol.Anthropic: {
+			execution.OperationChatCompletion: RouteNative,
+		},
+		protocol.Gemini: {
+			execution.OperationChatCompletion: RouteNative,
+		},
+	}
+	gotRoutes := make(map[protocol.Protocol]map[execution.Operation]RouteMode)
+	for _, route := range descriptor.Routes {
+		if gotRoutes[route.ClientProtocol] == nil {
+			gotRoutes[route.ClientProtocol] = make(map[execution.Operation]RouteMode)
+		}
+		gotRoutes[route.ClientProtocol][route.Operation] = route.RouteMode
+	}
+	if !reflect.DeepEqual(gotRoutes, wantRoutes) {
+		t.Fatalf("New API routes = %#v, want %#v", gotRoutes, wantRoutes)
+	}
+}

--- a/internal/channel/registry_test.go
+++ b/internal/channel/registry_test.go
@@ -33,6 +33,7 @@ func TestRegistryHasStableBuiltInOrderAndSearch(t *testing.T) {
 		OpenRouter,
 		Groq,
 		XAI,
+		NewAPI,
 		OpenAICompatible,
 	}
 	if got := descriptorIDs(registry.List()); !reflect.DeepEqual(got, wantIDs) {

--- a/internal/channel/route_golden_test.go
+++ b/internal/channel/route_golden_test.go
@@ -41,7 +41,7 @@ func TestBuiltInRouteGolden(t *testing.T) {
 	}
 
 	digest := fmt.Sprintf("%x", sha256.Sum256([]byte(strings.Join(got, "\n"))))
-	const wantDigest = "4d95bc5c1c3c37843eafe59a4fbad9ee223371fe8700ce0e29dd0045c951d0b9"
+	const wantDigest = "f0fa01548dc62ad3aa64023185cd601d151f7580a11e3372f94577ac97dd3c20"
 	if digest != wantDigest {
 		t.Fatalf("built-in routes changed: digest = %s, want %s\n%s", digest, wantDigest, strings.Join(got, "\n"))
 	}

--- a/internal/channel/spec/definition.go
+++ b/internal/channel/spec/definition.go
@@ -23,6 +23,7 @@ const (
 	AzureOpenAI      ID = "azure_openai"
 	AWSBedrock       ID = "aws_bedrock"
 	GoogleVertex     ID = "google_vertex"
+	NewAPI           ID = "newapi"
 	OpenAICompatible ID = "openai_compatible"
 	DeepSeek         ID = "deepseek"
 	MoonshotAI       ID = "moonshotai"
@@ -46,6 +47,7 @@ const (
 	ProviderGrok             ProviderKind = "grok"
 	ProviderAnthropic        ProviderKind = "anthropic"
 	ProviderGemini           ProviderKind = "gemini"
+	ProviderNewAPI           ProviderKind = "newapi"
 	ProviderOpenAICompatible ProviderKind = "openai_compatible"
 	ProviderAzureOpenAI      ProviderKind = "azure_openai"
 	ProviderAWSBedrock       ProviderKind = "aws_bedrock"
@@ -95,6 +97,7 @@ func (kind ProviderKind) Valid() bool {
 		ProviderGrok,
 		ProviderAnthropic,
 		ProviderGemini,
+		ProviderNewAPI,
 		ProviderOpenAICompatible,
 		ProviderAzureOpenAI,
 		ProviderAWSBedrock,

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -270,6 +270,7 @@ func newProviderAdapterRegistry(
 		{ProviderKind: channel.ProviderOpenAI, Adapter: bifrost},
 		{ProviderKind: channel.ProviderAnthropic, Adapter: bifrost},
 		{ProviderKind: channel.ProviderGemini, Adapter: bifrost},
+		{ProviderKind: channel.ProviderNewAPI, Adapter: bifrost},
 		{ProviderKind: channel.ProviderOpenAICompatible, Adapter: bifrost},
 		{ProviderKind: channel.ProviderAzureOpenAI, Adapter: bifrost},
 		{ProviderKind: channel.ProviderAWSBedrock, Adapter: bifrost},

--- a/internal/control/discover_executor.go
+++ b/internal/control/discover_executor.go
@@ -197,12 +197,16 @@ func parseDiscoveredModelsPage(
 	switch clientProtocol {
 	case protocol.OpenAICompletions:
 		var payload struct {
-			Data []struct {
+			Success *bool `json:"success"`
+			Data    []struct {
 				ID string `json:"id"`
 			} `json:"data"`
 		}
 		if err := decodeSingleJSON(body, &payload); err != nil {
 			return discoveredModelsPage{}, err
+		}
+		if payload.Success != nil && !*payload.Success {
+			return discoveredModelsPage{}, fmt.Errorf("upstream model discovery reported failure")
 		}
 		models := make([]string, 0, len(payload.Data))
 		for _, item := range payload.Data {

--- a/internal/control/discover_executor_test.go
+++ b/internal/control/discover_executor_test.go
@@ -156,6 +156,26 @@ func TestUtilityRequestShapeUsesSelectedProtocol(t *testing.T) {
 	}
 }
 
+func TestOpenAIModelDiscoveryRejectsExplicitNewAPIFailureEnvelope(t *testing.T) {
+	t.Parallel()
+
+	if _, err := parseDiscoveredModelsPage(
+		protocol.OpenAICompletions,
+		[]byte(`{"success":false,"message":"get user group failed"}`),
+	); err == nil {
+		t.Fatal("New API success:false model response was accepted")
+	}
+	for _, body := range []string{
+		`{"object":"list","data":[{"id":"standard-model"}]}`,
+		`{"success":true,"object":"list","data":[{"id":"newapi-model"}]}`,
+	} {
+		page, err := parseDiscoveredModelsPage(protocol.OpenAICompletions, []byte(body))
+		if err != nil || len(page.models) != 1 {
+			t.Fatalf("model response = %#v, err=%v", page, err)
+		}
+	}
+}
+
 func discoveryTargetForTest(
 	t *testing.T,
 	channelID channel.ID,

--- a/internal/execution/bifrost/capabilities.go
+++ b/internal/execution/bifrost/capabilities.go
@@ -18,7 +18,8 @@ func (manager *RuntimeManager) ValidateRouteCapability(
 	if manager == nil {
 		return fmt.Errorf("runtime manager is unavailable")
 	}
-	if _, sdkBacked := sdkProviderSpecFor(providerKind); !sdkBacked && providerKind != channel.ProviderOpenAICompatible {
+	if _, sdkBacked := sdkProviderSpecFor(providerKind); !sdkBacked &&
+		providerKind != channel.ProviderOpenAICompatible && providerKind != channel.ProviderNewAPI {
 		return fmt.Errorf("provider is not implemented by Bifrost")
 	}
 	if route.RouteMode == execution.RouteConverted {
@@ -72,6 +73,26 @@ func nativeRouteImplemented(
 		return clientProtocol == protocol.Anthropic && standardProtocolOperation(clientProtocol, operation)
 	case channel.ProviderGemini:
 		return clientProtocol == protocol.Gemini && standardProtocolOperation(clientProtocol, operation)
+	case channel.ProviderNewAPI:
+		switch clientProtocol {
+		case protocol.OpenAICompletions:
+			return operation == execution.OperationChatCompletion ||
+				operation == execution.OperationListModels ||
+				operation == execution.OperationProbe
+		case protocol.OpenAIResponses:
+			return operation == execution.OperationResponsesCreate ||
+				operation == execution.OperationResponsesCompact
+		case protocol.OpenAIImages:
+			return operation == execution.OperationImagesGenerate ||
+				operation == execution.OperationImagesEdit
+		case protocol.OpenAIEmbeddings:
+			return operation == execution.OperationEmbeddingsCreate ||
+				operation == execution.OperationProbe
+		case protocol.Anthropic, protocol.Gemini:
+			return operation == execution.OperationChatCompletion
+		default:
+			return false
+		}
 	case channel.ProviderOpenAICompatible:
 		if clientProtocol == protocol.OpenAIEmbeddings {
 			return operation == execution.OperationEmbeddingsCreate || operation == execution.OperationProbe

--- a/internal/execution/bifrost/embeddings.go
+++ b/internal/execution/bifrost/embeddings.go
@@ -127,6 +127,11 @@ func embeddingTypedTarget(
 	}
 	switch providerKind {
 	case channel.ProviderOpenAI:
+	case channel.ProviderNewAPI:
+		if !configured {
+			return "", fmt.Errorf("New API Embeddings target is required")
+		}
+		return resolveNewAPITargetURL(baseURL, resourcePath, rawQuery)
 	case channel.ProviderOpenRouter:
 		// OpenRouter concatenates the configured provider base URL with the
 		// context path, so the per-request override must remain relative.

--- a/internal/execution/bifrost/executor.go
+++ b/internal/execution/bifrost/executor.go
@@ -456,7 +456,8 @@ func (r *Runtime) prepare(spec execution.AttemptSpec, stream bool) (preparedAtte
 	}
 	safeQuery := safeAttemptQuery(spec)
 	if mode == channel.RouteNative && spec.ClientProtocol == protocol.Gemini &&
-		(providerKind == channel.ProviderGemini || providerKind == channel.ProviderGoogleVertex) {
+		(providerKind == channel.ProviderGemini || providerKind == channel.ProviderGoogleVertex ||
+			providerKind == channel.ProviderNewAPI) {
 		safeQuery = removeRawQueryValue(safeQuery, "alt")
 		if stream {
 			safeQuery = setRawQueryValue(safeQuery, "alt", "sse")
@@ -515,6 +516,27 @@ func (r *Runtime) prepare(spec execution.AttemptSpec, stream bool) (preparedAtte
 			}, nil
 		}
 		request := newProbeRequest(provider, providerKind, spec.UpstreamModel)
+		if providerKind == channel.ProviderNewAPI {
+			if spec.ClientProtocol != protocol.OpenAICompletions {
+				failure := notSentUnaryFailure(execution.ErrorKindInvalidRequest, "unsupported New API probe protocol")
+				return preparedAttempt{}, &failure
+			}
+			baseURL, configured, targetErr := targetBaseURL(resolved.TargetConfig)
+			if targetErr != nil || !configured {
+				failure := notSentUnaryFailure(execution.ErrorKindInvalidRequest, "invalid New API probe target")
+				return preparedAttempt{}, &failure
+			}
+			typedURL, targetErr := resolveNewAPITargetURL(baseURL, "/v1/chat/completions", "")
+			if targetErr != nil {
+				failure := notSentUnaryFailure(execution.ErrorKindInvalidRequest, "invalid New API probe target")
+				return preparedAttempt{}, &failure
+			}
+			return preparedAttempt{
+				provider: provider, mode: mode, upstreamProtocol: protocol.OpenAICompletions,
+				request: request, typedURL: typedURL, clientProtocol: spec.ClientProtocol,
+				directKey: directKey, secrets: secrets,
+			}, nil
+		}
 		responses := spec.ClientProtocol == protocol.OpenAIResponses
 		typedURL, upstreamProtocol, targetErr := convertedTypedTarget(
 			providerKind,
@@ -580,6 +602,17 @@ func (r *Runtime) prepare(spec execution.AttemptSpec, stream bool) (preparedAtte
 		}
 		passthroughHeaders := safePassthroughHeaders(sanitizedHeaders)
 		passthroughUpstreamURL := ""
+		if providerKind == channel.ProviderNewAPI &&
+			(spec.ClientProtocol == protocol.OpenAICompletions ||
+				spec.ClientProtocol == protocol.OpenAIResponses ||
+				spec.ClientProtocol == protocol.OpenAIImages) {
+			explicitPrefix, configured, prefixErr := targetBaseURL(resolved.TargetConfig)
+			if prefixErr != nil || !configured {
+				failure := notSentUnaryFailure(execution.ErrorKindInvalidRequest, "invalid New API gateway root")
+				return preparedAttempt{}, &failure
+			}
+			passthroughUpstreamURL = explicitPrefix
+		}
 		if spec.ClientProtocol == protocol.OpenAIImages {
 			explicitPrefix, configured, prefixErr := targetBaseURL(resolved.TargetConfig)
 			if prefixErr != nil {
@@ -770,11 +803,13 @@ func providerSupportsPassthrough(
 	switch providerKind {
 	case channel.ProviderOpenAI, channel.ProviderAnthropic, channel.ProviderGemini, channel.ProviderGoogleVertex:
 		return true
+	case channel.ProviderNewAPI:
+		return true
 	case channel.ProviderOpenAICompatible:
 		if clientProtocol == protocol.OpenAIImages {
 			return true
 		}
-		// Bifrost v1.7.7's OpenAI passthrough always inserts /v1. A compatible
+		// Bifrost's OpenAI passthrough inserts /v1. A compatible
 		// full API prefix with another suffix must use the typed custom path,
 		// without changing the frozen route mode or channel capability.
 		return strings.HasSuffix(baseURL, "/v1")
@@ -785,9 +820,11 @@ func providerSupportsPassthrough(
 
 func providerKindNativeForClient(providerKind channel.ProviderKind, clientProtocol protocol.Protocol) bool {
 	switch providerKind {
-	case channel.ProviderOpenAI, channel.ProviderOpenAICompatible:
+	case channel.ProviderOpenAI, channel.ProviderOpenAICompatible, channel.ProviderNewAPI:
 		return clientProtocol == protocol.OpenAICompletions || clientProtocol == protocol.OpenAIResponses ||
-			clientProtocol == protocol.OpenAIImages || clientProtocol == protocol.OpenAIEmbeddings
+			clientProtocol == protocol.OpenAIImages || clientProtocol == protocol.OpenAIEmbeddings ||
+			(providerKind == channel.ProviderNewAPI &&
+				(clientProtocol == protocol.Anthropic || clientProtocol == protocol.Gemini))
 	case channel.ProviderAnthropic:
 		return clientProtocol == protocol.Anthropic
 	case channel.ProviderGemini:
@@ -954,6 +991,17 @@ func nativePassthroughPath(spec execution.AttemptSpec, providerKind channel.Prov
 	switch providerKind {
 	case channel.ProviderOpenAI, channel.ProviderOpenAICompatible:
 		return spec.Path, nil
+	case channel.ProviderNewAPI:
+		if spec.ClientProtocol != protocol.Gemini {
+			return spec.Path, nil
+		}
+		marker := "/models/"
+		modelStart := strings.Index(spec.Path, marker)
+		colon := strings.LastIndex(spec.Path, ":")
+		if modelStart < 0 || colon <= modelStart+len(marker) {
+			return "", fmt.Errorf("invalid New API Gemini model path")
+		}
+		return spec.Path[:modelStart+len(marker)] + url.PathEscape(spec.UpstreamModel) + spec.Path[colon:], nil
 	case channel.ProviderAnthropic:
 		return spec.Path, nil
 	case channel.ProviderGemini:
@@ -1044,7 +1092,7 @@ func directKeyForAttempt(
 	secrets := credentialSecrets(credential)
 	apiKey, _ := credential.Value("api_key")
 	switch providerKind {
-	case channel.ProviderOpenAI, channel.ProviderAnthropic, channel.ProviderGemini,
+	case channel.ProviderOpenAI, channel.ProviderAnthropic, channel.ProviderGemini, channel.ProviderNewAPI,
 		channel.ProviderDeepSeek, channel.ProviderOpenRouter, channel.ProviderGroq, channel.ProviderXAI,
 		channel.ProviderOpenAICompatible:
 		if apiKey == "" {
@@ -1389,6 +1437,20 @@ func resolveTypedTargetURL(baseURL, resourcePath, rawQuery string) (string, erro
 		parsed.RawQuery = rawQuery
 	}
 	return parsed.String(), nil
+}
+
+func resolveNewAPITargetURL(baseURL, requestPath, rawQuery string) (string, error) {
+	parsed, err := url.Parse(baseURL)
+	if err != nil || parsed == nil || !parsed.IsAbs() || parsed.Host == "" || parsed.User != nil ||
+		parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" ||
+		!strings.HasPrefix(requestPath, "/") || strings.HasPrefix(requestPath, "//") {
+		return "", fmt.Errorf("invalid New API target URL")
+	}
+	target := strings.TrimRight(baseURL, "/") + requestPath
+	if rawQuery != "" {
+		target += "?" + rawQuery
+	}
+	return target, nil
 }
 
 func setTypedRequestURL(ctx *schemas.BifrostContext, requestURL string) {

--- a/internal/execution/bifrost/newapi_runtime_test.go
+++ b/internal/execution/bifrost/newapi_runtime_test.go
@@ -1,0 +1,681 @@
+package bifrost
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/outboundproxy"
+	"gpt-load/internal/protocol"
+	"gpt-load/internal/provideradapter"
+)
+
+func TestNewAPINativeUnaryProtocolsUseCanonicalRootPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		clientProtocol   protocol.Protocol
+		operation        execution.Operation
+		path             string
+		body             string
+		wantPath         string
+		credentialHeader string
+		response         string
+	}{
+		{
+			name: "completions", clientProtocol: protocol.OpenAICompletions,
+			operation: execution.OperationChatCompletion, path: "/v1/chat/completions",
+			body:     `{"model":"client-model","messages":[{"role":"user","content":"hello"}],"provider":"client","api_key":"client-body"}`,
+			wantPath: "/team-a/v1/chat/completions", credentialHeader: "Authorization",
+			response: `{"id":"chat_1","object":"chat.completion","created":1,"model":"upstream-model","choices":[{"index":0,"message":{"role":"assistant","content":"pong"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
+		},
+		{
+			name: "responses", clientProtocol: protocol.OpenAIResponses,
+			operation: execution.OperationResponsesCreate, path: "/v1/responses",
+			body:     `{"model":"client-model","input":"hello","store":false,"provider":"client","api_key":"client-body"}`,
+			wantPath: "/team-a/v1/responses", credentialHeader: "Authorization",
+			response: `{"id":"resp_1","object":"response","status":"completed","model":"upstream-model","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`,
+		},
+		{
+			name: "responses compact", clientProtocol: protocol.OpenAIResponses,
+			operation: execution.OperationResponsesCompact, path: "/v1/responses/compact",
+			body:     `{"model":"client-model","input":[{"role":"user","content":"hello"}],"provider":"client","api_key":"client-body"}`,
+			wantPath: "/team-a/v1/responses/compact", credentialHeader: "Authorization",
+			response: `{"id":"cmp_1","object":"response.compaction","model":"upstream-model","output":[]}`,
+		},
+		{
+			name: "images", clientProtocol: protocol.OpenAIImages,
+			operation: execution.OperationImagesGenerate, path: "/v1/images/generations",
+			body:     `{"model":"client-model","prompt":"hello","provider":"client","api_key":"client-body"}`,
+			wantPath: "/team-a/v1/images/generations", credentialHeader: "Authorization",
+			response: `{"created":1,"data":[{"url":"https://images.example/result.png"}]}`,
+		},
+		{
+			name: "embeddings", clientProtocol: protocol.OpenAIEmbeddings,
+			operation: execution.OperationEmbeddingsCreate, path: "/v1/embeddings",
+			body:     `{"model":"client-model","input":"hello","provider":"client","api_key":"client-body"}`,
+			wantPath: "/team-a/v1/embeddings", credentialHeader: "Authorization",
+			response: `{"object":"list","model":"upstream-model","data":[{"object":"embedding","index":0,"embedding":[0.1,0.2]}],"usage":{"prompt_tokens":1,"total_tokens":1}}`,
+		},
+		{
+			name: "anthropic", clientProtocol: protocol.Anthropic,
+			operation: execution.OperationChatCompletion, path: "/v1/messages",
+			body:     `{"model":"client-model","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"provider":"client","api_key":"client-body"}`,
+			wantPath: "/team-a/v1/messages", credentialHeader: "X-Api-Key",
+			response: `{"id":"msg_1","type":"message","role":"assistant","model":"upstream-model","content":[{"type":"text","text":"pong"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`,
+		},
+		{
+			name: "gemini", clientProtocol: protocol.Gemini,
+			operation: execution.OperationChatCompletion, path: "/v1beta/models/client-model:generateContent",
+			body:     `{"contents":[{"role":"user","parts":[{"text":"hello"}]}],"provider":"client","api_key":"client-body"}`,
+			wantPath: "/team-a/v1beta/models/upstream-model:generateContent", credentialHeader: "X-Goog-Api-Key",
+			response: `{"candidates":[{"content":{"role":"model","parts":[{"text":"pong"}]} ,"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2},"modelVersion":"upstream-model"}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				if request.Method != http.MethodPost || request.URL.Path != test.wantPath ||
+					request.URL.Query().Get("trace") != "kept" || request.URL.Query().Get("key") != "" ||
+					request.URL.Query().Get("api_key") != "" {
+					t.Errorf("upstream target = %s %s?%s", request.Method, request.URL.Path, request.URL.RawQuery)
+				}
+				wantCredential := testAPIKey
+				if test.credentialHeader == "Authorization" {
+					wantCredential = "Bearer " + testAPIKey
+				}
+				if request.Header.Get(test.credentialHeader) != wantCredential {
+					t.Errorf("credential %s = %q", test.credentialHeader, request.Header.Get(test.credentialHeader))
+				}
+				for _, name := range []string{"Authorization", "X-Api-Key", "X-Goog-Api-Key"} {
+					if name != test.credentialHeader && request.Header.Get(name) != "" {
+						t.Errorf("unexpected credential header %s = %q", name, request.Header.Get(name))
+					}
+				}
+				if test.clientProtocol == protocol.Anthropic && request.Header.Get("Anthropic-Version") == "" {
+					t.Error("Anthropic-Version is missing")
+				}
+				body, _ := io.ReadAll(request.Body)
+				var payload map[string]any
+				if err := json.Unmarshal(body, &payload); err != nil {
+					t.Fatalf("decode upstream request: %v", err)
+				}
+				if payload["provider"] != nil || payload["api_key"] != nil {
+					t.Errorf("control fields reached upstream: %#v", payload)
+				}
+				if test.clientProtocol != protocol.Gemini && payload["model"] != "upstream-model" {
+					t.Errorf("upstream model = %#v", payload["model"])
+				}
+				writer.Header().Set("Content-Type", "application/json")
+				writer.Header().Set("X-Request-Id", "newapi-"+test.name)
+				_, _ = io.WriteString(writer, test.response)
+			}))
+			defer server.Close()
+
+			registry := channel.NewRegistry()
+			resolved, err := registry.Resolve(
+				channel.NewAPI,
+				json.RawMessage(`{"base_url":"`+server.URL+`/team-a"}`),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			manager, err := newRuntimeManager(runtimeOptions{allowPrivateNetwork: true}, registry)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := manager.Start(t.Context()); err != nil {
+				t.Fatal(err)
+			}
+			defer manager.Shutdown()
+			if err := manager.Reconcile([]provideradapter.RuntimeTarget{{Target: resolved}}); err != nil {
+				t.Fatal(err)
+			}
+
+			spec := freezeTestAttempt(execution.AttemptSpec{
+				RequestID: "newapi-request", AttemptID: "newapi-attempt", Sequence: 1,
+				ChannelID: string(channel.NewAPI), ClientProtocol: test.clientProtocol,
+				Operation: test.operation, ClientModel: "client-model", UpstreamModel: "upstream-model",
+				Method: http.MethodPost, Path: test.path,
+				RawQuery: "trace=kept&key=client-query&api_key=client-query",
+				Header: http.Header{
+					"Authorization":  {"Bearer client-auth"},
+					"X-Api-Key":      {"client-auth"},
+					"X-Goog-Api-Key": {"client-auth"},
+					"Content-Type":   {"application/json"},
+				},
+				Body: []byte(test.body), TargetConfig: resolved.TargetConfig,
+				Credential: execution.NewCredentialSnapshot(
+					17, 1, 1, []byte(`{"api_key":"`+testAPIKey+`"}`),
+				),
+			})
+			if err := spec.Validate(); err != nil {
+				t.Fatal(err)
+			}
+			result := manager.Execute(context.Background(), spec)
+			if err := result.Validate(); err != nil {
+				t.Fatalf("result validation: %v; result=%+v", err, result)
+			}
+			if result.Error != nil || result.StatusCode != http.StatusOK ||
+				result.UpstreamProtocol != test.clientProtocol || result.UpstreamRequestID != "newapi-"+test.name {
+				t.Fatalf("result = %+v", result)
+			}
+		})
+	}
+}
+
+func TestNewAPIImageEditUsesGatewayRoot(t *testing.T) {
+	t.Parallel()
+
+	imageBytes := []byte{0x00, 0xff, 0x10, 0x20, '\r', '\n'}
+	body, contentType := imagesMultipartBody(t, imageBytes)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/team-a/v1/images/edits" {
+			t.Errorf("path = %q", request.URL.Path)
+		}
+		if request.Header.Get("Authorization") != "Bearer "+testAPIKey {
+			t.Errorf("Authorization = %q", request.Header.Get("Authorization"))
+		}
+		mediaType, parameters, err := mime.ParseMediaType(request.Header.Get("Content-Type"))
+		if err != nil || mediaType != "multipart/form-data" || parameters["boundary"] == "" {
+			t.Errorf("Content-Type = %q: %v", request.Header.Get("Content-Type"), err)
+			return
+		}
+		reader := multipart.NewReader(request.Body, parameters["boundary"])
+		seen := make(map[string]bool)
+		for {
+			part, nextErr := reader.NextRawPart()
+			if nextErr == io.EOF {
+				break
+			}
+			if nextErr != nil {
+				t.Errorf("NextRawPart() error = %v", nextErr)
+				return
+			}
+			_, disposition, parseErr := mime.ParseMediaType(part.Header.Get("Content-Disposition"))
+			if parseErr != nil {
+				t.Errorf("Content-Disposition = %q: %v", part.Header.Get("Content-Disposition"), parseErr)
+				return
+			}
+			name := disposition["name"]
+			seen[name] = true
+			data, readErr := io.ReadAll(part)
+			if readErr != nil {
+				t.Errorf("ReadAll(%q) error = %v", name, readErr)
+				return
+			}
+			switch name {
+			case "model":
+				if string(data) != "provider-image" {
+					t.Errorf("model = %q", data)
+				}
+			case "image[]":
+				if !bytes.Equal(data, imageBytes) {
+					t.Errorf("image data = %x", data)
+				}
+			case "api_key", "provider", "fallbacks":
+				t.Errorf("control part %q reached upstream", name)
+			}
+		}
+		for _, name := range []string{"prompt", "model", "stream", "image[]", "future"} {
+			if !seen[name] {
+				t.Errorf("part %q is missing", name)
+			}
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(writer, `{"created":1,"data":[{"b64_json":"b2s="}]}`)
+	}))
+	defer server.Close()
+
+	manager, _ := newNewAPIManagerForTest(t, server.URL+"/team-a")
+	spec := openAIImagesSpec(
+		channel.NewAPI,
+		server.URL+"/team-a",
+		execution.OperationImagesEdit,
+		"/v1/images/edits",
+		contentType,
+		body,
+	)
+	result := manager.Execute(context.Background(), spec)
+	if err := result.Validate(); err != nil || result.Error != nil || result.StatusCode != http.StatusOK {
+		t.Fatalf("result = %+v, validation=%v", result, err)
+	}
+}
+
+func TestNewAPIGeminiAcceptsOpenAIStyleErrorEnvelope(t *testing.T) {
+	t.Parallel()
+
+	const responseBody = `{"error":{"type":"rate_limit_error","message":"retry later"}}`
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/team-a/v1beta/models/upstream-model:generateContent" {
+			t.Errorf("path = %q", request.URL.Path)
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(writer, responseBody)
+	}))
+	defer server.Close()
+
+	manager, resolved := newNewAPIManagerForTest(t, server.URL+"/team-a")
+	spec := freezeTestAttempt(execution.AttemptSpec{
+		RequestID: "newapi-gemini-error", AttemptID: "newapi-gemini-error-attempt", Sequence: 1,
+		ChannelID: string(channel.NewAPI), ClientProtocol: protocol.Gemini,
+		Operation:   execution.OperationChatCompletion,
+		ClientModel: "client-model", UpstreamModel: "upstream-model",
+		Method: http.MethodPost, Path: "/v1beta/models/client-model:generateContent",
+		Header:       http.Header{"Content-Type": {"application/json"}},
+		Body:         []byte(`{"contents":[{"role":"user","parts":[{"text":"hello"}]}]}`),
+		TargetConfig: resolved.TargetConfig,
+		Credential: execution.NewCredentialSnapshot(
+			17, 1, 1, []byte(`{"api_key":"`+testAPIKey+`"}`),
+		),
+	})
+	result := manager.Execute(context.Background(), spec)
+	if err := result.Validate(); err != nil || result.Error == nil ||
+		result.Error.Kind != execution.ErrorKindHTTP || result.StatusCode != http.StatusTooManyRequests ||
+		result.UpstreamProtocol != protocol.Gemini || !bytes.Equal(result.Body, []byte(responseBody)) {
+		t.Fatalf("result = %+v, validation=%v, body=%s", result, err, result.Body)
+	}
+}
+
+func TestResolveNewAPITargetURLPreservesEncodedDeploymentPrefix(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolveNewAPITargetURL(
+		"https://relay.example/team%2Fone/",
+		"/v1/models",
+		"cursor=next%2Fpage",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = "https://relay.example/team%2Fone/v1/models?cursor=next%2Fpage"
+	if got != want {
+		t.Fatalf("target URL = %q, want %q", got, want)
+	}
+}
+
+func TestNewAPIUtilityOperationsUseGatewayRoot(t *testing.T) {
+	t.Parallel()
+
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		paths = append(paths, request.URL.Path)
+		if request.Header.Get("Authorization") != "Bearer "+testAPIKey {
+			t.Errorf("Authorization = %q", request.Header.Get("Authorization"))
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		switch request.URL.Path {
+		case "/team-a/v1/models":
+			_, _ = io.WriteString(writer, `{"success":true,"object":"list","data":[{"id":"model-one"}]}`)
+		case "/team-a/v1/chat/completions":
+			_, _ = io.WriteString(writer, `{"id":"chat_1","object":"chat.completion","created":1,"model":"probe-upstream","choices":[{"index":0,"message":{"role":"assistant","content":"pong"},"finish_reason":"stop"}]}`)
+		case "/team-a/v1/embeddings":
+			_, _ = io.WriteString(writer, `{"object":"list","data":[{"object":"embedding","index":0,"embedding":[0.1]}],"model":"probe-upstream","usage":{"prompt_tokens":1,"total_tokens":1}}`)
+		default:
+			writer.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	manager, resolved := newNewAPIManagerForTest(t, server.URL+"/team-a")
+	models := utilitySpec(channel.NewAPI, protocol.OpenAICompletions, execution.OperationListModels, http.MethodGet, "/v1/models", nil)
+	models.TargetConfig = resolved.TargetConfig
+	models = freezeTestAttempt(models)
+	modelsResult := manager.Execute(context.Background(), models)
+	if err := modelsResult.Validate(); err != nil || modelsResult.Error != nil ||
+		!bytes.Contains(modelsResult.Body, []byte(`"id":"model-one"`)) {
+		t.Fatalf("models result = %+v err=%v body=%s", modelsResult, err, modelsResult.Body)
+	}
+
+	chatProbe := utilitySpec(channel.NewAPI, protocol.OpenAICompletions, execution.OperationProbe, "", "", nil)
+	chatProbe.TargetConfig = resolved.TargetConfig
+	chatProbe.ClientModel, chatProbe.UpstreamModel = "probe-client", "probe-upstream"
+	chatProbe = freezeTestAttempt(chatProbe)
+	chatResult := manager.Execute(context.Background(), chatProbe)
+	if err := chatResult.Validate(); err != nil || chatResult.Error != nil {
+		t.Fatalf("chat probe = %+v err=%v", chatResult, err)
+	}
+
+	embeddingProbe := utilitySpec(channel.NewAPI, protocol.OpenAIEmbeddings, execution.OperationProbe, "", "", nil)
+	embeddingProbe.TargetConfig = resolved.TargetConfig
+	embeddingProbe.ClientModel, embeddingProbe.UpstreamModel = "probe-client", "probe-upstream"
+	embeddingProbe = freezeTestAttempt(embeddingProbe)
+	embeddingResult := manager.Execute(context.Background(), embeddingProbe)
+	if err := embeddingResult.Validate(); err != nil || embeddingResult.Error != nil {
+		t.Fatalf("embedding probe = %+v err=%v", embeddingResult, err)
+	}
+
+	wantPaths := []string{
+		"/team-a/v1/models",
+		"/team-a/v1/chat/completions",
+		"/team-a/v1/embeddings",
+	}
+	if !reflect.DeepEqual(paths, wantPaths) {
+		t.Fatalf("utility paths = %#v, want %#v", paths, wantPaths)
+	}
+}
+
+func TestNewAPIResponsesResourceSemanticsFailBeforeDispatch(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		calls++
+		writer.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	manager, resolved := newNewAPIManagerForTest(t, server.URL+"/team-a")
+	spec := freezeTestAttempt(execution.AttemptSpec{
+		RequestID: "responses-resource", AttemptID: "responses-resource-attempt", Sequence: 1,
+		ChannelID: string(channel.NewAPI), ClientProtocol: protocol.OpenAIResponses,
+		Operation: execution.OperationResponsesCreate, RouteRequirement: execution.RouteRequirementNative,
+		ClientModel: "client-model", UpstreamModel: "upstream-model",
+		Method: http.MethodPost, Path: "/v1/responses",
+		Header:       http.Header{"Content-Type": {"application/json"}},
+		Body:         []byte(`{"model":"client-model","input":"hello"}`),
+		TargetConfig: resolved.TargetConfig,
+		Credential: execution.NewCredentialSnapshot(
+			17, 1, 1, []byte(`{"api_key":"`+testAPIKey+`"}`),
+		),
+	})
+	result := manager.Execute(context.Background(), spec)
+	if err := result.Validate(); err != nil || result.DispatchState != execution.DispatchNotSent || result.Error == nil {
+		t.Fatalf("resource result = %+v err=%v", result, err)
+	}
+	if calls != 0 {
+		t.Fatalf("upstream calls = %d, want 0", calls)
+	}
+}
+
+func TestNewAPINativeStreamsKeepProtocolWireAndUsage(t *testing.T) {
+	t.Parallel()
+
+	const openAIStream = "data: {\"id\":\"chat_1\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"stream-model\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"ok\"},\"finish_reason\":null}]}\n\n" +
+		"data: {\"id\":\"chat_1\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"stream-model\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":2,\"total_tokens\":7}}\n\n" +
+		"data: [DONE]\n\n"
+	tests := []struct {
+		name             string
+		clientProtocol   protocol.Protocol
+		path             string
+		body             string
+		wantPath         string
+		credentialHeader string
+		stream           string
+	}{
+		{
+			name: "completions", clientProtocol: protocol.OpenAICompletions,
+			path: "/v1/chat/completions", wantPath: "/team-a/v1/chat/completions",
+			body:             `{"model":"stream-model","stream":true,"messages":[{"role":"user","content":"hello"}]}`,
+			credentialHeader: "Authorization", stream: openAIStream,
+		},
+		{
+			name: "anthropic", clientProtocol: protocol.Anthropic,
+			path: "/v1/messages", wantPath: "/team-a/v1/messages",
+			body:             `{"model":"stream-model","stream":true,"max_tokens":16,"messages":[{"role":"user","content":"hello"}]}`,
+			credentialHeader: "X-Api-Key", stream: anthropicResponsesStreamFixture,
+		},
+		{
+			name: "gemini", clientProtocol: protocol.Gemini,
+			path:             "/v1beta/models/stream-model:streamGenerateContent",
+			wantPath:         "/team-a/v1beta/models/stream-model:streamGenerateContent",
+			body:             `{"contents":[{"role":"user","parts":[{"text":"hello"}]}]}`,
+			credentialHeader: "X-Goog-Api-Key", stream: geminiResponsesStreamFixture,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				if request.URL.Path != test.wantPath || request.URL.Query().Get("trace") != "kept" ||
+					request.URL.Query().Get("key") != "" {
+					t.Errorf("stream target = %s?%s", request.URL.Path, request.URL.RawQuery)
+				}
+				if test.clientProtocol == protocol.Gemini && request.URL.Query().Get("alt") != "sse" {
+					t.Errorf("Gemini alt = %q", request.URL.Query().Get("alt"))
+				}
+				wantCredential := testAPIKey
+				if test.credentialHeader == "Authorization" {
+					wantCredential = "Bearer " + testAPIKey
+				}
+				if request.Header.Get(test.credentialHeader) != wantCredential {
+					t.Errorf("credential %s = %q", test.credentialHeader, request.Header.Get(test.credentialHeader))
+				}
+				writer.Header().Set("Content-Type", "text/event-stream")
+				writer.WriteHeader(http.StatusOK)
+				_, _ = io.WriteString(writer, test.stream)
+				writer.(http.Flusher).Flush()
+			}))
+			defer server.Close()
+
+			manager, resolved := newNewAPIManagerForTest(t, server.URL+"/team-a")
+			spec := freezeTestAttempt(execution.AttemptSpec{
+				RequestID: "newapi-stream", AttemptID: "newapi-stream-attempt", Sequence: 1,
+				ChannelID: string(channel.NewAPI), ClientProtocol: test.clientProtocol,
+				Operation:   execution.OperationChatCompletion,
+				ClientModel: "stream-model", UpstreamModel: "stream-model",
+				Method: http.MethodPost, Path: test.path,
+				RawQuery: "trace=kept&key=client-query&alt=client",
+				Header: http.Header{
+					"Authorization":  {"Bearer client-auth"},
+					"X-Api-Key":      {"client-auth"},
+					"X-Goog-Api-Key": {"client-auth"},
+					"Content-Type":   {"application/json"},
+				},
+				Body: []byte(test.body), TargetConfig: resolved.TargetConfig,
+				Credential: execution.NewCredentialSnapshot(
+					17, 1, 1, []byte(`{"api_key":"`+testAPIKey+`"}`),
+				),
+			})
+			var data bytes.Buffer
+			result := manager.ExecuteStream(context.Background(), spec, func(event execution.StreamEvent) error {
+				if event.Kind == execution.StreamEventData {
+					data.Write(event.Data)
+				}
+				return nil
+			})
+			if err := result.Validate(); err != nil || result.Error != nil || result.Usage == nil ||
+				result.UpstreamProtocol != test.clientProtocol || data.String() != test.stream {
+				t.Fatalf("stream result = %+v err=%v data=%q", result, err, data.String())
+			}
+		})
+	}
+}
+
+func newNewAPIManagerForTest(t *testing.T, baseURL string) (*RuntimeManager, channel.ResolvedTarget) {
+	t.Helper()
+
+	registry := channel.NewRegistry()
+	resolved, err := registry.Resolve(
+		channel.NewAPI,
+		json.RawMessage(`{"base_url":"`+baseURL+`"}`),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager, err := newRuntimeManager(runtimeOptions{allowPrivateNetwork: true}, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.Start(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(manager.Shutdown)
+	if err := manager.Reconcile([]provideradapter.RuntimeTarget{{Target: resolved}}); err != nil {
+		t.Fatal(err)
+	}
+	return manager, resolved
+}
+
+func TestNewAPIRuntimeProfilesUseOneGatewayRoot(t *testing.T) {
+	t.Parallel()
+
+	registry := channel.NewRegistry()
+	resolved, err := registry.Resolve(
+		channel.NewAPI,
+		json.RawMessage(`{"base_url":"https://relay.example/team-a"}`),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name         string
+		protocol     protocol.Protocol
+		operation    execution.Operation
+		wantProvider schemas.ModelProvider
+	}{
+		{name: "completions", protocol: protocol.OpenAICompletions, operation: execution.OperationChatCompletion, wantProvider: schemas.OpenAI},
+		{name: "responses", protocol: protocol.OpenAIResponses, operation: execution.OperationResponsesCreate, wantProvider: schemas.OpenAI},
+		{name: "images", protocol: protocol.OpenAIImages, operation: execution.OperationImagesGenerate, wantProvider: schemas.OpenAI},
+		{name: "embeddings", protocol: protocol.OpenAIEmbeddings, operation: execution.OperationEmbeddingsCreate, wantProvider: schemas.OpenAI},
+		{name: "anthropic", protocol: protocol.Anthropic, operation: execution.OperationChatCompletion, wantProvider: schemas.Anthropic},
+		{name: "gemini", protocol: protocol.Gemini, operation: execution.OperationChatCompletion, wantProvider: schemas.Gemini},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config, err := buildEffectiveProviderConfigForAttempt(
+				resolved,
+				execution.AttemptSpec{
+					ClientProtocol: test.protocol,
+					Operation:      test.operation,
+					RouteMode:      execution.RouteNative,
+				},
+				true,
+			)
+			if err != nil {
+				t.Fatalf("buildEffectiveProviderConfigForAttempt() error = %v", err)
+			}
+			if config.provider != test.wantProvider || config.custom ||
+				config.targetBaseURL != "https://relay.example/team-a" ||
+				config.providerConfig.NetworkConfig.BaseURL != "https://relay.example/team-a" {
+				t.Fatalf("New API config = provider %q custom %t target %q network %q", config.provider, config.custom, config.targetBaseURL, config.providerConfig.NetworkConfig.BaseURL)
+			}
+		})
+	}
+}
+
+func TestNewAPIReconcileKeepsEveryRuntimeProfileActive(t *testing.T) {
+	t.Parallel()
+
+	registry := channel.NewRegistry()
+	resolved, err := registry.Resolve(
+		channel.NewAPI,
+		json.RawMessage(`{"base_url":"https://relay.example/team-a"}`),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager, err := newRuntimeManager(runtimeOptions{allowPrivateNetwork: true}, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.Reconcile([]provideradapter.RuntimeTarget{{Target: resolved}}); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	expected := make([]effectiveProviderConfig, 0, 3)
+	for _, clientProtocol := range []protocol.Protocol{
+		protocol.OpenAICompletions,
+		protocol.Anthropic,
+		protocol.Gemini,
+	} {
+		config, err := buildEffectiveProviderConfigForAttempt(
+			resolved,
+			execution.AttemptSpec{ClientProtocol: clientProtocol, RouteMode: execution.RouteNative},
+			true,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expected = append(expected, config)
+	}
+
+	assertActive := func(want []effectiveProviderConfig) {
+		t.Helper()
+		manager.pool.mu.Lock()
+		defer manager.pool.mu.Unlock()
+		if len(manager.pool.active) != len(want) {
+			t.Fatalf("active runtime configs = %d, want %d", len(manager.pool.active), len(want))
+		}
+		for _, config := range want {
+			active, ok := manager.pool.active[config.fingerprint]
+			if !ok || !bytes.Equal(active, config.canonical) {
+				t.Errorf("profile %q is not active", config.provider)
+			}
+		}
+	}
+	assertActive(expected)
+
+	effectiveProxy := outboundproxy.Effective{
+		Config: outboundproxy.Config{Mode: outboundproxy.ModeCustom, URL: "http://proxy.example.com:8080"},
+		Source: outboundproxy.SourceGroup,
+	}
+	if err := manager.Reconcile([]provideradapter.RuntimeTarget{{
+		Target: resolved,
+		Proxy:  effectiveProxy,
+	}}); err != nil {
+		t.Fatalf("Reconcile(proxy) error = %v", err)
+	}
+	expectedWithProxy := append([]effectiveProviderConfig(nil), expected...)
+	for _, clientProtocol := range []protocol.Protocol{
+		protocol.OpenAICompletions,
+		protocol.Anthropic,
+		protocol.Gemini,
+	} {
+		config, err := buildEffectiveProviderConfigForAttempt(
+			resolved,
+			execution.AttemptSpec{
+				ClientProtocol: clientProtocol,
+				RouteMode:      execution.RouteNative,
+				Proxy:          effectiveProxy,
+			},
+			true,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expectedWithProxy = append(expectedWithProxy, config)
+	}
+	assertActive(expectedWithProxy)
+}
+
+func TestNewAPIRouteCapabilityMatchesDeclaredOperations(t *testing.T) {
+	t.Parallel()
+
+	registry := channel.NewRegistry()
+	manager, err := newRuntimeManager(runtimeOptions{}, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	descriptor, ok := registry.Get(channel.NewAPI)
+	if !ok {
+		t.Fatal("New API channel is missing")
+	}
+	for _, route := range descriptor.Routes {
+		if err := manager.ValidateRouteCapability(channel.ProviderNewAPI, route); err != nil {
+			t.Errorf("route %s/%s/%s rejected: %v", route.ClientProtocol, route.Operation, route.RouteMode, err)
+		}
+	}
+	for _, unsupported := range []channel.RouteDescriptor{
+		{ClientProtocol: protocol.Anthropic, Operation: execution.OperationCountTokens, RouteMode: execution.RouteNative},
+		{ClientProtocol: protocol.Gemini, Operation: execution.OperationCountTokens, RouteMode: execution.RouteNative},
+		{ClientProtocol: protocol.OpenAIResponses, Operation: execution.OperationResponsesRetrieve, RouteMode: execution.RouteNative},
+	} {
+		if err := manager.ValidateRouteCapability(channel.ProviderNewAPI, unsupported); err == nil {
+			t.Errorf("unsupported route accepted: %#v", unsupported)
+		}
+	}
+}

--- a/internal/execution/bifrost/runtime_manager.go
+++ b/internal/execution/bifrost/runtime_manager.go
@@ -43,6 +43,9 @@ func buildEffectiveProviderConfig(
 	resolved channel.ResolvedTarget,
 	allowPrivateNetwork bool,
 ) (effectiveProviderConfig, error) {
+	if resolved.ProviderKind == channel.ProviderNewAPI {
+		return buildNewAPIProviderConfig(resolved, schemas.OpenAI, allowPrivateNetwork)
+	}
 	provider, baseURL, custom, err := resolveSDKProviderConfig(resolved)
 	if err != nil {
 		return effectiveProviderConfig{}, err
@@ -95,7 +98,17 @@ func buildEffectiveProviderConfigForAttempt(
 	spec execution.AttemptSpec,
 	allowPrivateNetwork bool,
 ) (effectiveProviderConfig, error) {
-	base, err := buildEffectiveProviderConfig(resolved, allowPrivateNetwork)
+	var base effectiveProviderConfig
+	var err error
+	if resolved.ProviderKind == channel.ProviderNewAPI {
+		provider, profileErr := newAPIProviderProfile(spec.ClientProtocol)
+		if profileErr != nil {
+			return effectiveProviderConfig{}, profileErr
+		}
+		base, err = buildNewAPIProviderConfig(resolved, provider, allowPrivateNetwork)
+	} else {
+		base, err = buildEffectiveProviderConfig(resolved, allowPrivateNetwork)
+	}
 	if err != nil {
 		return base, err
 	}
@@ -123,6 +136,33 @@ func buildEffectiveProviderConfigForAttempt(
 		return effectiveProviderConfig{}, err
 	}
 	return applyAttemptProxy(base, spec.Proxy)
+}
+
+func newAPIProviderProfile(clientProtocol protocol.Protocol) (schemas.ModelProvider, error) {
+	switch clientProtocol {
+	case "", protocol.OpenAICompletions, protocol.OpenAIResponses,
+		protocol.OpenAIImages, protocol.OpenAIEmbeddings:
+		return schemas.OpenAI, nil
+	case protocol.Anthropic:
+		return schemas.Anthropic, nil
+	case protocol.Gemini:
+		return schemas.Gemini, nil
+	default:
+		return "", fmt.Errorf("unsupported New API client protocol %q", clientProtocol)
+	}
+}
+
+func buildNewAPIProviderConfig(
+	resolved channel.ResolvedTarget,
+	provider schemas.ModelProvider,
+	allowPrivateNetwork bool,
+) (effectiveProviderConfig, error) {
+	baseURL, configured, err := targetBaseURL(resolved.TargetConfig)
+	if err != nil || !configured {
+		return effectiveProviderConfig{}, fmt.Errorf("New API gateway root is required")
+	}
+	config := buildProviderConfig(provider, baseURL, false, provider, allowPrivateNetwork)
+	return newEffectiveProviderConfig(provider, baseURL, false, config)
 }
 
 func applyAttemptProxy(
@@ -685,9 +725,41 @@ func (manager *RuntimeManager) Reconcile(targets []provideradapter.RuntimeTarget
 	if manager == nil || manager.pool == nil {
 		return fmt.Errorf("reconcile provider runtimes: manager is unavailable")
 	}
-	configs := make([]effectiveProviderConfig, 0, len(targets)*4)
+	configs := make([]effectiveProviderConfig, 0, len(targets)*6)
 	for _, runtimeTarget := range targets {
 		target := runtimeTarget.Target
+		if target.ProviderKind == channel.ProviderNewAPI {
+			for _, clientProtocol := range []protocol.Protocol{
+				protocol.OpenAICompletions,
+				protocol.Anthropic,
+				protocol.Gemini,
+			} {
+				baseSpec := execution.AttemptSpec{
+					ClientProtocol: clientProtocol,
+					RouteMode:      execution.RouteNative,
+				}
+				baseConfig, baseErr := buildEffectiveProviderConfigForAttempt(
+					target,
+					baseSpec,
+					manager.options.allowPrivateNetwork,
+				)
+				if baseErr != nil {
+					return fmt.Errorf("reconcile provider runtime %q profile %q: %w", target.ChannelID, clientProtocol, baseErr)
+				}
+				configs = append(configs, baseConfig)
+				baseSpec.Proxy = runtimeTarget.Proxy
+				effectiveConfig, effectiveErr := buildEffectiveProviderConfigForAttempt(
+					target,
+					baseSpec,
+					manager.options.allowPrivateNetwork,
+				)
+				if effectiveErr != nil {
+					return fmt.Errorf("reconcile provider runtime %q profile %q proxy: %w", target.ChannelID, clientProtocol, effectiveErr)
+				}
+				configs = append(configs, effectiveConfig)
+			}
+			continue
+		}
 		config, err := buildEffectiveProviderConfig(target, manager.options.allowPrivateNetwork)
 		if err != nil {
 			return fmt.Errorf("reconcile provider runtime %q: %w", target.ChannelID, err)

--- a/internal/provideradapter/registry_test.go
+++ b/internal/provideradapter/registry_test.go
@@ -122,6 +122,7 @@ func completeBindings(bifrost execution.Executor, codex execution.Executor) []Bi
 		{ProviderKind: channel.ProviderOpenAI, Adapter: bifrost},
 		{ProviderKind: channel.ProviderAnthropic, Adapter: bifrost},
 		{ProviderKind: channel.ProviderGemini, Adapter: bifrost},
+		{ProviderKind: channel.ProviderNewAPI, Adapter: bifrost},
 		{ProviderKind: channel.ProviderOpenAICompatible, Adapter: bifrost},
 		{ProviderKind: channel.ProviderAzureOpenAI, Adapter: bifrost},
 		{ProviderKind: channel.ProviderAWSBedrock, Adapter: bifrost},

--- a/web/src/features/groups/settings/GroupSettingsBaseForm.vue
+++ b/web/src/features/groups/settings/GroupSettingsBaseForm.vue
@@ -78,6 +78,13 @@ function updateParam(field: ChannelFieldDto, value: string): void {
   emit('update:param', field.key, value)
 }
 
+function parameterHelp(field: ChannelFieldDto): string {
+  if (field.key === 'base_url' && props.channelId === 'newapi') {
+    return t('group.settings.base.newApiUrlDescription')
+  }
+  return t('group.settings.base.urlWarning')
+}
+
 function setWeightMode(value: string): void {
   if (props.pending) return
   emit('update:weightManual', value === 'auto' ? null : (props.weightManual ?? 50))
@@ -153,9 +160,7 @@ function setWeightMode(value: string): void {
             @input="updateParam(field, ($event.target as HTMLInputElement).value)"
           />
           <small v-if="paramErrors[field.key]" role="alert">{{ paramErrors[field.key] }}</small>
-          <small v-else-if="field.input_kind === 'url'">{{
-            t('group.settings.base.urlWarning')
-          }}</small>
+          <small v-else-if="field.input_kind === 'url'">{{ parameterHelp(field) }}</small>
         </label>
       </template>
     </div>

--- a/web/src/features/import/ImportConnectionSection.vue
+++ b/web/src/features/import/ImportConnectionSection.vue
@@ -68,6 +68,9 @@ function isOptionalBaseURL(key: string, required: boolean): boolean {
 }
 
 function baseURLDescription(): string {
+  if (props.channel?.channel_id === 'newapi') {
+    return t('import.connection.newApiUrlDescription')
+  }
   if (props.channel?.channel_id === 'openai_compatible') {
     return t('import.connection.compatibleUrlDescription')
   }

--- a/web/src/i18n/locales/en-US/group.ts
+++ b/web/src/i18n/locales/en-US/group.ts
@@ -225,6 +225,8 @@ export default {
         upstreamUrl: 'Upstream URL',
         upstreamUrlError: 'Enter a valid HTTP or HTTPS Base URL.',
         urlWarning: 'Changing the Base URL changes where future Group requests are sent.',
+        newApiUrlDescription:
+          'Enter the New API gateway root or deployment prefix. Do not include standard protocol paths such as /v1 or /v1beta.',
         customUrl: 'Custom upstream URL',
         customUrlHelp: 'Uses the channel preset or SDK official address by default.',
         paramRequired: 'Enter {field}.',

--- a/web/src/i18n/locales/en-US/import.ts
+++ b/web/src/i18n/locales/en-US/import.ts
@@ -98,6 +98,8 @@ export default {
       urlDescription: 'Enter the Base URL required by the upstream service',
       compatibleUrlDescription:
         'Enter the complete API prefix, for example https://api.example.com/v1',
+      newApiUrlDescription:
+        'Enter the New API gateway root or deployment prefix, for example https://relay.example.com/team-a. Do not include standard protocol paths such as /v1 or /v1beta.',
       urlDescriptionWithDefault: 'Default URL: {url}',
       urlVersionWarning: 'Version path may differ; please verify',
       customUrl: 'Custom upstream URL',

--- a/web/src/i18n/locales/ja-JP/group.ts
+++ b/web/src/i18n/locales/ja-JP/group.ts
@@ -224,6 +224,8 @@ export default {
         upstreamUrl: 'アップストリーム URL',
         upstreamUrlError: '有効な HTTP または HTTPS の Base URL を入力してください。',
         urlWarning: 'Base URL を変更すると、今後のグループリクエストの送信先が変わります。',
+        newApiUrlDescription:
+          'New API ゲートウェイのルートまたはデプロイ接頭辞を入力してください。/v1 や /v1beta などの標準プロトコルパスは含めないでください。',
         customUrl: 'カスタム上流 URL',
         customUrlHelp: '既定ではチャネル設定または SDK 公式アドレスを使用します。',
         paramRequired: '{field} を入力してください。',

--- a/web/src/i18n/locales/ja-JP/import.ts
+++ b/web/src/i18n/locales/ja-JP/import.ts
@@ -96,6 +96,8 @@ export default {
       urlDescription: 'アップストリームサービスが要求する Base URL を入力してください',
       compatibleUrlDescription:
         'https://api.example.com/v1 のように完全な API プレフィックスを入力してください',
+      newApiUrlDescription:
+        'New API ゲートウェイのルートまたはデプロイ接頭辞を入力します（例: https://relay.example.com/team-a）。/v1 や /v1beta などの標準プロトコルパスは含めないでください。',
       urlDescriptionWithDefault: '既定の URL：{url}',
       urlVersionWarning: 'バージョンパスが異なる可能性があります。確認してください',
       customUrl: 'カスタム上流 URL',

--- a/web/src/i18n/locales/zh-CN/group.ts
+++ b/web/src/i18n/locales/zh-CN/group.ts
@@ -219,6 +219,8 @@ export default {
         upstreamUrl: '上游地址',
         upstreamUrlError: '请输入有效的 HTTP 或 HTTPS Base URL。',
         urlWarning: '修改 Base URL 会影响此分组后续请求的发送位置。',
+        newApiUrlDescription:
+          '填写 New API 网关根地址或部署前缀；不要填写 /v1 或 /v1beta 等标准协议路径。',
         customUrl: '自定义上游地址',
         customUrlHelp: '默认使用渠道预设或 SDK 官方地址。',
         paramRequired: '请输入{field}。',

--- a/web/src/i18n/locales/zh-CN/import.ts
+++ b/web/src/i18n/locales/zh-CN/import.ts
@@ -92,6 +92,8 @@ export default {
       url: '上游基础地址',
       urlDescription: '请按上游服务要求填写 Base URL',
       compatibleUrlDescription: '填写完整 API 前缀，例如 https://api.example.com/v1',
+      newApiUrlDescription:
+        '填写 New API 网关根地址或部署前缀，例如 https://relay.example.com/team-a；不要填写 /v1 或 /v1beta 等标准协议路径',
       urlDescriptionWithDefault: '默认地址：{url}',
       urlVersionWarning: '版本路径可能不一致，请确认',
       customUrl: '自定义上游地址',

--- a/web/src/lib/upstream-base-url.ts
+++ b/web/src/lib/upstream-base-url.ts
@@ -6,6 +6,8 @@ export function isValidUpstreamBaseURL(value: string): boolean {
       parsed.hostname !== '' &&
       parsed.username === '' &&
       parsed.password === '' &&
+      parsed.search === '' &&
+      !value.trim().endsWith('?') &&
       parsed.hash === ''
     )
   } catch {


### PR DESCRIPTION
### 关联 Issue / Related Issue
Closes #521

### 变更内容 / Change Content
- [ ] Bug 修复 / Bug fix
- [x] 新功能 / New feature
- [ ] 其他改动 / Other changes

- 增加独立的 `New API` 渠道预设，使用必填的网关根地址（或部署前缀）与 API Key，支持 OpenAI Completions、Responses、Images、Embeddings、Anthropic、Gemini 六种原生协议。
- 由同一个可配置根地址拼接各协议的标准请求路径；保留自定义部署前缀，不把 `/v1` 或 `/v1beta` 固化到用户配置中。
- 为 OpenAI、Anthropic、Gemini 建立独立运行配置，支持统一出站代理，并保持原生请求、流式响应、模型重写和凭据清理语义。
- 模型发现固定使用根地址下的 `/v1/models`，兼容 New API 的 `success` 响应字段，并拒绝显式的 `success: false` 失败响应。
- 在新建分组和分组设置中说明 New API 地址填写规则，同时让前端 URL 校验与后端一致地拒绝查询参数。
- Responses 仅声明已验证的无状态 create 与 compact，不声明资源生命周期接口；Anthropic/Gemini 不声明未经验证的 count tokens。

兼容性说明：不涉及数据库 Schema 或持久化格式迁移，现有渠道行为不变。旧版本不认识 `newapi` 渠道，回滚前需先移除或替换使用该渠道的分组。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增 New API 内置渠道，支持通过网关接入 OpenAI、Anthropic 和 Gemini 等协议。
  - 支持补全、响应、图像、嵌入、对话及模型发现等操作，并兼容部署前缀。
  - 配置与导入界面新增 New API 地址填写说明。

- **问题修复**
  - 模型发现遇到明确失败响应时会及时报告错误。
  - 上游地址校验现在会拒绝包含查询参数或无效结尾问号的地址。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->