### PR TITLE
fix: route default openai-responses creates to NewAPI

### DIFF
--- a/internal/channel/modules/newapi.go
+++ b/internal/channel/modules/newapi.go
@@ -34,7 +34,12 @@ func NewAPI() spec.Module {
 				spec.NewRoute(protocol.OpenAICompletions, execution.OperationChatCompletion, execution.RouteNative),
 				spec.NewRoute(protocol.OpenAICompletions, execution.OperationListModels, execution.RouteNative),
 				spec.NewRoute(protocol.OpenAICompletions, execution.OperationProbe, execution.RouteNative),
-				spec.NewRoute(protocol.OpenAIResponses, execution.OperationResponsesCreate, execution.RouteNative),
+				{
+					ClientProtocol:              protocol.OpenAIResponses,
+					Operation:                   execution.OperationResponsesCreate,
+					Mode:                        execution.RouteNative,
+					ResponsesStoreCompatibility: spec.ResponsesStoreCompatibilityStateless,
+				},
 				spec.NewRoute(protocol.OpenAIResponses, execution.OperationResponsesCompact, execution.RouteNative),
 				spec.NewRoute(protocol.OpenAIImages, execution.OperationImagesGenerate, execution.RouteNative),
 				spec.NewRoute(protocol.OpenAIImages, execution.OperationImagesEdit, execution.RouteNative),

--- a/internal/channel/newapi_module_test.go
+++ b/internal/channel/newapi_module_test.go
@@ -53,6 +53,12 @@ func TestNewAPIChannelContract(t *testing.T) {
 	if target.SupportsResponsesLifecycle() {
 		t.Fatal("New API must not advertise a complete Responses lifecycle")
 	}
+	if got := target.ResponsesStoreCompatibility(
+		protocol.OpenAIResponses,
+		execution.OperationResponsesCreate,
+	); got != ResponsesStoreCompatibilityStateless {
+		t.Fatalf("New API Responses create store compatibility = %q, want stateless", got)
+	}
 
 	wantRoutes := map[protocol.Protocol]map[execution.Operation]RouteMode{
 		protocol.OpenAICompletions: {

--- a/internal/channel/registry_test.go
+++ b/internal/channel/registry_test.go
@@ -807,7 +807,7 @@ func TestOpenRouterUsesNativeChatAndResponsesWithoutLifecycle(t *testing.T) {
 
 func TestOnlyVerifiedNativeSubscriptionChannelsDeclareStatelessResponsesStore(t *testing.T) {
 	registry := NewRegistry()
-	verified := map[ID]struct{}{Codex: {}, Grok: {}}
+	verified := map[ID]struct{}{Codex: {}, Grok: {}, NewAPI: {}}
 
 	key := routeKey{
 		clientProtocol: protocol.OpenAIResponses,

--- a/internal/scheduler/channel_scheduler_test.go
+++ b/internal/scheduler/channel_scheduler_test.go
@@ -470,6 +470,60 @@ func TestOpenRouterRoutesResponsesWithReasoningOptOut(t *testing.T) {
 	}
 }
 
+func TestNewAPIRoutesDefaultResponsesCreate(t *testing.T) {
+	t.Parallel()
+
+	snapshot, err := state.Compile(state.CompileInput{
+		ChannelRegistry: channel.NewRegistry(),
+		Groups: []state.GroupConfig{{
+			ConnectionType: "api_key", ID: 12, Name: "newapi", ChannelID: channel.NewAPI,
+			Params: json.RawMessage(`{"base_url":"https://newapi.example/team-a"}`), Enabled: true,
+			Models: []state.ModelConfig{{ID: "gpt-5.6-luna", Alias: "gpt-5.6-luna"}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Compile() error = %v", err)
+	}
+
+	tests := []struct {
+		body       string
+		downgraded bool
+	}{
+		{body: `{"model":"gpt-5.6-luna","input":"hello"}`, downgraded: true},
+		{body: `{"model":"gpt-5.6-luna","input":"hello","store":true}`, downgraded: true},
+		{body: `{"model":"gpt-5.6-luna","input":"hello","store":false}`},
+	}
+	for _, test := range tests {
+		metadata, err := dialect.NewOpenAIResponses().InspectRequest(&dialect.ParsedRequest{
+			Method: http.MethodPost,
+			Path:   "/v1/responses",
+			Body:   []byte(test.body),
+		})
+		if err != nil {
+			t.Fatalf("InspectRequest(%s) error = %v", test.body, err)
+		}
+		selection, err := New(snapshot, fakeCredentialSource{keys: []state.CredentialMeta{{
+			ID: 121, GroupID: 12,
+		}}}, Query{
+			ClientProtocol:           protocol.OpenAIResponses,
+			Operation:                metadata.Operation,
+			RouteRequirement:         metadata.RouteRequirement,
+			ResponsesStorePreference: metadata.ResponsesStorePreference,
+			ExternalModel:            modelPointer("gpt-5.6-luna"),
+			AccessKey:                state.AccessKeyView{Status: state.AccessKeyStatusActive},
+		}, rand.New(zeroRandSource{})).Next()
+		if err != nil {
+			t.Fatalf("Next(%s) error = %v", test.body, err)
+		}
+		if selection.GroupID != 12 || selection.ChannelID != channel.NewAPI ||
+			selection.RouteMode != channel.RouteNative || selection.UpstreamModelID == nil ||
+			*selection.UpstreamModelID != "gpt-5.6-luna" ||
+			selection.ResponsesStoreDowngraded != test.downgraded {
+			t.Fatalf("Selection(%s) = %#v, want native New API target downgraded=%t", test.body, selection, test.downgraded)
+		}
+	}
+}
+
 func TestCandidateGroupIDsForQueryRoutesAnthropicThinkingToOpenAICompatible(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Mark NewAPI Responses create as ResponsesStoreCompatibilityStateless so store-omitted / store:true clients are scheduled instead of exhausting with 503 no_available_candidate. Completions were already fine.

Fixes #528

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - New API 的 Responses 创建请求现已采用无状态存储兼容模式。
  - 当请求未指定 `store` 或设置为 `true` 时，系统会自动按无状态方式处理；设置为 `false` 时保持原有行为。
  - New API 请求可正确路由至对应的原生渠道和上游模型。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->