### PR TITLE
fix(release): 固定 v1 镜像通道

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,7 +3,7 @@ name: Build Docker Image
 on:
   push:
     tags:
-      - "*"
+      - "v1.*"
 jobs:
   build_docker_image:
     name: Build Docker Image
@@ -49,7 +49,7 @@ jobs:
           tags: |
             type=ref,event=tag
             type=raw,value=beta,enable=${{ contains(github.ref, '-beta') }}
-            type=raw,value=latest,enable=${{ !contains(github.ref, '-') }}
+            type=raw,value=1,enable=${{ !contains(github.ref, '-') }}
 
       - name: Build and push Docker image
         id: build

--- a/README.md
+++ b/README.md
@@ -74,10 +74,12 @@ docker run -d --name gpt-load \
     -p 3001:3001 \
     -e AUTH_KEY=your-secure-key-here \
     -v "$(pwd)/data":/app/data \
-    ghcr.io/tbphp/gpt-load:latest
+    ghcr.io/tbphp/gpt-load:1
 ```
 
 > Please change `your-secure-key-here` to a strong password (never use the default value), then you can log in to the management interface: <http://localhost:3001>
+
+> The stable Docker tag for the v1 maintenance line is `1`. v1 releases no longer update `latest`; after the transition period, `latest` may move to v2. Existing v1 deployments should pin the image to `:1`.
 
 ### Method 2: Using Docker Compose (Recommended)
 
@@ -88,8 +90,8 @@ docker run -d --name gpt-load \
 mkdir -p gpt-load && cd gpt-load
 
 # Download configuration files
-wget https://raw.githubusercontent.com/tbphp/gpt-load/refs/heads/main/docker-compose.yml
-wget -O .env https://raw.githubusercontent.com/tbphp/gpt-load/refs/heads/main/.env.example
+wget https://raw.githubusercontent.com/tbphp/gpt-load/refs/heads/v1/docker-compose.yml
+wget -O .env https://raw.githubusercontent.com/tbphp/gpt-load/refs/heads/v1/.env.example
 
 # Edit the .env file and change AUTH_KEY to a strong password. Never use default or simple keys like sk-123456.
 
@@ -115,7 +117,7 @@ docker compose logs -f
 # Restart Service
 docker compose down && docker compose up -d
 
-# Update to latest version
+# Update to the latest v1 version
 docker compose pull && docker compose down && docker compose up -d
 ```
 
@@ -306,7 +308,7 @@ GPT-Load supports encrypted storage of API keys. You can enable, disable, or cha
 #### Docker Compose Deployment
 
 ```bash
-# 1. Update the image (ensure using the latest version)
+# 1. Update the image (ensure you are using the latest v1 version)
 docker compose pull
 
 # 2. Stop the service

--- a/README_CN.md
+++ b/README_CN.md
@@ -74,10 +74,12 @@ docker run -d --name gpt-load \
     -p 3001:3001 \
     -e AUTH_KEY=your-secure-key-here \
     -v "$(pwd)/data":/app/data \
-    ghcr.io/tbphp/gpt-load:latest
+    ghcr.io/tbphp/gpt-load:1
 ```
 
 > 请将 `your-secure-key-here` 改为强密码（决不能使用默认值），即可登录管理界面：<http://localhost:3001>
+
+> v1 维护线的稳定 Docker 标签为 `1`。v1 发布不再更新 `latest`；过渡期结束后，`latest` 可能切换至 v2。现有 v1 部署请将镜像固定为 `:1`。
 
 ### 方式二：使用 Docker Compose（推荐）
 
@@ -88,8 +90,8 @@ docker run -d --name gpt-load \
 mkdir -p gpt-load && cd gpt-load
 
 # 下载配置文件
-wget https://raw.githubusercontent.com/tbphp/gpt-load/refs/heads/main/docker-compose.yml
-wget -O .env https://raw.githubusercontent.com/tbphp/gpt-load/refs/heads/main/.env.example
+wget https://raw.githubusercontent.com/tbphp/gpt-load/refs/heads/v1/docker-compose.yml
+wget -O .env https://raw.githubusercontent.com/tbphp/gpt-load/refs/heads/v1/.env.example
 
 # 编辑 .env 文件，修改AUTH_KEY为强密码，绝不使用 sk-123456 等默认或者简单密钥
 
@@ -115,7 +117,7 @@ docker compose logs -f
 # 重启服务
 docker compose down && docker compose up -d
 
-# 更新到最新版本
+# 更新到最新 v1 版本
 docker compose pull && docker compose down && docker compose up -d
 ```
 
@@ -306,7 +308,7 @@ GPT-Load 支持对 API 密钥进行加密存储。您可以随时启用、禁用
 #### Docker Compose 部署
 
 ```bash
-# 1. 更新镜像（确保使用最新版本）
+# 1. 更新镜像（确保使用最新 v1 版本）
 docker compose pull
 
 # 2. 停止服务

--- a/README_JP.md
+++ b/README_JP.md
@@ -74,10 +74,12 @@ docker run -d --name gpt-load \
     -p 3001:3001 \
     -e AUTH_KEY=your-secure-key-here \
     -v "$(pwd)/data":/app/data \
-    ghcr.io/tbphp/gpt-load:latest
+    ghcr.io/tbphp/gpt-load:1
 ```
 
 > `your-secure-key-here`を強力なパスワードに変更してください（デフォルト値は絶対に使用しないでください）。その後、管理インターフェースにログインできます：<http://localhost:3001>
+
+> v1 メンテナンスラインの安定版 Docker タグは `1` です。v1 リリースでは `latest` を更新しません。移行期間の終了後、`latest` は v2 を指す可能性があります。既存の v1 環境ではイメージを `:1` に固定してください。
 
 ### 方法2: Docker Composeを使用（推奨）
 
@@ -88,8 +90,8 @@ docker run -d --name gpt-load \
 mkdir -p gpt-load && cd gpt-load
 
 # 設定ファイルをダウンロード
-wget https://raw.githubusercontent.com/tbphp/gpt-load/refs/heads/main/docker-compose.yml
-wget -O .env https://raw.githubusercontent.com/tbphp/gpt-load/refs/heads/main/.env.example
+wget https://raw.githubusercontent.com/tbphp/gpt-load/refs/heads/v1/docker-compose.yml
+wget -O .env https://raw.githubusercontent.com/tbphp/gpt-load/refs/heads/v1/.env.example
 
 # .envファイルを編集し、AUTH_KEYを強力なパスワードに変更します。デフォルトやsk-123456のような単純なキーは絶対に使用しないでください。
 
@@ -115,7 +117,7 @@ docker compose logs -f
 # サービスを再起動
 docker compose down && docker compose up -d
 
-# 最新バージョンに更新
+# 最新の v1 バージョンに更新
 docker compose pull && docker compose down && docker compose up -d
 ```
 
@@ -306,7 +308,7 @@ GPT-LoadはAPIキーの暗号化保存をサポートしています。いつで
 #### Docker Composeデプロイメント
 
 ```bash
-# 1. イメージを更新（最新バージョンを使用していることを確認）
+# 1. イメージを更新（最新の v1 バージョンを使用していることを確認）
 docker compose pull
 
 # 2. サービスを停止

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   gpt-load:
-    image: ghcr.io/tbphp/gpt-load:latest
+    image: ghcr.io/tbphp/gpt-load:1
     # build:
     #   context: .
     #   dockerfile: Dockerfile


### PR DESCRIPTION
### 关联 Issue / Related Issue

N/A

### 变更内容 / Change Content

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

- 将 v1 Docker 发布工作流限制为 `v1.*` Tag；稳定发布生成 `:1`，不再生成或更新 `latest`
- 将 v1 Compose 与三语言 README 的镜像示例固定为 `ghcr.io/tbphp/gpt-load:1`
- 将 README 中已经失效的 `main` 配置下载地址改为 `v1` 分支
- 明确说明 v1 用户应固定使用 `:1`，而 `latest` 在过渡期后可能指向 v2

本 PR 不创建 Tag、Release 或 Registry 标签。合并后由下一次稳定 v1 发布创建并更新 `:1`；现有 `latest` 保持原状。

验证结果：

- GitHub Actions Workflow YAML 解析通过
- `docker compose --env-file .env.example -f docker-compose.yml config --no-interpolate --quiet` 通过
- v1 镜像标签、分支下载链接与 `latest` 排除断言通过
- `git diff --check` 通过
- v1 `Makefile` 不提供 `make check` 目标，因此未运行该命令

### 自查清单 / Checklist

- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.