### PR TITLE
fix(gateway): 兼容 OpenCode Go 计费尾帧

### DIFF
--- a/internal/dialect/openai_responses.go
+++ b/internal/dialect/openai_responses.go
@@ -150,6 +150,12 @@ func (*OpenAIResponses) ClassifyStreamEvent(
 			}, nil
 		}
 	}
+	if eventType == "ping" {
+		return StreamEventClassification{
+			Disposition: StreamEventContinue,
+			Auxiliary:   true,
+		}, nil
+	}
 	return StreamEventClassification{
 		Disposition: StreamEventContinue,
 	}, nil

--- a/internal/dialect/openai_responses_stream_test.go
+++ b/internal/dialect/openai_responses_stream_test.go
@@ -16,9 +16,10 @@ func TestOpenAIResponsesClassifiesStreamEvents(t *testing.T) {
 	}
 
 	tests := []struct {
-		name  string
-		event StreamEvent
-		want  StreamEventDisposition
+		name          string
+		event         StreamEvent
+		want          StreamEventDisposition
+		wantAuxiliary bool
 	}{
 		{
 			name: "matching explicit and payload completed",
@@ -59,6 +60,15 @@ func TestOpenAIResponsesClassifiesStreamEvents(t *testing.T) {
 			want: StreamEventFailed,
 		},
 		{
+			name: "ping metadata",
+			event: StreamEvent{
+				Name:    "ping",
+				Payload: []byte(`{"type":"ping","cost":"0"}`),
+			},
+			want:          StreamEventContinue,
+			wantAuxiliary: true,
+		},
+		{
 			name: "unknown event remains pass through",
 			event: StreamEvent{
 				Name:    "response.output_text.delta",
@@ -78,6 +88,9 @@ func TestOpenAIResponsesClassifiesStreamEvents(t *testing.T) {
 			}
 			if got.Disposition != test.want {
 				t.Fatalf("Disposition = %v, want %v", got.Disposition, test.want)
+			}
+			if got.IsAuxiliary() != test.wantAuxiliary {
+				t.Fatalf("IsAuxiliary() = %t, want %t", got.IsAuxiliary(), test.wantAuxiliary)
 			}
 		})
 	}

--- a/internal/dialect/stream_event.go
+++ b/internal/dialect/stream_event.go
@@ -18,6 +18,9 @@ const (
 
 type StreamEventClassification struct {
 	Disposition StreamEventDisposition
+	// Auxiliary marks metadata-only events that do not advance response
+	// content and may safely appear after a terminal event.
+	Auxiliary bool
 }
 
 func (classification StreamEventClassification) IsTerminal() bool {
@@ -31,6 +34,11 @@ func (classification StreamEventClassification) IsTerminal() bool {
 
 func (classification StreamEventClassification) IsProviderError() bool {
 	return classification.Disposition == StreamEventFailed
+}
+
+func (classification StreamEventClassification) IsAuxiliary() bool {
+	return classification.Auxiliary &&
+		classification.Disposition == StreamEventContinue
 }
 
 // StreamEventClassifier optionally exposes protocol-specific SSE lifecycle

--- a/internal/dialect/stream_event_classifiers.go
+++ b/internal/dialect/stream_event_classifiers.go
@@ -19,13 +19,24 @@ func (*OpenAI) ClassifyStreamEvent(event StreamEvent) (StreamEventClassification
 		return StreamEventClassification{Disposition: StreamEventCompleted}, nil
 	}
 	var object struct {
-		Error json.RawMessage `json:"error"`
+		Error   json.RawMessage `json:"error"`
+		Choices json.RawMessage `json:"choices"`
 	}
 	if err := json.Unmarshal(event.Payload, &object); err != nil {
 		return StreamEventClassification{}, fmt.Errorf("decode OpenAI stream event")
 	}
 	if meaningfulJSONValue(object.Error) {
 		return StreamEventClassification{Disposition: StreamEventFailed}, nil
+	}
+	if choices := bytes.TrimSpace(object.Choices); len(choices) > 0 {
+		var values []json.RawMessage
+		if json.Unmarshal(choices, &values) == nil &&
+			values != nil && len(values) == 0 {
+			return StreamEventClassification{
+				Disposition: StreamEventContinue,
+				Auxiliary:   true,
+			}, nil
+		}
 	}
 	return StreamEventClassification{Disposition: StreamEventContinue}, nil
 }

--- a/internal/dialect/stream_event_classifiers_test.go
+++ b/internal/dialect/stream_event_classifiers_test.go
@@ -6,10 +6,11 @@ func TestStreamingDialectsClassifyTerminalAndErrorEvents(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		classifier StreamEventClassifier
-		event      StreamEvent
-		want       StreamEventDisposition
+		name          string
+		classifier    StreamEventClassifier
+		event         StreamEvent
+		want          StreamEventDisposition
+		wantAuxiliary bool
 	}{
 		{
 			name: "OpenAI done", classifier: NewOpenAI(),
@@ -22,6 +23,16 @@ func TestStreamingDialectsClassifyTerminalAndErrorEvents(t *testing.T) {
 		{
 			name: "OpenAI error", classifier: NewOpenAI(),
 			event: StreamEvent{Payload: []byte(`{"error":{"message":"failed"}}`)}, want: StreamEventFailed,
+		},
+		{
+			name: "OpenAI empty choices metadata", classifier: NewOpenAI(),
+			event: StreamEvent{Payload: []byte(`{"choices":[],"cost":"0"}`)},
+			want:  StreamEventContinue, wantAuxiliary: true,
+		},
+		{
+			name: "OpenAI null choices remains ordinary data", classifier: NewOpenAI(),
+			event: StreamEvent{Payload: []byte(`{"choices":null,"cost":"0"}`)},
+			want:  StreamEventContinue,
 		},
 		{
 			name: "Anthropic stop", classifier: NewAnthropic(),
@@ -57,6 +68,9 @@ func TestStreamingDialectsClassifyTerminalAndErrorEvents(t *testing.T) {
 			}
 			if got.Disposition != test.want {
 				t.Fatalf("Disposition = %v, want %v", got.Disposition, test.want)
+			}
+			if got.IsAuxiliary() != test.wantAuxiliary {
+				t.Fatalf("IsAuxiliary() = %t, want %t", got.IsAuxiliary(), test.wantAuxiliary)
 			}
 		})
 	}

--- a/internal/gateway/execution_forward_test.go
+++ b/internal/gateway/execution_forward_test.go
@@ -1467,6 +1467,99 @@ func TestExecutionForwarderRejectsStreamingEOFWithoutProtocolTerminal(t *testing
 	}
 }
 
+func TestExecutionForwarderAllowsSafeEventsAfterTerminal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    func() ForwardInput
+		delta    string
+		terminal string
+		metadata string
+	}{
+		{
+			name:     "OpenAI Chat cost metadata",
+			input:    executionForwardInput,
+			delta:    "data: {\"id\":\"chat_1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n",
+			terminal: "data: [DONE]\n\n",
+			metadata: "data: {\"choices\":[],\"cost\":\"0\"}\n\n",
+		},
+		{
+			name:  "OpenAI Responses ping metadata",
+			input: responsesExecutionForwardInput,
+			delta: "event: response.output_text.delta\n" +
+				"data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n",
+			terminal: "event: response.completed\n" +
+				"data: {\"type\":\"response.completed\",\"response\":{}}\n\n",
+			metadata: "event: ping\n" +
+				"data: {\"type\":\"ping\",\"cost\":\"0\"}\n\n",
+		},
+		{
+			name:  "OpenAI Responses done sentinel",
+			input: responsesExecutionForwardInput,
+			delta: "event: response.output_text.delta\n" +
+				"data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n",
+			terminal: "event: response.completed\n" +
+				"data: {\"type\":\"response.completed\",\"response\":{}}\n\n",
+			metadata: "data: [DONE]\n\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var metadataErr error
+			executor := fakeExecutionExecutor{stream: func(
+				_ context.Context,
+				_ execution.AttemptSpec,
+				sink execution.StreamSink,
+			) execution.StreamResult {
+				if err := sink(execution.StreamEvent{
+					Sequence: 1, Kind: execution.StreamEventReady, StatusCode: http.StatusOK,
+					Header: http.Header{"Content-Type": {"text/event-stream"}},
+				}); err != nil {
+					t.Fatalf("ready sink: %v", err)
+				}
+				if err := sink(execution.StreamEvent{
+					Sequence: 2, Kind: execution.StreamEventData, Data: []byte(test.delta),
+				}); err != nil {
+					t.Fatalf("delta sink: %v", err)
+				}
+				metadataErr = sink(execution.StreamEvent{
+					Sequence: 3, Kind: execution.StreamEventData,
+					Data: []byte(test.terminal + test.metadata),
+				})
+				return execution.StreamResult{
+					DispatchState: execution.DispatchMaybeSent, ResponseStarted: true,
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": {"text/event-stream"}},
+				}
+			}}
+			input := test.input()
+			input.ObserveUsage = true
+			recorder := httptest.NewRecorder()
+
+			result := NewExecutionForwarder(executor).ForwardStream(
+				context.Background(), input, recorder,
+			)
+			wantBody := test.delta + test.terminal + test.metadata
+			if metadataErr != nil || result.Err != nil || !result.Committed ||
+				result.Stream.EndReason != StreamEndCleanEOF ||
+				result.Usage.Diagnostics.Has(usage.DiagnosticInvalidPayload) ||
+				recorder.Body.String() != wantBody {
+				t.Fatalf(
+					"metadata error/result/body = %v / %#v / %q, want success and %q",
+					metadataErr,
+					result,
+					recorder.Body.String(),
+					wantBody,
+				)
+			}
+		})
+	}
+}
+
 func TestExecutionForwarderRejectsOpenAIResponsesDataAfterTerminal(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gateway/stream_observation.go
+++ b/internal/gateway/stream_observation.go
@@ -239,14 +239,9 @@ func (observer *streamEventObserver) classify(
 	if observer == nil {
 		return genericProviderError, nil
 	}
-	if observer.sawTerminal {
-		if bytes.Equal(bytes.TrimSpace(event.Payload), []byte("[DONE]")) {
-			return false, nil
-		}
-		return false, fmt.Errorf(
-			"%w: SSE data event received after terminal event",
-			ErrUpstreamProtocol,
-		)
+	if observer.sawTerminal &&
+		bytes.Equal(bytes.TrimSpace(event.Payload), []byte("[DONE]")) {
+		return false, nil
 	}
 
 	classification := dialect.StreamEventClassification{
@@ -260,12 +255,23 @@ func (observer *streamEventObserver) classify(
 			event,
 		)
 		if panicked || err != nil ||
-			!validStreamEventDisposition(classification.Disposition) {
+			!validStreamEventDisposition(classification.Disposition) ||
+			classification.Auxiliary &&
+				classification.Disposition != dialect.StreamEventContinue {
 			return false, fmt.Errorf(
 				"%w: classify upstream SSE event",
 				ErrUpstreamProtocol,
 			)
 		}
+	}
+	if observer.sawTerminal {
+		if classification.IsAuxiliary() {
+			return false, nil
+		}
+		return false, fmt.Errorf(
+			"%w: SSE data event received after terminal event",
+			ErrUpstreamProtocol,
+		)
 	}
 
 	if classification.IsTerminal() {


### PR DESCRIPTION
### 关联 Issue / Related Issue


### 变更内容 / Change Content

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

## Summary by CodeRabbit

- Classify OpenAI Chat empty `choices` payloads and Responses `ping` events as auxiliary metadata.
- Allow safe auxiliary events and `[DONE]` sentinels after a protocol terminal event.
- Add dialect and forwarder coverage for post-terminal metadata handling.

### 自查清单 / Checklist

- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 修复流式响应在终止事件后接收元数据时可能失败的问题。
  - 终止事件后的安全元数据（例如费用信息、Ping 事件及完成标记）现在可正常转发，不会触发无效载荷错误。
  - 改进对空 `choices` 等辅助事件的识别，避免将其误判为响应内容或协议错误。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
