### PR TITLE
fix(gateway): 兼容 SSE 终态后的扩展尾帧

### DIFF
--- a/internal/gateway/execution_forward.go
+++ b/internal/gateway/execution_forward.go
@@ -141,17 +141,19 @@ func (forwarder *ExecutionForwarder) ForwardStream(
 		if err != nil {
 			return false, err
 		}
-		streamEvents.observeUsageEvent(event)
-		if providerError {
-			streamEvents.observeError(
-				event.Payload,
-				summarizeErrorBody(
-					redactor,
+		if !wasTerminal {
+			streamEvents.observeUsageEvent(event)
+			if providerError {
+				streamEvents.observeError(
 					event.Payload,
-					fixedErrorSummary("upstream_sse_error"),
-					summarySecrets...,
-				),
-			)
+					summarizeErrorBody(
+						redactor,
+						event.Payload,
+						fixedErrorSummary("upstream_sse_error"),
+						summarySecrets...,
+					),
+				)
+			}
 		}
 		return !wasTerminal && streamEvents.sawTerminal, nil
 	})

--- a/internal/gateway/execution_forward_test.go
+++ b/internal/gateway/execution_forward_test.go
@@ -1467,54 +1467,157 @@ func TestExecutionForwarderRejectsStreamingEOFWithoutProtocolTerminal(t *testing
 	}
 }
 
-func TestExecutionForwarderRejectsOpenAIResponsesDataAfterTerminal(t *testing.T) {
+func TestExecutionForwarderFreezesObservationAfterOpenAIResponsesTerminal(t *testing.T) {
 	t.Parallel()
 
 	const completedEvent = "event: response.completed\n" +
-		"data: {\"type\":\"response.completed\",\"response\":{}}\n\n"
-	const extraEvent = "event: response.output_text.delta\n" +
-		"data: {\"type\":\"response.output_text.delta\",\"delta\":\"late\"}\n\n"
-	var extraErr error
-	executor := fakeExecutionExecutor{stream: func(
-		_ context.Context,
-		_ execution.AttemptSpec,
-		sink execution.StreamSink,
-	) execution.StreamResult {
-		if err := sink(execution.StreamEvent{
-			Sequence: 1, Kind: execution.StreamEventReady, StatusCode: http.StatusOK,
-			Header: http.Header{"Content-Type": {"text/event-stream"}},
-		}); err != nil {
-			t.Fatalf("ready sink: %v", err)
-		}
-		if err := sink(execution.StreamEvent{
-			Sequence: 2, Kind: execution.StreamEventData, Data: []byte(completedEvent),
-		}); err != nil {
-			t.Fatalf("terminal sink: %v", err)
-		}
-		extraErr = sink(execution.StreamEvent{
-			Sequence: 3, Kind: execution.StreamEventData, Data: []byte(extraEvent),
-		})
-		return execution.StreamResult{
-			DispatchState: execution.DispatchMaybeSent, ResponseStarted: true,
-			StatusCode: http.StatusOK,
-			Header:     http.Header{"Content-Type": {"text/event-stream"}},
-			Error: &execution.ErrorEvidence{
-				Kind: execution.ErrorKindCanceled, Summary: "stream sink stopped",
-			},
-		}
-	}}
+		"data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":8,\"output_tokens\":2,\"total_tokens\":10}}}\n\n"
+	const trailingEvent = "event: error\n" +
+		"data: {\"type\":\"error\",\"error\":{\"message\":\"late failure\"},\"response\":{\"usage\":{\"input_tokens\":80,\"output_tokens\":20,\"total_tokens\":100}}}\n\n"
 
-	recorder := httptest.NewRecorder()
-	result := NewExecutionForwarder(executor).ForwardStream(
-		context.Background(), responsesExecutionForwardInput(), recorder,
-	)
-	if !errors.Is(extraErr, ErrUpstreamProtocol) ||
-		result.Stream.EndReason != StreamEndUpstreamProtocolError ||
-		result.Stream.ErrorSummary != fixedErrorSummary("upstream_protocol_error") {
-		t.Fatalf("extra error/result = %v / %#v", extraErr, result)
+	tests := []struct {
+		name   string
+		chunks []string
+	}{
+		{name: "separate chunks", chunks: []string{completedEvent, trailingEvent}},
+		{name: "same chunk", chunks: []string{completedEvent + trailingEvent}},
 	}
-	if got := recorder.Body.String(); got != completedEvent {
-		t.Fatalf("response body = %q, want terminal only %q", got, completedEvent)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var sinkErr error
+			executor := fakeExecutionExecutor{stream: func(
+				_ context.Context,
+				_ execution.AttemptSpec,
+				sink execution.StreamSink,
+			) execution.StreamResult {
+				if err := sink(execution.StreamEvent{
+					Sequence: 1, Kind: execution.StreamEventReady, StatusCode: http.StatusOK,
+					Header: http.Header{"Content-Type": {"text/event-stream"}},
+				}); err != nil {
+					t.Fatalf("ready sink: %v", err)
+				}
+				for index, chunk := range test.chunks {
+					sinkErr = sink(execution.StreamEvent{
+						Sequence: uint64(index + 2), Kind: execution.StreamEventData,
+						Data: []byte(chunk),
+					})
+					if sinkErr != nil {
+						break
+					}
+				}
+				return execution.StreamResult{
+					DispatchState: execution.DispatchMaybeSent, ResponseStarted: true,
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": {"text/event-stream"}},
+				}
+			}}
+
+			forwarder := NewExecutionForwarder(executor)
+			recorder := httptest.NewRecorder()
+			result := forwarder.ForwardStream(
+				context.Background(), responsesExecutionForwardInput(), recorder,
+			)
+			if sinkErr != nil || result.Err != nil || !result.Committed ||
+				result.Stream.EndReason != StreamEndCleanEOF || result.Stream.ErrorSummary != "" {
+				t.Fatalf("sink error/result = %v / %#v", sinkErr, result)
+			}
+			if result.Usage.State != usage.StateComplete ||
+				result.Usage.Tokens != (usage.Tokens{UncachedInput: 8, Output: 2}) {
+				t.Fatalf("usage = %#v", result.Usage)
+			}
+			if failures := forwarder.usageCapture.failureTotal.Load(); failures != 0 {
+				t.Fatalf("usage capture failures = %d, want 0", failures)
+			}
+			if got, want := recorder.Body.String(), completedEvent+trailingEvent; got != want {
+				t.Fatalf("response body = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestExecutionForwarderPassesDataAfterTerminalAcrossDialects(t *testing.T) {
+	t.Parallel()
+
+	const trailingEvent = "data: {\"metadata\":{\"cost\":\"0\"}}\n\n"
+	tests := []struct {
+		name     string
+		dialect  dialect.Dialect
+		protocol protocol.Protocol
+		terminal string
+	}{
+		{
+			name: "OpenAI Chat", dialect: dialect.NewOpenAI(),
+			protocol: protocol.OpenAICompletions,
+			terminal: "data: [DONE]\n\n",
+		},
+		{
+			name: "Anthropic", dialect: dialect.NewAnthropic(),
+			protocol: protocol.Anthropic,
+			terminal: "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+		},
+		{
+			name: "Gemini", dialect: dialect.NewGemini(),
+			protocol: protocol.Gemini,
+			terminal: "data: {\"candidates\":[{\"index\":0,\"finishReason\":\"STOP\"}]}\n\n",
+		},
+		{
+			name: "OpenAI Images", dialect: dialect.NewOpenAIImages(),
+			protocol: protocol.OpenAIImages,
+			terminal: "event: image_generation.completed\ndata: {\"type\":\"image_generation.completed\"}\n\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var sinkErr error
+			executor := fakeExecutionExecutor{stream: func(
+				_ context.Context,
+				_ execution.AttemptSpec,
+				sink execution.StreamSink,
+			) execution.StreamResult {
+				if err := sink(execution.StreamEvent{
+					Sequence: 1, Kind: execution.StreamEventReady, StatusCode: http.StatusOK,
+					Header: http.Header{"Content-Type": {"text/event-stream"}},
+				}); err != nil {
+					t.Fatalf("ready sink: %v", err)
+				}
+				sinkErr = sink(execution.StreamEvent{
+					Sequence: 2, Kind: execution.StreamEventData,
+					Data: []byte(test.terminal + trailingEvent),
+				})
+				return execution.StreamResult{
+					DispatchState: execution.DispatchMaybeSent, ResponseStarted: true,
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": {"text/event-stream"}},
+				}
+			}}
+
+			input := executionForwardInput()
+			input.Dialect = test.dialect
+			input.ClientProtocol = test.protocol
+			if test.protocol == protocol.OpenAIImages {
+				input.Operation = execution.OperationImagesGenerate
+				input.Request.Path = "/v1/images/generations"
+				input.Request.RawQuery = ""
+				input.Request.Body = []byte(`{"model":"public","stream":true}`)
+			}
+			recorder := httptest.NewRecorder()
+			result := NewExecutionForwarder(executor).ForwardStream(
+				context.Background(), input, recorder,
+			)
+			if sinkErr != nil || result.Err != nil || !result.Committed ||
+				result.Stream.EndReason != StreamEndCleanEOF {
+				t.Fatalf("sink error/result = %v / %#v", sinkErr, result)
+			}
+			if got, want := recorder.Body.String(), test.terminal+trailingEvent; got != want {
+				t.Fatalf("response body = %q, want %q", got, want)
+			}
+		})
 	}
 }
 

--- a/internal/gateway/stream_observation.go
+++ b/internal/gateway/stream_observation.go
@@ -240,13 +240,8 @@ func (observer *streamEventObserver) classify(
 		return genericProviderError, nil
 	}
 	if observer.sawTerminal {
-		if bytes.Equal(bytes.TrimSpace(event.Payload), []byte("[DONE]")) {
-			return false, nil
-		}
-		return false, fmt.Errorf(
-			"%w: SSE data event received after terminal event",
-			ErrUpstreamProtocol,
-		)
+		// 首个协议终态确定观测结果；后续数据仅透传。
+		return false, nil
 	}
 
 	classification := dialect.StreamEventClassification{


### PR DESCRIPTION
### 关联 Issue / Related Issue
Closes #539

### 变更内容 / Change Content
- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

- 首个 SSE 协议终态确定最终观测结果，后续完整数据事件保持原样透传。
- 终态后的事件不再参与方言分类、usage 采集或 provider error 观察。
- 保留现有 framing、缺失终态、安全检查、首帧错误及下游写入失败语义。
- 增加同 chunk、分 chunk、跨方言及 usage/error 冻结回归测试。

兼容性影响：终态后的完整 SSE 数据事件不再将已完成请求改记为协议错误；无数据迁移。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 流式响应在收到终止事件后仍可继续转发后续数据。
  * 终止事件后的错误不会覆盖成功状态，使用量统计保持冻结。
  * 改善了 OpenAI Responses、OpenAI Chat、Anthropic、Gemini 和 OpenAI Images 等响应类型的流式处理一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->