### PR TITLE
fix(ci): update references after default branch rename

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 # 仓库已对所有 action 强制 SHA pin，上游补丁不会自动到达；由 Dependabot 提 PR
 # 更新 SHA 并同步刷新其后的版本注释，保持"可审计"与"能更新"同时成立。
 #
-# 不要声明 target-branch。Dependabot 默认就针对默认分支（当前为 v2），而一旦声明
+# 不要声明 target-branch。Dependabot 默认就针对默认分支（当前为 main），而一旦声明
 # target-branch，本文件对该 ecosystem 的配置就不再作用于 security update，
 # groups、labels 与 commit-message 会对安全更新 PR 全部失效。
 # https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: V2 CI
 on:
   push:
     branches:
-      - v2
+      - main
   pull_request:
     branches:
-      - v2
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,11 +105,11 @@ jobs:
           } >>"${GITHUB_OUTPUT}"
           # release-tag-validation:end
 
-      - name: Require tag commit in v2 history
+      - name: Require tag commit in main history
         shell: bash
         run: |
-          git fetch --no-tags origin v2
-          git merge-base --is-ancestor "${GITHUB_SHA}" origin/v2
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "${GITHUB_SHA}" origin/main
 
       - name: Reuse CI verdict for this commit
         id: ci
@@ -731,8 +731,8 @@ jobs:
           set -euo pipefail
           test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
           test "$(git rev-parse "${GITHUB_REF_NAME}^{commit}")" = "${GITHUB_SHA}"
-          git fetch --no-tags origin v2
-          git merge-base --is-ancestor "${GITHUB_SHA}" origin/v2
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "${GITHUB_SHA}" origin/main
 
       - name: Verify complete release asset set
         run: .github/scripts/release-verify-assets.sh release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,10 +18,10 @@ Thanks for helping improve GPT-Load. This document covers what a human contribut
 
 `2.x` 与 `1.x` 是两套不兼容的实现，数据不互通。
 
-- **2.x 开发基于 `v2` 分支**，PR 也提交到 `v2`。
+- **2.x 开发基于 `main` 分支**，PR 也提交到 `main`。
 - `1.x` 处于维护状态，只接受安全和严重缺陷修复。
 
-`2.x` and `1.x` are incompatible implementations and do not share data. Base 2.x work on the **`v2` branch** and target your PR at `v2`. The `1.x` line is in maintenance and only takes security and critical bug fixes.
+`2.x` and `1.x` are incompatible implementations and do not share data. Base 2.x work on the **`main` branch** and target your PR at `main`. The `1.x` line is in maintenance and only takes security and critical bug fixes.
 
 ## 本地开发 / Local development
 
@@ -56,13 +56,13 @@ Race tests for that module run in CI; per repository convention they are not run
 
 ## 提交 PR / Submitting a pull request
 
-1. 从 `v2` 切出分支，保持改动聚焦，不要夹带无关重构或格式化。
+1. 从 `main` 切出分支，保持改动聚焦，不要夹带无关重构或格式化。
 2. 修复缺陷或改变行为时，优先补一个能复现问题的测试。
 3. 提交前跑一次 `make check`；无法运行时在 PR 里说明原因和未验证范围。
 4. 按 `.github/pull_request_template.md` 填写，如实勾选自查清单。
 5. 改动涉及用户可见能力时，**三份 README（`README.md`、`README_CN.md`、`README_JP.md`）必须同步更新**。
 
-1. Branch from `v2`, keep the change focused, and avoid unrelated refactors or reformatting.
+1. Branch from `main`, keep the change focused, and avoid unrelated refactors or reformatting.
 2. For bug fixes and behavior changes, add a test that reproduces the problem first.
 3. Run `make check` before submitting; if you cannot, say why and what remains unverified.
 4. Fill in `.github/pull_request_template.md` honestly, including the checklist.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Your application only needs one base URL and one AccessKey. Providers, accounts,
 Requires Docker and Docker Compose.
 
 ```bash
-git clone --depth 1 --branch v2 https://github.com/tbphp/gpt-load.git
+git clone --depth 1 https://github.com/tbphp/gpt-load.git
 cd gpt-load
 
 cp .env.example .env

--- a/README_CN.md
+++ b/README_CN.md
@@ -65,7 +65,7 @@
 需要 Docker 与 Docker Compose。
 
 ```bash
-git clone --depth 1 --branch v2 https://github.com/tbphp/gpt-load.git
+git clone --depth 1 https://github.com/tbphp/gpt-load.git
 cd gpt-load
 
 cp .env.example .env

--- a/README_JP.md
+++ b/README_JP.md
@@ -65,7 +65,7 @@ API キー、サブスクリプションアカウント、トラフィック制�
 Docker と Docker Compose が必要です。
 
 ```bash
-git clone --depth 1 --branch v2 https://github.com/tbphp/gpt-load.git
+git clone --depth 1 https://github.com/tbphp/gpt-load.git
 cd gpt-load
 
 cp .env.example .env

--- a/internal/webui/workflow_test.go
+++ b/internal/webui/workflow_test.go
@@ -81,6 +81,40 @@ func TestMakeCheckDoesNotDuplicateWebTypeCheck(t *testing.T) {
 	}
 }
 
+func TestBranchAndReleaseWorkflowsFollowDefaultBranch(t *testing.T) {
+	ci := readRepositoryFile(t, ".github/workflows/ci.yml")
+	triggers := workflowTopLevelBlock(t, ci, "on")
+	for _, required := range []string{
+		"push:\n    branches:\n      - main",
+		"pull_request:\n    branches:\n      - main",
+	} {
+		if !strings.Contains(triggers, required) {
+			t.Fatalf("branch CI triggers do not contain %q:\n%s", required, triggers)
+		}
+	}
+	if strings.Contains(triggers, "      - v2") {
+		t.Fatalf("branch CI still targets the removed v2 branch:\n%s", triggers)
+	}
+
+	release := readRepositoryFile(t, ".github/workflows/release.yml")
+	for _, required := range []struct {
+		value string
+		count int
+	}{
+		{value: "git fetch --no-tags origin main", count: 2},
+		{value: `git merge-base --is-ancestor "${GITHUB_SHA}" origin/main`, count: 2},
+	} {
+		if count := strings.Count(release, required.value); count != required.count {
+			t.Fatalf("release workflow contains %q %d times, want %d", required.value, count, required.count)
+		}
+	}
+	for _, forbidden := range []string{"origin/v2", "Require tag commit in v2 history"} {
+		if strings.Contains(release, forbidden) {
+			t.Fatalf("release workflow still contains removed branch reference %q", forbidden)
+		}
+	}
+}
+
 func TestBranchAndReleaseWorkflowsRunRaceInParallelGates(t *testing.T) {
 	content := readRepositoryFile(t, ".github/workflows/ci.yml")
 	testJob := workflowJobBlock(t, content, "test")


### PR DESCRIPTION
### 关联 Issue / Related Issue

N/A — maintenance fix after the repository default branch moved from `v2` to `main`.

### 变更内容 / Change Content

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

The repository's default and protected branch is now `main`, and the old `v2` branch no longer exists. Several CI, release, and contributor-facing references still target the removed branch.

This PR:

- updates CI push and pull-request filters to target `main`;
- updates both release ancestry checks to fetch and verify `origin/main`;
- updates the Dependabot comment and contribution instructions;
- removes `--branch v2` from all three README clone examples;
- adds a repository contract test to prevent these stale branch references from returning.

#### Verification

Passed on Linux with Go 1.27:

```bash
go test -count=1 \
  -run '^TestBranchAndReleaseWorkflows(FollowDefaultBranch|RunRaceInParallelGates)$' \
  ./internal/webui
```

Also passed:

- YAML parsing for the three changed workflow/config files
- focused stale-branch-reference assertions
- `git diff --check`

`make check` was also run at this commit. Dependency and lockfile checks, `gofmt`, `go mod tidy -diff`, `go vet`, frontend lint/format/typecheck/build, and the Go build passed. The overall command did not finish green because this branch and a clean `origin/main` checkout both fail the same three existing release-image mock tests:

- `TestReleaseWorkflowKeepsUntrustedImageRevisionInsideJQComparison`
- `TestReleaseImageVersionAcceptsOnlyMatchingStrictSemverLabels`
- `TestReleaseImageChannelPromotionIsMonotonicAndPreservesLatest`

Likewise, actionlint 1.7.7 reports the same existing `macos-15-intel` runner-label and concurrency `queue` diagnostics on both the branch and clean base. This change introduces no additional actionlint diagnostic.

The hosted `V2 CI` trigger is not yet verified end to end. GitHub may continue to evaluate this pull request with the base branch's existing workflow definition, so the first definitive `main`-triggered run may occur only after merge.

### 自查清单 / Checklist

- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.

No application API, configuration schema, database, or data-migration behavior is changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档**
  - 更新中英文及日文快速开始指南，默认克隆 `main` 分支。
  - 更新贡献指南中的分支与提交规范，统一使用 `main` 分支。

- **发布与持续集成**
  - CI 工作流的推送和合并请求触发分支切换为 `main`。
  - 发布校验改为确认标签提交位于 `main` 分支历史中。

- **测试**
  - 增加分支与发布工作流校验，确保配置持续使用 `main`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->