### PR TITLE
ci: 删除重复依赖漏洞检查

### DIFF
--- a/.github/actions/web-ci/action.yml
+++ b/.github/actions/web-ci/action.yml
@@ -21,12 +21,6 @@ runs:
       shell: bash
       run: pnpm --dir web install --frozen-lockfile
 
-    - name: Audit web dependencies
-      shell: bash
-      # 只审计生产依赖：devDependencies 经 Vite 构建后不进入 internal/webui/dist，
-      # 让它们的 CVE 阻断发布只会制造噪音。
-      run: pnpm --dir web audit --prod --audit-level high
-
     - name: Lint web source
       shell: bash
       run: pnpm --dir web run lint

--- a/.github/actions/web-ci/action.yml
+++ b/.github/actions/web-ci/action.yml
@@ -6,6 +6,9 @@ runs:
   steps:
     - name: Set up pnpm
       uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      env:
+        NPM_CONFIG_AUDIT: "false"
+        NPM_CONFIG_FUND: "false"
       with:
         version: 11.17.0
         run_install: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,6 @@ jobs:
           go mod tidy -diff
           go vet ./...
 
-      - name: Audit Go dependencies
-        run: go run golang.org/x/vuln/cmd/govulncheck@v1.7.0 ./...
-
       - name: Run Go vet
         run: go vet ./...
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,9 +193,6 @@ jobs:
           go mod tidy -diff
           go vet ./...
 
-      - name: Audit Go dependencies
-        run: go run golang.org/x/vuln/cmd/govulncheck@v1.7.0 ./...
-
       - name: Run Go vet
         run: go vet ./...
 

--- a/internal/webui/workflow_parallelism_test.go
+++ b/internal/webui/workflow_parallelism_test.go
@@ -9,7 +9,7 @@ func TestReleaseWorkflowParallelizesIndependentBuildStages(t *testing.T) {
 	content := readRepositoryFile(t, ".github/workflows/release.yml")
 	webJob := workflowJobBlock(t, content, "verify-and-build-web")
 	staticJob := workflowJobBlock(t, content, "static-checks")
-	for _, command := range []string{"govulncheck", "go vet ./...", "go build -trimpath"} {
+	for _, command := range []string{"go vet ./...", "go build -trimpath"} {
 		if strings.Contains(webJob, command) {
 			t.Fatalf("web artifact job still serializes %q:\n%s", command, webJob)
 		}

--- a/internal/webui/workflow_test.go
+++ b/internal/webui/workflow_test.go
@@ -41,6 +41,24 @@ func TestWebCICompositeActionRunsCompleteFrontendGate(t *testing.T) {
 		}
 	}
 
+	const pnpmSetupStep = "    - name: Set up pnpm\n"
+	pnpmSetupIndex := strings.Index(content, pnpmSetupStep)
+	if pnpmSetupIndex == -1 {
+		t.Fatal("web-ci action does not contain the pnpm setup step")
+	}
+	pnpmSetupBlock := content[pnpmSetupIndex+len(pnpmSetupStep):]
+	if nextStepIndex := strings.Index(pnpmSetupBlock, "\n    - name: "); nextStepIndex != -1 {
+		pnpmSetupBlock = pnpmSetupBlock[:nextStepIndex]
+	}
+	for _, required := range []string{
+		"        NPM_CONFIG_AUDIT: \"false\"",
+		"        NPM_CONFIG_FUND: \"false\"",
+	} {
+		if !strings.Contains(pnpmSetupBlock, required) {
+			t.Fatalf("pnpm setup step does not contain %q", required)
+		}
+	}
+
 	previousIndex := -1
 	for _, command := range []string{
 		"pnpm --dir web install --frozen-lockfile",

--- a/internal/webui/workflow_test.go
+++ b/internal/webui/workflow_test.go
@@ -44,7 +44,6 @@ func TestWebCICompositeActionRunsCompleteFrontendGate(t *testing.T) {
 	previousIndex := -1
 	for _, command := range []string{
 		"pnpm --dir web install --frozen-lockfile",
-		"pnpm --dir web audit --prod --audit-level high",
 		"pnpm --dir web run lint",
 		"pnpm --dir web run format",
 		"pnpm --dir web run build",
@@ -61,13 +60,40 @@ func TestWebCICompositeActionRunsCompleteFrontendGate(t *testing.T) {
 	if strings.Contains(content, "pnpm --dir web run type-check") {
 		t.Fatal("web-ci action duplicates the type-check already run by the build script")
 	}
-	// devDependencies 不进入 internal/webui/dist，审计它们只会让发布被无关 CVE 阻断。
-	if strings.Contains(content, "pnpm --dir web audit --audit-level") {
-		t.Fatal("web-ci action audits devDependencies that never reach the release artifact")
-	}
 	packageJSON := readRepositoryFile(t, "web/package.json")
 	if !strings.Contains(packageJSON, `"build": "pnpm run type-check && vite build"`) {
 		t.Fatal("web build script no longer includes the required type-check")
+	}
+}
+
+func TestDependencyVulnerabilityMonitoringIsDelegatedToDependabot(t *testing.T) {
+	for _, file := range []string{
+		".github/actions/web-ci/action.yml",
+		".github/workflows/ci.yml",
+		".github/workflows/release.yml",
+	} {
+		content := readRepositoryFile(t, file)
+		for _, forbidden := range []string{
+			"Audit web dependencies",
+			"pnpm --dir web audit",
+			"Audit Go dependencies",
+			"govulncheck",
+		} {
+			if strings.Contains(content, forbidden) {
+				t.Fatalf("%s duplicates Dependabot dependency monitoring with %q", file, forbidden)
+			}
+		}
+	}
+
+	dependabot := readRepositoryFile(t, ".github/dependabot.yml")
+	for _, required := range []string{
+		"- package-ecosystem: npm\n    directory: /web",
+		"- package-ecosystem: gomod\n    directory: /",
+		"- package-ecosystem: gomod\n    directory: /third_party/cpaembedded",
+	} {
+		if !strings.Contains(dependabot, required) {
+			t.Fatalf("Dependabot configuration does not contain %q", required)
+		}
 	}
 }
 
@@ -124,7 +150,6 @@ func TestBranchAndReleaseWorkflowsRunRaceInParallelGates(t *testing.T) {
 		run  string
 	}{
 		{name: "Check module graph", run: "go mod tidy -diff"},
-		{name: "Audit Go dependencies", run: "go run golang.org/x/vuln/cmd/govulncheck@v1.7.0 ./..."},
 		{name: "Run Go vet", run: "go vet ./..."},
 		{name: "Check repository invariants", run: "git diff --check"},
 	} {
@@ -2805,10 +2830,10 @@ func TestReleaseWorkflowSkipsOnlyCIProvenGatesAndStillFailsClosed(t *testing.T) 
 			t.Fatalf("%s does not reuse the CI verdict:\n%s", jobName, job)
 		}
 	}
-	// 静态检查依赖会随时间变化的漏洞库，每次发布都必须重跑。
+	// Release 的静态检查仍需独立执行，不复用 CI 结论。
 	staticChecks := workflowJobBlock(t, content, "static-checks")
 	if strings.Contains(staticChecks, "ci_verified") {
-		t.Fatalf("static checks must not reuse a stale vulnerability audit:\n%s", staticChecks)
+		t.Fatalf("release static checks must run independently of the CI verdict:\n%s", staticChecks)
 	}
 
 	preflight := workflowJobBlock(t, content, "publication-preflight")


### PR DESCRIPTION
### 关联 Issue / Related Issue

N/A

### 变更内容 / Change Content

- [ ] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [x] 其他改动 / Other changes

- 删除共享 Web CI 中的 `pnpm audit`，避免 CI 与 Release 重复执行前端依赖漏洞扫描。
- 删除分支 CI 与 Release 中的 `govulncheck`，统一由仓库级 Dependabot 监控 npm、根 Go module 与 CPA 子 module。
- 保留 `go vet`、race、数据库合同、CodeQL、SBOM 与最终镜像 Trivy 扫描等非重复门禁。
- 增加工作流契约测试，防止重复依赖扫描被重新引入，并确保 Dependabot 覆盖三个依赖域。

### 自查清单 / Checklist

- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.

兼容性说明：不涉及运行时 API、数据结构或数据库迁移；变更仅调整 CI/Release 的依赖漏洞检查策略。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **变更**
  - Web 和 Go 依赖漏洞审计不再作为 CI 与发布流程的门禁。
  - pnpm 安装过程不再显示审计和资助提示。
  - 依赖漏洞监控改由 Dependabot 负责，覆盖 Web、根目录及指定第三方模块。
  - 保留代码静态检查、构建和仓库一致性验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->