### PR TITLE
chore(ci): 收敛主分支检查与命名

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
-name: V2 CI
+name: CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
@@ -17,7 +14,7 @@ env:
   GOPROXY: https://proxy.golang.org|direct
 
 concurrency:
-  group: v2-ci-${{ github.event.pull_request.number || github.ref }}
+  group: ci-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release 2.x
+name: Release
 
 on:
   push:

--- a/internal/webui/workflow_test.go
+++ b/internal/webui/workflow_test.go
@@ -128,15 +128,9 @@ func TestMakeCheckDoesNotDuplicateWebTypeCheck(t *testing.T) {
 func TestBranchAndReleaseWorkflowsFollowDefaultBranch(t *testing.T) {
 	ci := readRepositoryFile(t, ".github/workflows/ci.yml")
 	triggers := workflowTopLevelBlock(t, ci, "on")
-	required := "pull_request:\n    branches:\n      - main"
-	if !strings.Contains(triggers, required) {
-		t.Fatalf("branch CI triggers do not contain %q:\n%s", required, triggers)
-	}
-	if strings.Contains(triggers, "push:") {
-		t.Fatalf("branch CI still runs after changes merge into main:\n%s", triggers)
-	}
-	if strings.Contains(triggers, "      - v2") {
-		t.Fatalf("branch CI still targets the removed v2 branch:\n%s", triggers)
+	wantTriggers := "on:\n  pull_request:\n    branches:\n      - main"
+	if got := strings.Join(workflowSignificantYAMLLines(triggers), "\n"); got != wantTriggers {
+		t.Fatalf("branch CI triggers = %q, want %q", got, wantTriggers)
 	}
 
 	release := readRepositoryFile(t, ".github/workflows/release.yml")
@@ -167,9 +161,16 @@ func TestWorkflowNamesDoNotCarryRetiredV2PhaseLabel(t *testing.T) {
 		{file: ".github/workflows/release.yml", name: "Release"},
 	} {
 		content := readRepositoryFile(t, workflow.file)
-		if !strings.HasPrefix(content, "name: "+workflow.name+"\n") {
+		if got := workflowTopLevelScalar(t, content, "name"); got != workflow.name {
 			t.Fatalf("%s does not use workflow name %q", workflow.file, workflow.name)
 		}
+	}
+}
+
+func TestWorkflowTopLevelScalarAllowsLeadingYAMLMetadata(t *testing.T) {
+	content := "---\n# Generated workflow metadata.\nname: CI\non:\n"
+	if got := workflowTopLevelScalar(t, content, "name"); got != "CI" {
+		t.Fatalf("workflow name = %q, want CI", got)
 	}
 }
 
@@ -2671,6 +2672,38 @@ func readRepositoryFile(t *testing.T, name string) string {
 	return string(content)
 }
 
+func workflowTopLevelScalar(t *testing.T, content, key string) string {
+	t.Helper()
+	for _, line := range workflowSignificantYAMLLines(content) {
+		if strings.HasPrefix(line, " ") {
+			continue
+		}
+		lineKey, value, found := strings.Cut(line, ":")
+		if !found || lineKey != key {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		if value == "" {
+			t.Fatalf("workflow top-level %s is not a scalar", key)
+		}
+		return value
+	}
+	t.Fatalf("workflow does not contain top-level %s", key)
+	return ""
+}
+
+func workflowSignificantYAMLLines(content string) []string {
+	lines := make([]string, 0)
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || trimmed == "---" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	return lines
+}
+
 func workflowTopLevelBlock(t *testing.T, content, key string) string {
 	t.Helper()
 	lines := strings.Split(content, "\n")
@@ -2686,7 +2719,11 @@ func workflowTopLevelBlock(t *testing.T, content, key string) string {
 	}
 	end := len(lines)
 	for index := start + 1; index < len(lines); index++ {
-		if lines[index] != "" && !strings.HasPrefix(lines[index], " ") {
+		trimmed := strings.TrimSpace(lines[index])
+		if trimmed == "" || trimmed == "---" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if !strings.HasPrefix(lines[index], " ") {
 			end = index
 			break
 		}

--- a/internal/webui/workflow_test.go
+++ b/internal/webui/workflow_test.go
@@ -128,13 +128,12 @@ func TestMakeCheckDoesNotDuplicateWebTypeCheck(t *testing.T) {
 func TestBranchAndReleaseWorkflowsFollowDefaultBranch(t *testing.T) {
 	ci := readRepositoryFile(t, ".github/workflows/ci.yml")
 	triggers := workflowTopLevelBlock(t, ci, "on")
-	for _, required := range []string{
-		"push:\n    branches:\n      - main",
-		"pull_request:\n    branches:\n      - main",
-	} {
-		if !strings.Contains(triggers, required) {
-			t.Fatalf("branch CI triggers do not contain %q:\n%s", required, triggers)
-		}
+	required := "pull_request:\n    branches:\n      - main"
+	if !strings.Contains(triggers, required) {
+		t.Fatalf("branch CI triggers do not contain %q:\n%s", required, triggers)
+	}
+	if strings.Contains(triggers, "push:") {
+		t.Fatalf("branch CI still runs after changes merge into main:\n%s", triggers)
 	}
 	if strings.Contains(triggers, "      - v2") {
 		t.Fatalf("branch CI still targets the removed v2 branch:\n%s", triggers)
@@ -155,6 +154,21 @@ func TestBranchAndReleaseWorkflowsFollowDefaultBranch(t *testing.T) {
 	for _, forbidden := range []string{"origin/v2", "Require tag commit in v2 history"} {
 		if strings.Contains(release, forbidden) {
 			t.Fatalf("release workflow still contains removed branch reference %q", forbidden)
+		}
+	}
+}
+
+func TestWorkflowNamesDoNotCarryRetiredV2PhaseLabel(t *testing.T) {
+	for _, workflow := range []struct {
+		file string
+		name string
+	}{
+		{file: ".github/workflows/ci.yml", name: "CI"},
+		{file: ".github/workflows/release.yml", name: "Release"},
+	} {
+		content := readRepositoryFile(t, workflow.file)
+		if !strings.HasPrefix(content, "name: "+workflow.name+"\n") {
+			t.Fatalf("%s does not use workflow name %q", workflow.file, workflow.name)
 		}
 	}
 }
@@ -290,7 +304,7 @@ func TestBranchWorkflowCancelsSupersededRuns(t *testing.T) {
 	content := readRepositoryFile(t, ".github/workflows/ci.yml")
 	concurrency := workflowTopLevelBlock(t, content, "concurrency")
 	for _, required := range []string{
-		`group: v2-ci-${{ github.event.pull_request.number || github.ref }}`,
+		`group: ci-pr-${{ github.event.pull_request.number }}`,
 		"cancel-in-progress: true",
 	} {
 		if !strings.Contains(concurrency, required) {


### PR DESCRIPTION
### 关联 Issue / Related Issue

N/A

### 变更内容 / Change Content

- [ ] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [x] 其他改动 / Other changes

- 将完整 CI 收敛到面向 `main` 的 Pull Request，不再在合并后重复执行。
- 将工作流显示名从 `V2 CI`、`Release 2.x` 简化为 `CI`、`Release`，并清理 `v2-ci` 并发标识。
- 更新 workflow 合同测试，锁定 PR-only 触发与通用命名。
- 配套的 `main` Ruleset 已启用严格 required checks：必须走 squash PR、6 项 CI 全绿、基于最新 `main`，且不可绕过。

### 自查清单 / Checklist

- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.

兼容性说明：合并后不再为最终 squash commit 生成常规 CI run；Release 查不到同 SHA 的成功 CI 时，会按现有 fail-closed 逻辑重新执行 race、CPA 和数据库合同检查。无数据迁移影响。
