### PR TITLE
feat(gateway): 支持数据面 CORS 与响应头规则

### DIFF
--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -226,7 +226,9 @@ func BuildContainer() (*dig.Container, error) {
 	if err := dependencyContainer.Invoke(func(
 		engine *gin.Engine,
 		registry *httproute.Registry,
+		gatewayHandler *gateway.Handler,
 	) error {
+		engine.Use(gatewayHandler.DownstreamHeadersMiddleware())
 		return registry.Bind(engine)
 	}); err != nil {
 		return nil, fmt.Errorf("register HTTP routes: %w", err)

--- a/internal/container/container_test.go
+++ b/internal/container/container_test.go
@@ -80,6 +80,78 @@ func TestSystemOutboundProxyProviderUsesEnvironmentAndLatestGlobalSnapshot(t *te
 	}
 }
 
+func TestBuildContainerInstallsDataPlaneCORSBeforeRouteAuthentication(t *testing.T) {
+	t.Setenv("AUTH_KEY", "test-auth-key")
+	t.Setenv("DATA_DIR", t.TempDir())
+	t.Setenv("DATABASE_DSN", ":memory:")
+	t.Setenv("ENCRYPTION_KEY", "test-master-key-long")
+	if err := i18n.Init(); err != nil {
+		t.Fatalf("i18n.Init() error = %v", err)
+	}
+
+	dependencyContainer, err := BuildContainer()
+	if err != nil {
+		t.Fatalf("BuildContainer() error = %v", err)
+	}
+	var engine *gin.Engine
+	var manager *state.Manager
+	if err := dependencyContainer.Invoke(func(
+		resolvedEngine *gin.Engine,
+		resolvedManager *state.Manager,
+		db *gorm.DB,
+	) {
+		engine = resolvedEngine
+		manager = resolvedManager
+		sqlDB, dbErr := db.DB()
+		if dbErr == nil {
+			t.Cleanup(func() { _ = sqlDB.Close() })
+		}
+	}); err != nil {
+		t.Fatalf("resolve container dependencies: %v", err)
+	}
+	if _, err := manager.Publish(state.CompileInput{
+		ChannelRegistry: channel.NewRegistry(),
+		SystemSettings: config.Settings{
+			state.SettingCORS: map[string]any{
+				"enabled":         true,
+				"allowed_origins": []any{"app://obsidian.md"},
+				"allowed_methods": []any{"POST"},
+				"allowed_headers": []any{"Authorization"},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("publish CORS settings: %v", err)
+	}
+
+	for _, target := range []string{"/v1/responses", "/v1/chat/completions"} {
+		request := httptest.NewRequest(http.MethodOptions, target, nil)
+		request.Header.Set("Origin", "app://obsidian.md")
+		request.Header.Set("Access-Control-Request-Method", "POST")
+		request.Header.Set("Access-Control-Request-Headers", "Authorization")
+		response := httptest.NewRecorder()
+		engine.ServeHTTP(response, request)
+
+		if response.Code != http.StatusNoContent ||
+			response.Header().Get("Access-Control-Allow-Origin") != "app://obsidian.md" {
+			t.Fatalf("OPTIONS %s = %d headers=%#v, want CORS 204", target, response.Code, response.Header())
+		}
+		if response.Header().Get("X-Gptload-Attempts") != "" ||
+			response.Header().Get("X-Gptload-Group") != "" {
+			t.Fatalf("OPTIONS %s entered data-plane authentication: %#v", target, response.Header())
+		}
+	}
+
+	controlRequest := httptest.NewRequest(http.MethodOptions, "/api/settings", nil)
+	controlRequest.Header.Set("Origin", "app://obsidian.md")
+	controlRequest.Header.Set("Access-Control-Request-Method", "PUT")
+	controlResponse := httptest.NewRecorder()
+	engine.ServeHTTP(controlResponse, controlRequest)
+	if controlResponse.Code == http.StatusNoContent ||
+		controlResponse.Header().Get("Access-Control-Allow-Origin") != "" {
+		t.Fatalf("control-plane OPTIONS unexpectedly used data-plane CORS: %d %#v", controlResponse.Code, controlResponse.Header())
+	}
+}
+
 func TestBuildContainerDoesNotInitializeUnusedRuntimeStore(t *testing.T) {
 	t.Setenv("AUTH_KEY", "test-auth-key")
 	t.Setenv("DATA_DIR", t.TempDir())

--- a/internal/control/settings.go
+++ b/internal/control/settings.go
@@ -26,11 +26,23 @@ type HeaderRulesResponse struct {
 	Remove []string          `json:"remove"`
 }
 
+type CORSConfigResponse struct {
+	Enabled          bool     `json:"enabled"`
+	AllowedOrigins   []string `json:"allowed_origins"`
+	AllowedMethods   []string `json:"allowed_methods"`
+	AllowedHeaders   []string `json:"allowed_headers"`
+	ExposedHeaders   []string `json:"exposed_headers"`
+	AllowCredentials bool     `json:"allow_credentials"`
+	MaxAge           int      `json:"max_age"`
+}
+
 type SettingsValuesResponse struct {
 	FirstByteTimeout         int64               `json:"first_byte_timeout"`
 	RequestTimeout           int64               `json:"request_timeout"`
 	StreamIdleTimeout        int64               `json:"stream_idle_timeout"`
 	HeaderRules              HeaderRulesResponse `json:"header_rules"`
+	CORS                     CORSConfigResponse  `json:"cors"`
+	ResponseHeaderRules      HeaderRulesResponse `json:"response_header_rules"`
 	InjectUsageOptions       bool                `json:"inject_usage_options"`
 	RetryCount               int                 `json:"retry_count"`
 	BlacklistThreshold       int                 `json:"blacklist_threshold"`
@@ -276,6 +288,11 @@ func mapSettingsResponse(
 		set[name] = value
 	}
 	remove := append([]string{}, settings.HeaderRules.Remove...)
+	responseSet := make(map[string]string, len(settings.ResponseHeaderRules.Set))
+	for name, value := range settings.ResponseHeaderRules.Set {
+		responseSet[name] = value
+	}
+	responseRemove := append([]string{}, settings.ResponseHeaderRules.Remove...)
 	overrides := make([]string, 0, len(rows))
 	var configuredProxy *outboundproxy.Config
 	for _, row := range rows {
@@ -321,6 +338,19 @@ func mapSettingsResponse(
 			HeaderRules: HeaderRulesResponse{
 				Set:    set,
 				Remove: remove,
+			},
+			CORS: CORSConfigResponse{
+				Enabled:          settings.CORS.Enabled,
+				AllowedOrigins:   append([]string{}, settings.CORS.AllowedOrigins...),
+				AllowedMethods:   append([]string{}, settings.CORS.AllowedMethods...),
+				AllowedHeaders:   append([]string{}, settings.CORS.AllowedHeaders...),
+				ExposedHeaders:   append([]string{}, settings.CORS.ExposedHeaders...),
+				AllowCredentials: settings.CORS.AllowCredentials,
+				MaxAge:           settings.CORS.MaxAgeSeconds,
+			},
+			ResponseHeaderRules: HeaderRulesResponse{
+				Set:    responseSet,
+				Remove: responseRemove,
 			},
 			InjectUsageOptions:       settings.InjectUsageOptions,
 			RetryCount:               settings.RetryCount,

--- a/internal/control/settings_test.go
+++ b/internal/control/settings_test.go
@@ -123,11 +123,79 @@ func TestGetSettingsReturnsSnapshotDefaultsAndNoOverrides(t *testing.T) {
 	if got.Values.HeaderRules.Remove == nil || len(got.Values.HeaderRules.Remove) != 0 {
 		t.Fatalf("header_rules.remove = %#v, want empty slice", got.Values.HeaderRules.Remove)
 	}
+	if got.Values.CORS.Enabled ||
+		!reflect.DeepEqual(got.Values.CORS.AllowedMethods, []string{"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"}) ||
+		!reflect.DeepEqual(got.Values.CORS.AllowedHeaders, []string{"*"}) ||
+		got.Values.CORS.MaxAge != 600 {
+		t.Fatalf("cors = %#v, want disabled browser-access defaults", got.Values.CORS)
+	}
+	if got.Values.CORS.AllowedOrigins == nil || got.Values.CORS.ExposedHeaders == nil {
+		t.Fatalf("cors collections must be non-nil: %#v", got.Values.CORS)
+	}
+	if got.Values.ResponseHeaderRules.Set == nil || got.Values.ResponseHeaderRules.Remove == nil {
+		t.Fatalf("response_header_rules collections must be non-nil: %#v", got.Values.ResponseHeaderRules)
+	}
 	if got.Overrides == nil {
 		t.Fatal("overrides = nil, want empty slice")
 	}
 	if !got.Values.ModelsDevAutoSyncEnabled || got.ReadOnly == nil || len(got.ReadOnly) != 0 {
 		t.Fatalf("Models.dev settings = %#v/%#v, want true and no read-only keys", got.Values, got.ReadOnly)
+	}
+}
+
+func TestUpdateSettingsPublishesCORSAndResponseHeaderRules(t *testing.T) {
+	t.Parallel()
+	fixture := newServiceFixture(t)
+	updated, err := fixture.service.UpdateSettings(t.Context(), SettingsUpdateRequest{
+		Settings: map[string]json.RawMessage{
+			state.SettingCORS: json.RawMessage(`{
+				"enabled": true,
+				"allowed_origins": ["app://obsidian.md"],
+				"allowed_methods": ["post"],
+				"allowed_headers": ["authorization", "content-type"],
+				"exposed_headers": ["x-request-id"],
+				"allow_credentials": true,
+				"max_age": 900
+			}`),
+			state.SettingResponseHeaderRules: json.RawMessage(`{
+				"set": {"x-browser-client": "enabled"},
+				"remove": ["x-upstream-marker"]
+			}`),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantCORS := CORSConfigResponse{
+		Enabled:          true,
+		AllowedOrigins:   []string{"app://obsidian.md"},
+		AllowedMethods:   []string{"POST"},
+		AllowedHeaders:   []string{"Authorization", "Content-Type"},
+		ExposedHeaders:   []string{"X-Request-Id"},
+		AllowCredentials: true,
+		MaxAge:           900,
+	}
+	if !reflect.DeepEqual(updated.Values.CORS, wantCORS) {
+		t.Fatalf("cors = %#v, want %#v", updated.Values.CORS, wantCORS)
+	}
+	wantRules := HeaderRulesResponse{
+		Set:    map[string]string{"X-Browser-Client": "enabled"},
+		Remove: []string{"X-Upstream-Marker"},
+	}
+	if !reflect.DeepEqual(updated.Values.ResponseHeaderRules, wantRules) {
+		t.Fatalf("response header rules = %#v, want %#v", updated.Values.ResponseHeaderRules, wantRules)
+	}
+	wantOverrides := []string{state.SettingCORS, state.SettingResponseHeaderRules}
+	if !reflect.DeepEqual(updated.Overrides, wantOverrides) {
+		t.Fatalf("overrides = %#v, want %#v", updated.Overrides, wantOverrides)
+	}
+
+	var rows []models.SystemSetting
+	if err := fixture.db.Order("key").Find(&rows).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 || rows[0].Key != state.SettingCORS || rows[1].Key != state.SettingResponseHeaderRules {
+		t.Fatalf("persisted rows = %#v", rows)
 	}
 }
 
@@ -613,6 +681,8 @@ func TestUpdateSettingsRejectsInvalidChangesWithoutPublishing(t *testing.T) {
 		{name: "excess retention", updates: map[string]json.RawMessage{state.SettingRequestLogRetentionDays: json.RawMessage("366")}, wantErr: app_errors.ErrValidation},
 		{name: "unknown header rule", updates: map[string]json.RawMessage{state.SettingHeaderRules: json.RawMessage(`{"append":{}}`)}, wantErr: app_errors.ErrValidation},
 		{name: "case folded duplicate header", updates: map[string]json.RawMessage{state.SettingHeaderRules: json.RawMessage(`{"set":{"X-Test":"one","x-test":"two"}}`)}, wantErr: app_errors.ErrValidation},
+		{name: "enabled CORS without origins", updates: map[string]json.RawMessage{state.SettingCORS: json.RawMessage(`{"enabled":true,"allowed_origins":[]}`)}, wantErr: app_errors.ErrValidation},
+		{name: "reserved response header", updates: map[string]json.RawMessage{state.SettingResponseHeaderRules: json.RawMessage(`{"set":{"Access-Control-Allow-Origin":"*"}}`)}, wantErr: app_errors.ErrValidation},
 		{name: "malformed raw value", updates: map[string]json.RawMessage{state.SettingRequestTimeout: json.RawMessage("900 800")}, wantErr: app_errors.ErrValidation},
 		{name: "empty", updates: map[string]json.RawMessage{}, wantErr: app_errors.ErrBadRequest},
 		{name: "nil", updates: nil, wantErr: app_errors.ErrBadRequest},
@@ -689,6 +759,7 @@ func TestSettingsUpdateRequestRejectsDuplicateUnknownAndWrongShapeJSON(t *testin
 		{name: "duplicate header rules field", body: `{"settings":{"header_rules":{"set":{},"set":{}}}}`},
 		{name: "duplicate header set member", body: `{"settings":{"header_rules":{"set":{"X-Test":"one","X-Test":"two"}}}}`},
 		{name: "duplicate object nested in array", body: `{"settings":{"header_rules":{"remove":[{"future":1,"future":2}]}}}`},
+		{name: "duplicate CORS field", body: `{"settings":{"cors":{"enabled":true,"enabled":false}}}`},
 		{name: "unknown top level", body: `{"settings":{},"other":{}}`},
 		{name: "missing settings", body: `{}`},
 		{name: "null settings", body: `{"settings":null}`},

--- a/internal/gateway/downstream_headers.go
+++ b/internal/gateway/downstream_headers.go
@@ -36,7 +36,7 @@ func (handler *Handler) DownstreamHeadersMiddleware() gin.HandlerFunc {
 			snapshot.Settings.CORS,
 		)
 		responseRules := snapshot.Settings.ResponseHeaderRules
-		if !preflightAllowed && len(corsHeaders) == 0 &&
+		if !preflightAllowed && len(corsHeaders) == 0 && len(vary) == 0 &&
 			len(responseRules.Set) == 0 && len(responseRules.Remove) == 0 {
 			context.Next()
 			return
@@ -70,13 +70,17 @@ func downstreamCORSHeaders(
 	if request == nil || !config.Enabled {
 		return nil, nil, false
 	}
+	var originVary []string
+	if !containsExactString(config.AllowedOrigins, "*") {
+		originVary = []string{"Origin"}
+	}
 	origin := strings.TrimSpace(request.Header.Get("Origin"))
 	allowedOrigin, wildcard := matchCORSOrigin(origin, config.AllowedOrigins)
 	preflight := request.Method == http.MethodOptions &&
 		origin != "" &&
 		strings.TrimSpace(request.Header.Get("Access-Control-Request-Method")) != ""
 	if !allowedOrigin {
-		return nil, nil, false
+		return nil, originVary, false
 	}
 
 	if preflight {
@@ -88,7 +92,7 @@ func downstreamCORSHeaders(
 		)
 		if !valid || !corsMethodAllowed(method, config.AllowedMethods) ||
 			!corsHeadersAllowed(requestedHeaders, config.AllowedHeaders) {
-			return nil, nil, false
+			return nil, originVary, false
 		}
 		headers := corsActualResponseHeaders(origin, wildcard, config)
 		headers.Set("Access-Control-Allow-Methods", strings.Join(config.AllowedMethods, ", "))
@@ -115,7 +119,7 @@ func downstreamCORSHeaders(
 	if wildcard {
 		return headers, nil, false
 	}
-	return headers, []string{"Origin"}, false
+	return headers, originVary, false
 }
 
 func corsActualResponseHeaders(origin string, wildcard bool, config state.CORSConfig) http.Header {

--- a/internal/gateway/downstream_headers.go
+++ b/internal/gateway/downstream_headers.go
@@ -1,0 +1,305 @@
+package gateway
+
+import (
+	"net/http"
+	"net/textproto"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"gpt-load/internal/state"
+)
+
+// DownstreamHeadersMiddleware applies the system-owned response-header and
+// browser-access policy to data-plane namespaces before route authentication.
+func (handler *Handler) DownstreamHeadersMiddleware() gin.HandlerFunc {
+	return func(context *gin.Context) {
+		if context == nil {
+			return
+		}
+		if context.Request == nil || context.Request.URL == nil ||
+			!isDataPlaneNamespacePath(context.Request.URL.Path) ||
+			handler == nil || handler.manager == nil {
+			context.Next()
+			return
+		}
+
+		snapshot := handler.manager.Current()
+		if snapshot == nil {
+			context.Next()
+			return
+		}
+
+		corsHeaders, vary, preflightAllowed := downstreamCORSHeaders(
+			context.Request,
+			snapshot.Settings.CORS,
+		)
+		responseRules := snapshot.Settings.ResponseHeaderRules
+		if !preflightAllowed && len(corsHeaders) == 0 &&
+			len(responseRules.Set) == 0 && len(responseRules.Remove) == 0 {
+			context.Next()
+			return
+		}
+		writer := &downstreamHeaderWriter{
+			ResponseWriter: context.Writer,
+			rules:          responseRules,
+			corsHeaders:    corsHeaders,
+			vary:           vary,
+		}
+		context.Writer = writer
+		defer writer.apply()
+
+		if preflightAllowed {
+			context.AbortWithStatus(http.StatusNoContent)
+			return
+		}
+		context.Next()
+	}
+}
+
+func isDataPlaneNamespacePath(path string) bool {
+	return path == "/v1" || strings.HasPrefix(path, "/v1/") ||
+		path == "/v1beta" || strings.HasPrefix(path, "/v1beta/")
+}
+
+func downstreamCORSHeaders(
+	request *http.Request,
+	config state.CORSConfig,
+) (http.Header, []string, bool) {
+	if request == nil || !config.Enabled {
+		return nil, nil, false
+	}
+	origin := strings.TrimSpace(request.Header.Get("Origin"))
+	allowedOrigin, wildcard := matchCORSOrigin(origin, config.AllowedOrigins)
+	preflight := request.Method == http.MethodOptions &&
+		origin != "" &&
+		strings.TrimSpace(request.Header.Get("Access-Control-Request-Method")) != ""
+	if !allowedOrigin {
+		return nil, nil, false
+	}
+
+	if preflight {
+		method := strings.ToUpper(strings.TrimSpace(
+			request.Header.Get("Access-Control-Request-Method"),
+		))
+		requestedHeaders, valid := parseCORSRequestHeaders(
+			request.Header.Get("Access-Control-Request-Headers"),
+		)
+		if !valid || !corsMethodAllowed(method, config.AllowedMethods) ||
+			!corsHeadersAllowed(requestedHeaders, config.AllowedHeaders) {
+			return nil, nil, false
+		}
+		headers := corsActualResponseHeaders(origin, wildcard, config)
+		headers.Set("Access-Control-Allow-Methods", strings.Join(config.AllowedMethods, ", "))
+		if containsExactString(config.AllowedHeaders, "*") {
+			if len(requestedHeaders) > 0 {
+				headers.Set("Access-Control-Allow-Headers", strings.Join(requestedHeaders, ", "))
+			} else {
+				headers.Set("Access-Control-Allow-Headers", "*")
+			}
+		} else {
+			headers.Set("Access-Control-Allow-Headers", strings.Join(config.AllowedHeaders, ", "))
+		}
+		if config.MaxAgeSeconds > 0 {
+			headers.Set("Access-Control-Max-Age", strconv.Itoa(config.MaxAgeSeconds))
+		}
+		vary := []string{"Access-Control-Request-Method", "Access-Control-Request-Headers"}
+		if !wildcard {
+			vary = append([]string{"Origin"}, vary...)
+		}
+		return headers, vary, true
+	}
+
+	headers := corsActualResponseHeaders(origin, wildcard, config)
+	if wildcard {
+		return headers, nil, false
+	}
+	return headers, []string{"Origin"}, false
+}
+
+func corsActualResponseHeaders(origin string, wildcard bool, config state.CORSConfig) http.Header {
+	headers := make(http.Header)
+	if wildcard {
+		headers.Set("Access-Control-Allow-Origin", "*")
+	} else {
+		headers.Set("Access-Control-Allow-Origin", origin)
+	}
+	if config.AllowCredentials {
+		headers.Set("Access-Control-Allow-Credentials", "true")
+	}
+	if len(config.ExposedHeaders) > 0 {
+		headers.Set("Access-Control-Expose-Headers", strings.Join(config.ExposedHeaders, ", "))
+	}
+	return headers
+}
+
+func matchCORSOrigin(origin string, allowed []string) (bool, bool) {
+	if origin == "" {
+		return false, false
+	}
+	for _, candidate := range allowed {
+		if candidate == "*" {
+			return true, true
+		}
+		if candidate == origin {
+			return true, false
+		}
+	}
+	return false, false
+}
+
+func corsMethodAllowed(method string, allowed []string) bool {
+	if method == "" {
+		return false
+	}
+	for _, candidate := range allowed {
+		if candidate == method {
+			return true
+		}
+	}
+	return false
+}
+
+func parseCORSRequestHeaders(value string) ([]string, bool) {
+	if strings.TrimSpace(value) == "" {
+		return nil, true
+	}
+	parts := strings.Split(value, ",")
+	result := make([]string, 0, len(parts))
+	seen := make(map[string]struct{}, len(parts))
+	for _, part := range parts {
+		name := strings.TrimSpace(part)
+		if !validCORSRequestHeaderName(name) {
+			return nil, false
+		}
+		identity := strings.ToLower(name)
+		if _, duplicate := seen[identity]; duplicate {
+			continue
+		}
+		seen[identity] = struct{}{}
+		result = append(result, textproto.CanonicalMIMEHeaderKey(name))
+	}
+	return result, true
+}
+
+func validCORSRequestHeaderName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for index := range len(name) {
+		value := name[index]
+		switch {
+		case value >= '0' && value <= '9':
+		case value >= 'a' && value <= 'z':
+		case value >= 'A' && value <= 'Z':
+		case strings.IndexByte("!#$%&'*+-.^_`|~", value) >= 0:
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func corsHeadersAllowed(requested, allowed []string) bool {
+	if containsExactString(allowed, "*") {
+		return true
+	}
+	allowedSet := make(map[string]struct{}, len(allowed))
+	for _, name := range allowed {
+		allowedSet[strings.ToLower(name)] = struct{}{}
+	}
+	for _, name := range requested {
+		if _, exists := allowedSet[strings.ToLower(name)]; !exists {
+			return false
+		}
+	}
+	return true
+}
+
+func containsExactString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+type downstreamHeaderWriter struct {
+	gin.ResponseWriter
+	rules       state.HeaderRules
+	corsHeaders http.Header
+	vary        []string
+	applied     bool
+}
+
+func (writer *downstreamHeaderWriter) WriteHeader(statusCode int) {
+	writer.apply()
+	writer.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (writer *downstreamHeaderWriter) WriteHeaderNow() {
+	writer.apply()
+	writer.ResponseWriter.WriteHeaderNow()
+}
+
+func (writer *downstreamHeaderWriter) Write(data []byte) (int, error) {
+	writer.apply()
+	return writer.ResponseWriter.Write(data)
+}
+
+func (writer *downstreamHeaderWriter) WriteString(data string) (int, error) {
+	writer.apply()
+	return writer.ResponseWriter.WriteString(data)
+}
+
+func (writer *downstreamHeaderWriter) Flush() {
+	writer.apply()
+	writer.ResponseWriter.Flush()
+}
+
+func (writer *downstreamHeaderWriter) Unwrap() http.ResponseWriter {
+	return writer.ResponseWriter
+}
+
+func (writer *downstreamHeaderWriter) apply() {
+	if writer == nil || writer.ResponseWriter == nil || writer.applied {
+		return
+	}
+	writer.applied = true
+	headers := writer.ResponseWriter.Header()
+	for _, name := range writer.rules.Remove {
+		deleteHeaderField(headers, name)
+	}
+	for name, value := range writer.rules.Set {
+		deleteHeaderField(headers, name)
+		headers.Set(name, value)
+	}
+	for name, values := range writer.corsHeaders {
+		deleteHeaderField(headers, name)
+		for _, value := range values {
+			headers.Add(name, value)
+		}
+	}
+	for _, token := range writer.vary {
+		appendVaryToken(headers, token)
+	}
+}
+
+func appendVaryToken(headers http.Header, token string) {
+	values := headerFieldValues(headers, "Vary")
+	for _, value := range values {
+		for _, current := range strings.Split(value, ",") {
+			current = strings.TrimSpace(current)
+			if current == "*" || strings.EqualFold(current, token) {
+				return
+			}
+		}
+	}
+	deleteHeaderField(headers, "Vary")
+	for _, value := range values {
+		headers.Add("Vary", value)
+	}
+	headers.Add("Vary", token)
+}

--- a/internal/gateway/downstream_headers_test.go
+++ b/internal/gateway/downstream_headers_test.go
@@ -120,6 +120,39 @@ func TestDownstreamHeadersMiddlewareAppliesConfiguredRulesToActualResponses(t *t
 	}
 }
 
+func TestDownstreamHeadersMiddlewareVariesExplicitOriginPolicyOnOriginMisses(t *testing.T) {
+	handler := newDownstreamHeadersTestHandler(t, config.Settings{
+		state.SettingCORS: map[string]any{
+			"enabled":         true,
+			"allowed_origins": []any{"app://obsidian.md"},
+		},
+	})
+	engine := gin.New()
+	engine.Use(handler.DownstreamHeadersMiddleware())
+	engine.POST("/v1/responses", func(context *gin.Context) {
+		context.Status(http.StatusUnauthorized)
+	})
+
+	for _, origin := range []string{"", "https://untrusted.example"} {
+		request := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+		if origin != "" {
+			request.Header.Set("Origin", origin)
+		}
+		response := httptest.NewRecorder()
+		engine.ServeHTTP(response, request)
+
+		if response.Code != http.StatusUnauthorized {
+			t.Fatalf("origin %q status = %d, want 401", origin, response.Code)
+		}
+		if !headerListContains(response.Header().Values("Vary"), "Origin") {
+			t.Errorf("origin %q Vary = %#v, want Origin", origin, response.Header().Values("Vary"))
+		}
+		if response.Header().Get("Access-Control-Allow-Origin") != "" {
+			t.Errorf("origin %q exposed CORS headers: %#v", origin, response.Header())
+		}
+	}
+}
+
 func TestDownstreamHeadersMiddlewareRejectsDisallowedPreflightWithoutAffectingControlPlane(t *testing.T) {
 	handler := newDownstreamHeadersTestHandler(t, configuredBrowserAccessSettings())
 	engine := gin.New()

--- a/internal/gateway/downstream_headers_test.go
+++ b/internal/gateway/downstream_headers_test.go
@@ -1,0 +1,238 @@
+package gateway
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/platform/config"
+	"gpt-load/internal/state"
+)
+
+func TestDownstreamHeadersMiddlewarePreservesDisabledPreflightBehavior(t *testing.T) {
+	handler := newDownstreamHeadersTestHandler(t, nil)
+	engine := gin.New()
+	engine.Use(handler.DownstreamHeadersMiddleware())
+	reached := false
+	engine.Any("/v1/responses", func(context *gin.Context) {
+		reached = true
+		context.JSON(http.StatusUnauthorized, gin.H{"code": "invalid_access_key"})
+	})
+
+	request := newPreflightRequest("/v1/responses", "app://obsidian.md", "POST", "authorization")
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, request)
+
+	if !reached || response.Code != http.StatusUnauthorized {
+		t.Fatalf("disabled preflight = reached:%t status:%d, want downstream 401", reached, response.Code)
+	}
+	if response.Header().Get("Access-Control-Allow-Origin") != "" {
+		t.Fatalf("disabled preflight exposed CORS headers: %#v", response.Header())
+	}
+}
+
+func TestDownstreamHeadersMiddlewareAnswersAllowedPreflightBeforeAuthentication(t *testing.T) {
+	handler := newDownstreamHeadersTestHandler(t, configuredBrowserAccessSettings())
+	engine := gin.New()
+	engine.Use(handler.DownstreamHeadersMiddleware())
+	reached := false
+	engine.Any("/v1/responses", func(context *gin.Context) {
+		reached = true
+		context.Status(http.StatusUnauthorized)
+	})
+
+	request := newPreflightRequest(
+		"/v1/responses",
+		"app://obsidian.md",
+		"POST",
+		"authorization, content-type",
+	)
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, request)
+
+	if reached || response.Code != http.StatusNoContent || response.Body.Len() != 0 {
+		t.Fatalf(
+			"preflight = reached:%t status:%d body:%q, want local 204",
+			reached,
+			response.Code,
+			response.Body.String(),
+		)
+	}
+	for name, want := range map[string]string{
+		"Access-Control-Allow-Origin":      "app://obsidian.md",
+		"Access-Control-Allow-Methods":     "POST, GET",
+		"Access-Control-Allow-Headers":     "Authorization, Content-Type",
+		"Access-Control-Expose-Headers":    "X-Request-Id",
+		"Access-Control-Allow-Credentials": "true",
+		"Access-Control-Max-Age":           "900",
+		"X-Browser-Client":                 "enabled",
+	} {
+		if got := response.Header().Get(name); got != want {
+			t.Errorf("%s = %q, want %q", name, got, want)
+		}
+	}
+	for _, token := range []string{"Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers"} {
+		if !headerListContains(response.Header().Values("Vary"), token) {
+			t.Errorf("Vary = %#v, want %q", response.Header().Values("Vary"), token)
+		}
+	}
+	if response.Header().Get(debugHeaderAttempts) != "" || response.Header().Get(debugHeaderGroup) != "" {
+		t.Fatalf("preflight initialized data-plane debug headers: %#v", response.Header())
+	}
+}
+
+func TestDownstreamHeadersMiddlewareAppliesConfiguredRulesToActualResponses(t *testing.T) {
+	handler := newDownstreamHeadersTestHandler(t, configuredBrowserAccessSettings())
+	engine := gin.New()
+	engine.Use(handler.DownstreamHeadersMiddleware())
+	engine.POST("/v1/responses", func(context *gin.Context) {
+		context.Header("X-Browser-Client", "upstream")
+		context.Header("X-Upstream-Marker", "remove-me")
+		context.Header("Vary", "Accept-Encoding")
+		context.JSON(http.StatusUnauthorized, gin.H{"code": "invalid_access_key"})
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	request.Header.Set("Origin", "app://obsidian.md")
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, request)
+
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("response status = %d, want 401", response.Code)
+	}
+	if got := response.Header().Values("X-Browser-Client"); len(got) != 1 || got[0] != "enabled" {
+		t.Fatalf("X-Browser-Client = %#v, want configured override", got)
+	}
+	if got := response.Header().Get("X-Upstream-Marker"); got != "" {
+		t.Fatalf("X-Upstream-Marker = %q, want removed", got)
+	}
+	if got := response.Header().Get("Access-Control-Allow-Origin"); got != "app://obsidian.md" {
+		t.Fatalf("Access-Control-Allow-Origin = %q", got)
+	}
+	for _, token := range []string{"Accept-Encoding", "Origin"} {
+		if !headerListContains(response.Header().Values("Vary"), token) {
+			t.Errorf("Vary = %#v, want %q", response.Header().Values("Vary"), token)
+		}
+	}
+}
+
+func TestDownstreamHeadersMiddlewareRejectsDisallowedPreflightWithoutAffectingControlPlane(t *testing.T) {
+	handler := newDownstreamHeadersTestHandler(t, configuredBrowserAccessSettings())
+	engine := gin.New()
+	engine.Use(handler.DownstreamHeadersMiddleware())
+	engine.Any("/v1/responses", func(context *gin.Context) {
+		context.Status(http.StatusUnauthorized)
+	})
+	engine.Any("/api/settings", func(context *gin.Context) {
+		context.Status(http.StatusTeapot)
+	})
+
+	for _, request := range []*http.Request{
+		newPreflightRequest("/v1/responses", "https://untrusted.example", "POST", "authorization"),
+		newPreflightRequest("/v1/responses", "app://obsidian.md", "DELETE", "authorization"),
+		newPreflightRequest("/v1/responses", "app://obsidian.md", "POST", "x-not-allowed"),
+	} {
+		response := httptest.NewRecorder()
+		engine.ServeHTTP(response, request)
+		if response.Code != http.StatusUnauthorized || response.Header().Get("Access-Control-Allow-Origin") != "" {
+			t.Fatalf("disallowed preflight = %d headers=%#v, want downstream 401 without CORS", response.Code, response.Header())
+		}
+	}
+
+	controlResponse := httptest.NewRecorder()
+	engine.ServeHTTP(
+		controlResponse,
+		newPreflightRequest("/api/settings", "app://obsidian.md", "PUT", "authorization"),
+	)
+	if controlResponse.Code != http.StatusTeapot || controlResponse.Header().Get("X-Browser-Client") != "" {
+		t.Fatalf("control preflight = %d headers=%#v, want untouched", controlResponse.Code, controlResponse.Header())
+	}
+}
+
+func TestDownstreamHeadersMiddlewareExpandsWildcardAllowedHeaders(t *testing.T) {
+	handler := newDownstreamHeadersTestHandler(t, config.Settings{
+		state.SettingCORS: map[string]any{
+			"enabled":         true,
+			"allowed_origins": []any{"*"},
+			"allowed_methods": []any{"POST"},
+			"allowed_headers": []any{"*"},
+		},
+	})
+	engine := gin.New()
+	engine.Use(handler.DownstreamHeadersMiddleware())
+	engine.Any("/v1/chat/completions", func(context *gin.Context) {
+		context.Status(http.StatusUnauthorized)
+	})
+
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(
+		response,
+		newPreflightRequest(
+			"/v1/chat/completions",
+			"https://client.example",
+			"POST",
+			"authorization, x-client-version",
+		),
+	)
+
+	if response.Code != http.StatusNoContent ||
+		response.Header().Get("Access-Control-Allow-Origin") != "*" ||
+		response.Header().Get("Access-Control-Allow-Headers") != "Authorization, X-Client-Version" {
+		t.Fatalf("wildcard preflight = %d headers=%#v", response.Code, response.Header())
+	}
+}
+
+func newDownstreamHeadersTestHandler(t *testing.T, settings config.Settings) *Handler {
+	t.Helper()
+	manager := state.NewManager()
+	if _, err := manager.Publish(state.CompileInput{
+		SystemSettings:  settings,
+		ChannelRegistry: channel.NewRegistry(),
+	}); err != nil {
+		t.Fatalf("publish test settings: %v", err)
+	}
+	return &Handler{manager: manager}
+}
+
+func configuredBrowserAccessSettings() config.Settings {
+	return config.Settings{
+		state.SettingCORS: map[string]any{
+			"enabled":           true,
+			"allowed_origins":   []any{"app://obsidian.md"},
+			"allowed_methods":   []any{"POST", "GET"},
+			"allowed_headers":   []any{"Authorization", "Content-Type"},
+			"exposed_headers":   []any{"X-Request-Id"},
+			"allow_credentials": true,
+			"max_age":           900,
+		},
+		state.SettingResponseHeaderRules: map[string]any{
+			"set":    map[string]any{"X-Browser-Client": "enabled"},
+			"remove": []any{"X-Upstream-Marker"},
+		},
+	}
+}
+
+func newPreflightRequest(path, origin, method, headers string) *http.Request {
+	request := httptest.NewRequest(http.MethodOptions, path, nil)
+	request.Header.Set("Origin", origin)
+	request.Header.Set("Access-Control-Request-Method", method)
+	if headers != "" {
+		request.Header.Set("Access-Control-Request-Headers", headers)
+	}
+	return request
+}
+
+func headerListContains(values []string, target string) bool {
+	for _, value := range values {
+		for _, token := range strings.Split(value, ",") {
+			if strings.EqualFold(strings.TrimSpace(token), target) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/gateway/http_routes_test.go
+++ b/internal/gateway/http_routes_test.go
@@ -19,6 +19,7 @@ func bindGatewayRoutesForTest(
 	handler *Handler,
 ) {
 	t.Helper()
+	engine.Use(handler.DownstreamHeadersMiddleware())
 	registry, err := httproute.NewRegistry(handler.HTTPModule())
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)

--- a/internal/platform/httpheader/policy.go
+++ b/internal/platform/httpheader/policy.go
@@ -27,6 +27,31 @@ var forbiddenRequestRuleNames = map[string]struct{}{
 	"content-encoding":  {},
 }
 
+var forbiddenResponseRuleNames = map[string]struct{}{
+	"connection":                       {},
+	"proxy-connection":                 {},
+	"keep-alive":                       {},
+	"te":                               {},
+	"trailer":                          {},
+	"transfer-encoding":                {},
+	"upgrade":                          {},
+	"content-encoding":                 {},
+	"content-length":                   {},
+	"content-range":                    {},
+	"content-type":                     {},
+	"date":                             {},
+	"server":                           {},
+	"set-cookie":                       {},
+	"set-cookie2":                      {},
+	"vary":                             {},
+	"access-control-allow-origin":      {},
+	"access-control-allow-methods":     {},
+	"access-control-allow-headers":     {},
+	"access-control-allow-credentials": {},
+	"access-control-expose-headers":    {},
+	"access-control-max-age":           {},
+}
+
 func IsCredentialName(name string) bool {
 	normalized := normalizeName(name)
 	if normalized == "" {
@@ -50,6 +75,23 @@ func IsForbiddenRequestRuleName(name string) bool {
 
 func IsForbiddenRequestRuleSetName(name string) bool {
 	return IsForbiddenRequestRuleName(name)
+}
+
+// IsForbiddenResponseRuleName reports whether a user-managed downstream rule
+// could interfere with HTTP framing, gateway-owned metadata, credentials, or
+// the dedicated CORS policy.
+func IsForbiddenResponseRuleName(name string) bool {
+	normalized := normalizeName(name)
+	if normalized == "" {
+		return false
+	}
+	if strings.HasPrefix(normalized, "proxy-") ||
+		strings.HasPrefix(normalized, "x-gptload-") ||
+		IsCredentialName(normalized) {
+		return true
+	}
+	_, exists := forbiddenResponseRuleNames[normalized]
+	return exists
 }
 
 func normalizeName(name string) string {

--- a/internal/platform/httpheader/policy_test.go
+++ b/internal/platform/httpheader/policy_test.go
@@ -96,3 +96,30 @@ func TestIsForbiddenRequestRuleName(t *testing.T) {
 		})
 	}
 }
+
+func TestIsForbiddenResponseRuleName(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		want bool
+	}{
+		{name: "Connection", want: true},
+		{name: "Content-Length", want: true},
+		{name: "content-type", want: true},
+		{name: "Set-Cookie", want: true},
+		{name: "Vary", want: true},
+		{name: "Access-Control-Allow-Origin", want: true},
+		{name: "Access-Control-Allow-Private-Network"},
+		{name: "x-gptload-attempts", want: true},
+		{name: "Authorization", want: true},
+		{name: "Proxy-Custom", want: true},
+		{name: "Cross-Origin-Resource-Policy"},
+		{name: "Cache-Control"},
+		{name: "X-Custom"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := IsForbiddenResponseRuleName(test.name); got != test.want {
+				t.Fatalf("IsForbiddenResponseRuleName(%q) = %t, want %t", test.name, got, test.want)
+			}
+		})
+	}
+}

--- a/internal/state/cors.go
+++ b/internal/state/cors.go
@@ -1,0 +1,232 @@
+package state
+
+import (
+	"fmt"
+	"net/textproto"
+	"net/url"
+	"strings"
+)
+
+var defaultCORSMethods = []string{
+	"GET",
+	"POST",
+	"PUT",
+	"PATCH",
+	"DELETE",
+	"HEAD",
+	"OPTIONS",
+}
+
+// CORSConfig controls browser access to the data-plane namespaces. An empty or
+// disabled policy never bypasses normal data-plane authentication.
+type CORSConfig struct {
+	Enabled          bool
+	AllowedOrigins   []string
+	AllowedMethods   []string
+	AllowedHeaders   []string
+	ExposedHeaders   []string
+	AllowCredentials bool
+	MaxAgeSeconds    int
+}
+
+func defaultCORSConfig() CORSConfig {
+	return CORSConfig{
+		AllowedMethods: append([]string(nil), defaultCORSMethods...),
+		AllowedHeaders: []string{"*"},
+		MaxAgeSeconds:  600,
+	}
+}
+
+func parseCORSConfig(value any) (CORSConfig, error) {
+	object, ok := value.(map[string]any)
+	if !ok {
+		return CORSConfig{}, fmt.Errorf("cors must be an object")
+	}
+	for key := range object {
+		switch key {
+		case "enabled",
+			"allowed_origins",
+			"allowed_methods",
+			"allowed_headers",
+			"exposed_headers",
+			"allow_credentials",
+			"max_age":
+		default:
+			return CORSConfig{}, fmt.Errorf("unknown cors field %q", key)
+		}
+	}
+
+	config := defaultCORSConfig()
+	var err error
+	if raw, exists := object["enabled"]; exists {
+		config.Enabled, err = strictBoolean("cors.enabled", raw)
+		if err != nil {
+			return CORSConfig{}, err
+		}
+	}
+	if raw, exists := object["allowed_origins"]; exists {
+		config.AllowedOrigins, err = parseCORSOrigins(raw)
+		if err != nil {
+			return CORSConfig{}, err
+		}
+	}
+	if raw, exists := object["allowed_methods"]; exists {
+		config.AllowedMethods, err = parseCORSMethods(raw)
+		if err != nil {
+			return CORSConfig{}, err
+		}
+	}
+	if raw, exists := object["allowed_headers"]; exists {
+		config.AllowedHeaders, err = parseCORSHeaderNames("cors.allowed_headers", raw)
+		if err != nil {
+			return CORSConfig{}, err
+		}
+	}
+	if raw, exists := object["exposed_headers"]; exists {
+		config.ExposedHeaders, err = parseCORSHeaderNames("cors.exposed_headers", raw)
+		if err != nil {
+			return CORSConfig{}, err
+		}
+	}
+	if raw, exists := object["allow_credentials"]; exists {
+		config.AllowCredentials, err = strictBoolean("cors.allow_credentials", raw)
+		if err != nil {
+			return CORSConfig{}, err
+		}
+	}
+	if raw, exists := object["max_age"]; exists {
+		config.MaxAgeSeconds, err = nonNegativeWholeNumber("cors.max_age", raw)
+		if err != nil {
+			return CORSConfig{}, err
+		}
+	}
+
+	if config.Enabled && len(config.AllowedOrigins) == 0 {
+		return CORSConfig{}, fmt.Errorf("cors.allowed_origins must not be empty when cors is enabled")
+	}
+	if config.Enabled && len(config.AllowedMethods) == 0 {
+		return CORSConfig{}, fmt.Errorf("cors.allowed_methods must not be empty when cors is enabled")
+	}
+	if config.Enabled && len(config.AllowedHeaders) == 0 {
+		return CORSConfig{}, fmt.Errorf("cors.allowed_headers must not be empty when cors is enabled")
+	}
+	if config.AllowCredentials && containsExact(config.AllowedOrigins, "*") {
+		return CORSConfig{}, fmt.Errorf("cors.allow_credentials cannot be used with wildcard origin")
+	}
+	if config.AllowCredentials && containsExact(config.ExposedHeaders, "*") {
+		return CORSConfig{}, fmt.Errorf("cors.allow_credentials cannot be used with wildcard exposed headers")
+	}
+	return config, nil
+}
+
+func parseCORSOrigins(value any) ([]string, error) {
+	values, ok := value.([]any)
+	if !ok {
+		return nil, fmt.Errorf("cors.allowed_origins must be an array")
+	}
+	parsed := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for index, raw := range values {
+		origin, ok := raw.(string)
+		if !ok {
+			return nil, fmt.Errorf("cors.allowed_origins[%d] must be a string", index)
+		}
+		origin = strings.TrimSpace(origin)
+		if !validCORSOrigin(origin) {
+			return nil, fmt.Errorf("cors.allowed_origins[%d] is invalid", index)
+		}
+		if _, duplicate := seen[origin]; duplicate {
+			return nil, fmt.Errorf("cors.allowed_origins contains duplicate origin %q", origin)
+		}
+		seen[origin] = struct{}{}
+		parsed = append(parsed, origin)
+	}
+	if len(parsed) > 1 && containsExact(parsed, "*") {
+		return nil, fmt.Errorf("cors.allowed_origins wildcard must be the only origin")
+	}
+	return parsed, nil
+}
+
+func parseCORSMethods(value any) ([]string, error) {
+	values, ok := value.([]any)
+	if !ok {
+		return nil, fmt.Errorf("cors.allowed_methods must be an array")
+	}
+	parsed := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for index, raw := range values {
+		method, ok := raw.(string)
+		if !ok {
+			return nil, fmt.Errorf("cors.allowed_methods[%d] must be a string", index)
+		}
+		method = strings.ToUpper(strings.TrimSpace(method))
+		if method == "*" || !validHTTPHeaderName(method) {
+			return nil, fmt.Errorf("cors.allowed_methods[%d] is invalid", index)
+		}
+		if _, duplicate := seen[method]; duplicate {
+			return nil, fmt.Errorf("cors.allowed_methods contains duplicate method %q", method)
+		}
+		seen[method] = struct{}{}
+		parsed = append(parsed, method)
+	}
+	return parsed, nil
+}
+
+func validCORSOrigin(origin string) bool {
+	if origin == "*" || origin == "null" {
+		return true
+	}
+	if origin == "" || strings.ContainsAny(origin, " \t\r\n,") || !validHTTPHeaderValue(origin) {
+		return false
+	}
+	parsed, err := url.Parse(origin)
+	return err == nil &&
+		parsed.Scheme != "" &&
+		parsed.Host != "" &&
+		parsed.User == nil &&
+		parsed.Path == "" &&
+		parsed.RawQuery == "" &&
+		parsed.Fragment == "" &&
+		parsed.Opaque == ""
+}
+
+func parseCORSHeaderNames(path string, value any) ([]string, error) {
+	values, ok := value.([]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must be an array", path)
+	}
+	parsed := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for index, raw := range values {
+		name, ok := raw.(string)
+		if !ok {
+			return nil, fmt.Errorf("%s[%d] must be a string", path, index)
+		}
+		name = strings.TrimSpace(name)
+		if name != "*" && !validHTTPHeaderName(name) {
+			return nil, fmt.Errorf("%s[%d] contains invalid header name %q", path, index, name)
+		}
+		identity := strings.ToLower(name)
+		if _, duplicate := seen[identity]; duplicate {
+			return nil, fmt.Errorf("%s contains duplicate header %q", path, name)
+		}
+		seen[identity] = struct{}{}
+		if name != "*" {
+			name = textproto.CanonicalMIMEHeaderKey(name)
+		}
+		parsed = append(parsed, name)
+	}
+	if len(parsed) > 1 && containsExact(parsed, "*") {
+		return nil, fmt.Errorf("%s wildcard must be the only header", path)
+	}
+	return parsed, nil
+}
+
+func containsExact(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/state/cors.go
+++ b/internal/state/cors.go
@@ -2,9 +2,13 @@ package state
 
 import (
 	"fmt"
+	"net"
 	"net/textproto"
 	"net/url"
+	"strconv"
 	"strings"
+
+	"golang.org/x/net/idna"
 )
 
 var defaultCORSMethods = []string{
@@ -131,8 +135,8 @@ func parseCORSOrigins(value any) ([]string, error) {
 		if !ok {
 			return nil, fmt.Errorf("cors.allowed_origins[%d] must be a string", index)
 		}
-		origin = strings.TrimSpace(origin)
-		if !validCORSOrigin(origin) {
+		origin, valid := canonicalCORSOrigin(strings.TrimSpace(origin))
+		if !valid {
 			return nil, fmt.Errorf("cors.allowed_origins[%d] is invalid", index)
 		}
 		if _, duplicate := seen[origin]; duplicate {
@@ -172,22 +176,52 @@ func parseCORSMethods(value any) ([]string, error) {
 	return parsed, nil
 }
 
-func validCORSOrigin(origin string) bool {
+func canonicalCORSOrigin(origin string) (string, bool) {
 	if origin == "*" || origin == "null" {
-		return true
+		return origin, true
 	}
 	if origin == "" || strings.ContainsAny(origin, " \t\r\n,") || !validHTTPHeaderValue(origin) {
-		return false
+		return "", false
 	}
 	parsed, err := url.Parse(origin)
-	return err == nil &&
-		parsed.Scheme != "" &&
-		parsed.Host != "" &&
-		parsed.User == nil &&
-		parsed.Path == "" &&
-		parsed.RawQuery == "" &&
-		parsed.Fragment == "" &&
-		parsed.Opaque == ""
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.User != nil ||
+		parsed.Path != "" || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.Opaque != "" {
+		return "", false
+	}
+
+	scheme := strings.ToLower(parsed.Scheme)
+	hostname := parsed.Hostname()
+	if hostname == "" {
+		return "", false
+	}
+	host := ""
+	if ip := net.ParseIP(hostname); ip != nil {
+		host = ip.String()
+	} else {
+		host, err = idna.Lookup.ToASCII(hostname)
+		if err != nil {
+			return "", false
+		}
+		host = strings.ToLower(host)
+	}
+
+	port := parsed.Port()
+	if port != "" {
+		parsedPort, parseErr := strconv.ParseUint(port, 10, 16)
+		if parseErr != nil {
+			return "", false
+		}
+		port = strconv.FormatUint(parsedPort, 10)
+	}
+	if (scheme == "http" && port == "80") || (scheme == "https" && port == "443") {
+		port = ""
+	}
+	if port != "" {
+		host = net.JoinHostPort(host, port)
+	} else if strings.Contains(host, ":") {
+		host = "[" + host + "]"
+	}
+	return scheme + "://" + host, true
 }
 
 func parseCORSHeaderNames(path string, value any) ([]string, error) {

--- a/internal/state/loader/loader_test.go
+++ b/internal/state/loader/loader_test.go
@@ -433,23 +433,11 @@ func TestLoaderMapsSystemAndGroupRows(t *testing.T) {
 	if snapshot == nil {
 		t.Fatal("Current() = nil, want snapshot")
 	}
-	wantSettings := state.RuntimeSettings{
-		FirstByteTimeout:  20 * time.Second,
-		RequestTimeout:    600 * time.Second,
-		StreamIdleTimeout: 300 * time.Second,
-		HeaderRules: state.HeaderRules{
-			Set:    map[string]string{"X-System": "system"},
-			Remove: []string{"X-System-Remove"},
-		},
-		InjectUsageOptions:       true,
-		RetryCount:               2,
-		BlacklistThreshold:       3,
-		AffinityEnabled:          true,
-		AffinityTTL:              time.Hour,
-		AffinityCapacity:         10_000,
-		ValidationInterval:       10 * time.Minute,
-		RequestLogRetentionDays:  7,
-		ModelsDevAutoSyncEnabled: true,
+	wantSettings := state.DefaultRuntimeSettings()
+	wantSettings.FirstByteTimeout = 20 * time.Second
+	wantSettings.HeaderRules = state.HeaderRules{
+		Set:    map[string]string{"X-System": "system"},
+		Remove: []string{"X-System-Remove"},
 	}
 	if !reflect.DeepEqual(snapshot.Settings, wantSettings) {
 		t.Fatalf("snapshot Settings = %#v, want %#v", snapshot.Settings, wantSettings)

--- a/internal/state/runtime_settings.go
+++ b/internal/state/runtime_settings.go
@@ -18,6 +18,8 @@ const (
 	SettingRequestTimeout           = "request_timeout"
 	SettingStreamIdleTimeout        = "stream_idle_timeout"
 	SettingHeaderRules              = "header_rules"
+	SettingCORS                     = "cors"
+	SettingResponseHeaderRules      = "response_header_rules"
 	SettingInjectUsageOptions       = "inject_usage_options"
 	SettingRetryCount               = "retry_count"
 	SettingBlacklistThreshold       = "blacklist_threshold"
@@ -43,6 +45,8 @@ type RuntimeSettings struct {
 	RequestTimeout           time.Duration
 	StreamIdleTimeout        time.Duration
 	HeaderRules              HeaderRules
+	CORS                     CORSConfig
+	ResponseHeaderRules      HeaderRules
 	InjectUsageOptions       bool
 	RetryCount               int
 	BlacklistThreshold       int
@@ -69,6 +73,8 @@ func DefaultRuntimeSettings() RuntimeSettings {
 		RequestTimeout:           600 * time.Second,
 		StreamIdleTimeout:        300 * time.Second,
 		HeaderRules:              HeaderRules{Set: map[string]string{}},
+		CORS:                     defaultCORSConfig(),
+		ResponseHeaderRules:      HeaderRules{Set: map[string]string{}},
 		InjectUsageOptions:       true,
 		RetryCount:               2,
 		BlacklistThreshold:       3,
@@ -87,6 +93,8 @@ func IsRuntimeSettingKey(key string) bool {
 		SettingRequestTimeout,
 		SettingStreamIdleTimeout,
 		SettingHeaderRules,
+		SettingCORS,
+		SettingResponseHeaderRules,
 		SettingInjectUsageOptions,
 		SettingRetryCount,
 		SettingBlacklistThreshold,
@@ -130,6 +138,18 @@ func ResolveRuntimeSettings(settings config.Settings) (RuntimeSettings, error) {
 				return RuntimeSettings{}, err
 			}
 			resolved.HeaderRules = rules
+		case SettingCORS:
+			cors, err := parseCORSConfig(value)
+			if err != nil {
+				return RuntimeSettings{}, err
+			}
+			resolved.CORS = cors
+		case SettingResponseHeaderRules:
+			rules, err := parseResponseHeaderRules(value)
+			if err != nil {
+				return RuntimeSettings{}, err
+			}
+			resolved.ResponseHeaderRules = rules
 		case SettingInjectUsageOptions:
 			value, err := strictBoolean(key, value)
 			if err != nil {
@@ -280,6 +300,12 @@ func ValidateRuntimeSetting(key string, value any) error {
 	case SettingHeaderRules:
 		_, err := parseHeaderRules(value)
 		return err
+	case SettingCORS:
+		_, err := parseCORSConfig(value)
+		return err
+	case SettingResponseHeaderRules:
+		_, err := parseResponseHeaderRules(value)
+		return err
 	case SettingInjectUsageOptions:
 		_, err := strictBoolean(key, value)
 		return err
@@ -415,48 +441,72 @@ func positiveWholeSeconds(path string, value any) (int64, error) {
 }
 
 func parseHeaderRules(value any) (HeaderRules, error) {
+	return parseHeaderRulesWithPolicy(
+		value,
+		SettingHeaderRules,
+		func(name string) bool {
+			return httpheader.IsForbiddenRequestRuleName(name) ||
+				httpheader.IsCredentialName(name)
+		},
+	)
+}
+
+func parseResponseHeaderRules(value any) (HeaderRules, error) {
+	return parseHeaderRulesWithPolicy(
+		value,
+		SettingResponseHeaderRules,
+		httpheader.IsForbiddenResponseRuleName,
+	)
+}
+
+func parseHeaderRulesWithPolicy(
+	value any,
+	settingName string,
+	forbidden func(string) bool,
+) (HeaderRules, error) {
 	rules := HeaderRules{Set: make(map[string]string)}
 	object, ok := value.(map[string]any)
 	if !ok {
-		return HeaderRules{}, fmt.Errorf("header_rules must be an object")
+		return HeaderRules{}, fmt.Errorf("%s must be an object", settingName)
 	}
 	for key := range object {
 		if key != "set" && key != "remove" {
-			return HeaderRules{}, fmt.Errorf("unknown header_rules field %q", key)
+			return HeaderRules{}, fmt.Errorf("unknown %s field %q", settingName, key)
 		}
 	}
 	seen := make(map[string]struct{})
 	if rawSet, exists := object["set"]; exists {
 		set, ok := rawSet.(map[string]any)
 		if !ok {
-			return HeaderRules{}, fmt.Errorf("header_rules.set must be an object")
+			return HeaderRules{}, fmt.Errorf("%s.set must be an object", settingName)
 		}
 		for name, rawValue := range set {
 			if !validHTTPHeaderName(name) {
-				return HeaderRules{}, fmt.Errorf("header_rules.set contains invalid header name %q", name)
+				return HeaderRules{}, fmt.Errorf("%s.set contains invalid header name %q", settingName, name)
 			}
 			canonicalName := textproto.CanonicalMIMEHeaderKey(name)
-			if httpheader.IsForbiddenRequestRuleName(canonicalName) ||
-				httpheader.IsCredentialName(canonicalName) {
+			if forbidden != nil && forbidden(canonicalName) {
 				return HeaderRules{}, fmt.Errorf(
-					"header_rules.set cannot set forbidden header %q",
+					"%s.set cannot set forbidden header %q",
+					settingName,
 					canonicalName,
 				)
 			}
 			identity := strings.ToLower(name)
 			if _, duplicate := seen[identity]; duplicate {
 				return HeaderRules{}, fmt.Errorf(
-					"header_rules.set contains duplicate header %q",
+					"%s.set contains duplicate header %q",
+					settingName,
 					canonicalName,
 				)
 			}
 			seen[identity] = struct{}{}
 			text, ok := rawValue.(string)
 			if !ok {
-				return HeaderRules{}, fmt.Errorf("header_rules.set.%s must be a string", name)
+				return HeaderRules{}, fmt.Errorf("%s.set.%s must be a string", settingName, name)
 			}
 			if !validHTTPHeaderValue(text) {
-				return HeaderRules{}, fmt.Errorf("header_rules.set.%s contains invalid header value", name)
+				return HeaderRules{}, fmt.Errorf("%s.set.%s contains invalid header value", settingName, name)
 			}
 			rules.Set[canonicalName] = text
 		}
@@ -464,33 +514,35 @@ func parseHeaderRules(value any) (HeaderRules, error) {
 	if rawRemove, exists := object["remove"]; exists {
 		remove, ok := rawRemove.([]any)
 		if !ok {
-			return HeaderRules{}, fmt.Errorf("header_rules.remove must be an array")
+			return HeaderRules{}, fmt.Errorf("%s.remove must be an array", settingName)
 		}
 		rules.Remove = make([]string, 0, len(remove))
 		for index, rawName := range remove {
 			name, ok := rawName.(string)
 			if !ok {
-				return HeaderRules{}, fmt.Errorf("header_rules.remove[%d] must be a string", index)
+				return HeaderRules{}, fmt.Errorf("%s.remove[%d] must be a string", settingName, index)
 			}
 			if !validHTTPHeaderName(name) {
 				return HeaderRules{}, fmt.Errorf(
-					"header_rules.remove[%d] contains invalid header name %q",
+					"%s.remove[%d] contains invalid header name %q",
+					settingName,
 					index,
 					name,
 				)
 			}
 			canonicalName := textproto.CanonicalMIMEHeaderKey(name)
-			if httpheader.IsForbiddenRequestRuleName(canonicalName) ||
-				httpheader.IsCredentialName(canonicalName) {
+			if forbidden != nil && forbidden(canonicalName) {
 				return HeaderRules{}, fmt.Errorf(
-					"header_rules.remove cannot remove forbidden header %q",
+					"%s.remove cannot remove forbidden header %q",
+					settingName,
 					canonicalName,
 				)
 			}
 			identity := strings.ToLower(name)
 			if _, duplicate := seen[identity]; duplicate {
 				return HeaderRules{}, fmt.Errorf(
-					"header_rules.remove contains duplicate header %q",
+					"%s.remove contains duplicate header %q",
+					settingName,
 					canonicalName,
 				)
 			}

--- a/internal/state/runtime_settings_test.go
+++ b/internal/state/runtime_settings_test.go
@@ -17,10 +17,16 @@ func TestCompilePublishesDefaultRuntimeSettingsWithoutGroups(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := RuntimeSettings{
-		FirstByteTimeout:         120 * time.Second,
-		RequestTimeout:           600 * time.Second,
-		StreamIdleTimeout:        300 * time.Second,
-		HeaderRules:              HeaderRules{Set: map[string]string{}},
+		FirstByteTimeout:  120 * time.Second,
+		RequestTimeout:    600 * time.Second,
+		StreamIdleTimeout: 300 * time.Second,
+		HeaderRules:       HeaderRules{Set: map[string]string{}},
+		CORS: CORSConfig{
+			AllowedMethods: []string{"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"},
+			AllowedHeaders: []string{"*"},
+			MaxAgeSeconds:  600,
+		},
+		ResponseHeaderRules:      HeaderRules{Set: map[string]string{}},
 		InjectUsageOptions:       true,
 		RetryCount:               2,
 		BlacklistThreshold:       3,
@@ -33,6 +39,139 @@ func TestCompilePublishesDefaultRuntimeSettingsWithoutGroups(t *testing.T) {
 	}
 	if !reflect.DeepEqual(snapshot.Settings, want) {
 		t.Fatalf("Settings = %#v, want %#v", snapshot.Settings, want)
+	}
+}
+
+func TestCORSAndResponseHeaderRulesAreSystemOnlyRuntimeSettings(t *testing.T) {
+	for key, value := range map[string]any{
+		SettingCORS: map[string]any{
+			"enabled":           true,
+			"allowed_origins":   []any{"app://obsidian.md", "https://notes.example"},
+			"allowed_methods":   []any{"post", "GET"},
+			"allowed_headers":   []any{"authorization", "content-type"},
+			"exposed_headers":   []any{"x-request-id"},
+			"allow_credentials": true,
+			"max_age":           json.Number("900"),
+		},
+		SettingResponseHeaderRules: map[string]any{
+			"set":    map[string]any{"x-browser-client": "enabled"},
+			"remove": []any{"x-upstream-marker"},
+		},
+	} {
+		if !IsRuntimeSettingKey(key) {
+			t.Errorf("IsRuntimeSettingKey(%q) = false", key)
+		}
+		if err := ValidateRuntimeSetting(key, value); err != nil {
+			t.Errorf("ValidateRuntimeSetting(%q) error = %v", key, err)
+		}
+	}
+
+	resolved, err := ResolveRuntimeSettings(config.Settings{
+		SettingCORS: map[string]any{
+			"enabled":           true,
+			"allowed_origins":   []any{"app://obsidian.md", "https://notes.example"},
+			"allowed_methods":   []any{"post", "GET"},
+			"allowed_headers":   []any{"authorization", "content-type"},
+			"exposed_headers":   []any{"x-request-id"},
+			"allow_credentials": true,
+			"max_age":           json.Number("900"),
+		},
+		SettingResponseHeaderRules: map[string]any{
+			"set":    map[string]any{"x-browser-client": "enabled"},
+			"remove": []any{"x-upstream-marker"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantCORS := CORSConfig{
+		Enabled:          true,
+		AllowedOrigins:   []string{"app://obsidian.md", "https://notes.example"},
+		AllowedMethods:   []string{"POST", "GET"},
+		AllowedHeaders:   []string{"Authorization", "Content-Type"},
+		ExposedHeaders:   []string{"X-Request-Id"},
+		AllowCredentials: true,
+		MaxAgeSeconds:    900,
+	}
+	if !reflect.DeepEqual(resolved.CORS, wantCORS) {
+		t.Fatalf("CORS = %#v, want %#v", resolved.CORS, wantCORS)
+	}
+	wantRules := HeaderRules{
+		Set:    map[string]string{"X-Browser-Client": "enabled"},
+		Remove: []string{"X-Upstream-Marker"},
+	}
+	if !reflect.DeepEqual(resolved.ResponseHeaderRules, wantRules) {
+		t.Fatalf("ResponseHeaderRules = %#v, want %#v", resolved.ResponseHeaderRules, wantRules)
+	}
+
+	for _, key := range []string{SettingCORS, SettingResponseHeaderRules} {
+		if _, err := ResolveGroupRuntimeSettings(
+			resolved,
+			config.Settings{key: map[string]any{}},
+		); err == nil {
+			t.Fatalf("ResolveGroupRuntimeSettings accepted system-only %q", key)
+		}
+	}
+}
+
+func TestCORSValidationRejectsUnsafeOrAmbiguousConfiguration(t *testing.T) {
+	validBase := map[string]any{
+		"enabled":         true,
+		"allowed_origins": []any{"https://notes.example"},
+	}
+	tests := []struct {
+		name  string
+		value map[string]any
+	}{
+		{name: "enabled without origins", value: map[string]any{"enabled": true, "allowed_origins": []any{}}},
+		{name: "credentialed wildcard", value: map[string]any{"enabled": true, "allowed_origins": []any{"*"}, "allow_credentials": true}},
+		{name: "wildcard mixed with origin", value: map[string]any{"enabled": true, "allowed_origins": []any{"*", "https://notes.example"}}},
+		{name: "origin with comma", value: map[string]any{"enabled": true, "allowed_origins": []any{"https://one.example, https://two.example"}}},
+		{name: "origin with path", value: map[string]any{"enabled": true, "allowed_origins": []any{"https://notes.example/path"}}},
+		{name: "origin without scheme", value: map[string]any{"enabled": true, "allowed_origins": []any{"notes.example"}}},
+		{name: "duplicate origin", value: map[string]any{"enabled": true, "allowed_origins": []any{"https://notes.example", "https://notes.example"}}},
+		{name: "empty methods", value: map[string]any{"enabled": true, "allowed_origins": []any{"https://notes.example"}, "allowed_methods": []any{}}},
+		{name: "wildcard method", value: map[string]any{"enabled": true, "allowed_origins": []any{"https://notes.example"}, "allowed_methods": []any{"*"}}},
+		{name: "invalid method", value: map[string]any{"enabled": true, "allowed_origins": []any{"https://notes.example"}, "allowed_methods": []any{"POST\nTRACE"}}},
+		{name: "invalid allowed header", value: map[string]any{"enabled": true, "allowed_origins": []any{"https://notes.example"}, "allowed_headers": []any{"Bad Header"}}},
+		{name: "negative max age", value: map[string]any{"enabled": true, "allowed_origins": []any{"https://notes.example"}, "max_age": json.Number("-1")}},
+		{name: "credentialed wildcard exposed headers", value: map[string]any{"enabled": true, "allowed_origins": []any{"https://notes.example"}, "allow_credentials": true, "exposed_headers": []any{"*"}}},
+		{name: "unknown field", value: map[string]any{"enabled": false, "surprise": true}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := ValidateRuntimeSetting(SettingCORS, test.value); err == nil {
+				t.Fatalf("ValidateRuntimeSetting accepted %#v", test.value)
+			}
+		})
+	}
+	if err := ValidateRuntimeSetting(SettingCORS, validBase); err != nil {
+		t.Fatalf("ValidateRuntimeSetting rejected valid CORS config: %v", err)
+	}
+}
+
+func TestResponseHeaderRulesRejectTransportAndCORSOwnedHeaders(t *testing.T) {
+	for _, name := range []string{
+		"Connection",
+		"Content-Length",
+		"Content-Type",
+		"Set-Cookie",
+		"Transfer-Encoding",
+		"Vary",
+		"Access-Control-Allow-Origin",
+		"X-GPTLoad-Attempts",
+	} {
+		for _, section := range []string{"set", "remove"} {
+			value := map[string]any{}
+			if section == "set" {
+				value[section] = map[string]any{name: "value"}
+			} else {
+				value[section] = []any{name}
+			}
+			if err := ValidateRuntimeSetting(SettingResponseHeaderRules, value); err == nil {
+				t.Errorf("response_header_rules accepted %s %q", section, name)
+			}
+		}
 	}
 }
 
@@ -461,6 +600,8 @@ func TestIsRuntimeSettingKeyRecognizesOnlyPublicRuntimeKeys(t *testing.T) {
 		SettingRequestTimeout,
 		SettingStreamIdleTimeout,
 		SettingHeaderRules,
+		SettingCORS,
+		SettingResponseHeaderRules,
 		SettingInjectUsageOptions,
 		SettingRetryCount,
 		SettingBlacklistThreshold,

--- a/internal/state/runtime_settings_test.go
+++ b/internal/state/runtime_settings_test.go
@@ -150,6 +150,36 @@ func TestCORSValidationRejectsUnsafeOrAmbiguousConfiguration(t *testing.T) {
 	}
 }
 
+func TestCORSOriginsAreCanonicalizedBeforeDuplicateDetection(t *testing.T) {
+	origins, err := parseCORSOrigins([]any{
+		"HTTPS://EXAMPLE.COM",
+		"http://EXAMPLE.COM:80",
+		"https://EXAMPLE.COM:444",
+		"https://bücher.example",
+		"APP://OBSIDIAN.MD",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"https://example.com",
+		"http://example.com",
+		"https://example.com:444",
+		"https://xn--bcher-kva.example",
+		"app://obsidian.md",
+	}
+	if !reflect.DeepEqual(origins, want) {
+		t.Fatalf("origins = %#v, want %#v", origins, want)
+	}
+
+	if _, err := parseCORSOrigins([]any{
+		"HTTPS://EXAMPLE.COM",
+		"https://example.com:443",
+	}); err == nil || !strings.Contains(err.Error(), "duplicate origin") {
+		t.Fatalf("normalized duplicate error = %v, want duplicate origin", err)
+	}
+}
+
 func TestResponseHeaderRulesRejectTransportAndCORSOwnedHeaders(t *testing.T) {
 	for _, name := range []string{
 		"Connection",

--- a/web/src/app/resources/settings.ts
+++ b/web/src/app/resources/settings.ts
@@ -24,6 +24,8 @@ export const runtimeSettingKeys = [
   'retry_count',
   'blacklist_threshold',
   'header_rules',
+  'cors',
+  'response_header_rules',
   'inject_usage_options',
   'affinity_enabled',
   'affinity_ttl',
@@ -39,6 +41,8 @@ export type TimeoutSettingKey = Exclude<
   | 'retry_count'
   | 'blacklist_threshold'
   | 'header_rules'
+  | 'cors'
+  | 'response_header_rules'
   | 'inject_usage_options'
   | 'affinity_enabled'
   | 'affinity_capacity'
@@ -47,6 +51,16 @@ export type TimeoutSettingKey = Exclude<
 >
 export type PolicyCountSettingKey = 'retry_count' | 'blacklist_threshold'
 
+export interface CORSConfigDto {
+  enabled: boolean
+  allowed_origins: string[]
+  allowed_methods: string[]
+  allowed_headers: string[]
+  exposed_headers: string[]
+  allow_credentials: boolean
+  max_age: number
+}
+
 export interface SettingsValues {
   first_byte_timeout: number
   request_timeout: number
@@ -54,6 +68,8 @@ export interface SettingsValues {
   retry_count: number
   blacklist_threshold: number
   header_rules: HeaderRulesDto
+  cors: CORSConfigDto
+  response_header_rules: HeaderRulesDto
   inject_usage_options: boolean
   affinity_enabled: boolean
   affinity_ttl: number
@@ -77,6 +93,8 @@ export type SettingsPatch = Partial<{
   retry_count: number | null
   blacklist_threshold: number | null
   header_rules: HeaderRulesDto | null
+  cors: CORSConfigDto | null
+  response_header_rules: HeaderRulesDto | null
   inject_usage_options: boolean | null
   affinity_enabled: boolean | null
   affinity_ttl: number | null
@@ -117,6 +135,34 @@ function projectHeaderRules(value: unknown): HeaderRulesDto {
   }
 }
 
+function projectCORSConfig(value: unknown): CORSConfigDto {
+  const record = projectRecord(value)
+  assertNoSecretLikeFields(record, [
+    'enabled',
+    'allowed_origins',
+    'allowed_methods',
+    'allowed_headers',
+    'exposed_headers',
+    'allow_credentials',
+    'max_age',
+  ])
+  const projectList = (input: unknown): string[] =>
+    projectArray(input, (item) => {
+      const projected = projectString(item)
+      if (projected !== projected.trim()) invalidResponse()
+      return projected
+    })
+  return {
+    enabled: projectBoolean(record.enabled),
+    allowed_origins: projectList(record.allowed_origins),
+    allowed_methods: projectList(record.allowed_methods),
+    allowed_headers: projectList(record.allowed_headers),
+    exposed_headers: projectList(record.exposed_headers),
+    allow_credentials: projectBoolean(record.allow_credentials),
+    max_age: projectSafeInteger(record.max_age, { minimum: 0 }),
+  }
+}
+
 export function projectSettings(value: unknown): SettingsDto {
   const record = projectRecord(value)
   assertNoSecretLikeFields(record, settingsFields)
@@ -146,6 +192,8 @@ export function projectSettings(value: unknown): SettingsDto {
       retry_count: projectSafeInteger(values.retry_count, { minimum: 0 }),
       blacklist_threshold: projectSafeInteger(values.blacklist_threshold, { minimum: 0 }),
       header_rules: projectHeaderRules(values.header_rules),
+      cors: projectCORSConfig(values.cors),
+      response_header_rules: projectHeaderRules(values.response_header_rules),
       inject_usage_options: projectBoolean(values.inject_usage_options),
       affinity_enabled: projectBoolean(values.affinity_enabled),
       affinity_ttl: projectSafeInteger(values.affinity_ttl, { minimum: 1 }),

--- a/web/src/components/config/HeaderRulesEditor.vue
+++ b/web/src/components/config/HeaderRulesEditor.vue
@@ -10,6 +10,7 @@ import {
   validateHeaderRuleRows,
   type HeaderRuleAction,
   type HeaderRuleValidationError,
+  type HeaderRuleValidationPolicy,
 } from './header-rules-validation'
 
 interface RuleRow {
@@ -30,6 +31,7 @@ const props = withDefaults(
     resetKey?: number
     showNotice?: boolean
     showAdd?: boolean
+    validationPolicy?: HeaderRuleValidationPolicy
   }>(),
   {
     disabled: false,
@@ -39,6 +41,7 @@ const props = withDefaults(
     resetKey: 0,
     showNotice: true,
     showAdd: true,
+    validationPolicy: 'request',
   },
 )
 const emit = defineEmits<{
@@ -114,6 +117,7 @@ function rowsMatchRules(rows: readonly RuleRow[], rules: HeaderRulesDto): boolea
 const validationErrors = computed(() =>
   validateHeaderRuleRows(
     rows.value.map(({ key, action, name, value }) => ({ rowKey: key, action, name, value })),
+    props.validationPolicy,
   ),
 )
 const validationErrorsByRow = computed(() => {

--- a/web/src/components/config/header-rules-validation.ts
+++ b/web/src/components/config/header-rules-validation.ts
@@ -1,4 +1,5 @@
 export type HeaderRuleAction = 'set' | 'remove'
+export type HeaderRuleValidationPolicy = 'request' | 'response'
 
 export interface HeaderRuleInput {
   rowKey: number
@@ -31,8 +32,28 @@ const forbiddenSetNames = new Set([
   'cookie2',
 ])
 
+const forbiddenResponseNames = new Set([
+  ...forbiddenSetNames,
+  'content-encoding',
+  'content-length',
+  'content-range',
+  'content-type',
+  'date',
+  'server',
+  'set-cookie',
+  'set-cookie2',
+  'vary',
+  'access-control-allow-origin',
+  'access-control-allow-methods',
+  'access-control-allow-headers',
+  'access-control-allow-credentials',
+  'access-control-expose-headers',
+  'access-control-max-age',
+])
+
 export function validateHeaderRuleRows(
   rows: readonly HeaderRuleInput[],
+  policy: HeaderRuleValidationPolicy = 'request',
 ): HeaderRuleValidationError[] {
   const errors: HeaderRuleValidationError[] = []
   const duplicateRows = duplicateHeaderRuleRows(rows)
@@ -51,7 +72,7 @@ export function validateHeaderRuleRows(
       continue
     }
     const normalizedName = asciiLower(row.name)
-    if (credentialNames.has(normalizedName) || isForbiddenSetName(normalizedName)) {
+    if (credentialNames.has(normalizedName) || isForbiddenName(normalizedName, policy)) {
       errors.push({ code: 'forbidden_set_name', rowKey: row.rowKey })
       continue
     }
@@ -103,8 +124,10 @@ function isHTTPHeaderValue(value: string): boolean {
   return true
 }
 
-function isForbiddenSetName(normalizedName: string): boolean {
-  return normalizedName.startsWith('proxy-') || forbiddenSetNames.has(normalizedName)
+function isForbiddenName(normalizedName: string, policy: HeaderRuleValidationPolicy): boolean {
+  if (normalizedName.startsWith('proxy-')) return true
+  if (policy === 'request') return forbiddenSetNames.has(normalizedName)
+  return normalizedName.startsWith('x-gptload-') || forbiddenResponseNames.has(normalizedName)
 }
 
 function asciiLower(value: string): string {

--- a/web/src/features/settings/BrowserAccessSection.vue
+++ b/web/src/features/settings/BrowserAccessSection.vue
@@ -1,0 +1,610 @@
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import type { HeaderRulesDto } from '@/app/resources/groups'
+import type { RuntimeSettingKey, SettingsResource } from '@/app/resources/settings'
+import HeaderRulesEditor from '@/components/config/HeaderRulesEditor.vue'
+import AppButton from '@/components/ui/AppButton.vue'
+import AppSwitch from '@/components/ui/AppSwitch.vue'
+import AppTextInput from '@/components/ui/AppTextInput.vue'
+import CompactFieldError from '@/components/ui/CompactFieldError.vue'
+import StatusBadge from '@/components/ui/StatusBadge.vue'
+
+import {
+  createSettingsDraft,
+  isValidCORSConfig,
+  setSettingsOverride,
+  type SettingsDraft,
+} from './settings-patch'
+import type { SettingsDraftChange } from './use-settings-controller'
+
+type CORSListKey = 'allowed_origins' | 'allowed_methods' | 'allowed_headers' | 'exposed_headers'
+
+const props = defineProps<{
+  base: SettingsResource
+  draft: SettingsDraft
+  disabled: boolean
+  resetKey: number
+}>()
+const emit = defineEmits<{
+  change: [change: SettingsDraftChange]
+  'update:valid': [value: boolean]
+  'update:corsValid': [value: boolean]
+  'update:responseRulesValid': [value: boolean]
+  'update:invalidEdits': [value: boolean]
+}>()
+const { t } = useI18n()
+const responseRulesValid = ref(true)
+const responseRulesInvalidEdits = ref(false)
+const responseEditorResetKey = ref(0)
+
+const corsOverridden = computed(() => props.draft.overrides.has('cors'))
+const responseRulesOverridden = computed(() => props.draft.overrides.has('response_header_rules'))
+const corsPendingRestore = computed(
+  () => !corsOverridden.value && props.base.settings.overrides.includes('cors'),
+)
+const responseRulesPendingRestore = computed(
+  () =>
+    !responseRulesOverridden.value &&
+    props.base.settings.overrides.includes('response_header_rules'),
+)
+const cors = computed(() =>
+  corsOverridden.value ? props.draft.values.cors : props.base.settings.values.cors,
+)
+const responseRules = computed(() =>
+  responseRulesOverridden.value
+    ? props.draft.values.response_header_rules
+    : props.base.settings.values.response_header_rules,
+)
+const responseRuleCount = computed(
+  () => Object.keys(responseRules.value.set).length + responseRules.value.remove.length,
+)
+const corsValid = computed(
+  () => !corsOverridden.value || isValidCORSConfig(props.draft.values.cors),
+)
+const effectiveResponseRulesValid = computed(
+  () => !responseRulesOverridden.value || responseRulesValid.value,
+)
+const valid = computed(() => corsValid.value && effectiveResponseRulesValid.value)
+
+watch(valid, (value) => emit('update:valid', value), { immediate: true })
+watch(corsValid, (value) => emit('update:corsValid', value), { immediate: true })
+watch(effectiveResponseRulesValid, (value) => emit('update:responseRulesValid', value), {
+  immediate: true,
+})
+watch(responseRulesInvalidEdits, (value) => emit('update:invalidEdits', value), { immediate: true })
+watch(
+  () => props.resetKey,
+  () => {
+    responseRulesValid.value = true
+    responseRulesInvalidEdits.value = false
+    responseEditorResetKey.value += 1
+  },
+)
+watch(responseRulesOverridden, (overridden) => {
+  if (!overridden) {
+    responseRulesValid.value = true
+    responseRulesInvalidEdits.value = false
+  }
+})
+
+function cloneDraft(): SettingsDraft {
+  return createSettingsDraft({
+    values: props.draft.values,
+    overrides: [...props.draft.overrides],
+    read_only: [...props.draft.readOnly],
+  })
+}
+
+function publish(key: RuntimeSettingKey, draft: SettingsDraft): void {
+  emit('change', { key, draft })
+}
+
+async function toggleOverride(key: 'cors' | 'response_header_rules'): Promise<void> {
+  publish(
+    key,
+    setSettingsOverride(props.base.settings, props.draft, key, !props.draft.overrides.has(key)),
+  )
+  if (key === 'response_header_rules') {
+    responseRulesValid.value = true
+    responseRulesInvalidEdits.value = false
+    await nextTick()
+    responseEditorResetKey.value += 1
+  }
+}
+
+function setCORSEnabled(value: boolean): void {
+  const draft = cloneDraft()
+  draft.values.cors.enabled = value
+  publish('cors', draft)
+}
+
+function setCORSList(key: CORSListKey, value: string): void {
+  const draft = cloneDraft()
+  draft.values.cors[key] = splitList(value)
+  publish('cors', draft)
+}
+
+function setAllowCredentials(value: boolean): void {
+  const draft = cloneDraft()
+  draft.values.cors.allow_credentials = value
+  publish('cors', draft)
+}
+
+function setMaxAge(value: string): void {
+  const draft = cloneDraft()
+  draft.values.cors.max_age = value.trim() === '' ? Number.NaN : Number(value)
+  publish('cors', draft)
+}
+
+function updateResponseRules(value: HeaderRulesDto): void {
+  const draft = cloneDraft()
+  draft.values.response_header_rules = value
+  publish('response_header_rules', draft)
+}
+
+function splitList(value: string): string[] {
+  if (value.trim() === '') return []
+  return value.split(',').map((entry) => entry.trim())
+}
+
+function joined(values: string[]): string {
+  return values.join(', ')
+}
+
+function unique(values: string[], caseInsensitive = false): boolean {
+  const normalized = values.map((value) => (caseInsensitive ? value.toLowerCase() : value))
+  return new Set(normalized).size === normalized.length
+}
+
+function validHTTPToken(value: string): boolean {
+  return value.length > 0 && /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/u.test(value)
+}
+
+function validOrigin(value: string): boolean {
+  if (value === '*' || value === 'null') return true
+  return (
+    value === value.trim() &&
+    !value.includes('@') &&
+    /^[A-Za-z][A-Za-z0-9+.-]*:\/\/[^/?#\s,]+$/u.test(value)
+  )
+}
+
+function validHeaderList(values: string[], required: boolean): boolean {
+  if (required && values.length === 0) return false
+  return (
+    unique(values, true) &&
+    values.every((value) => value === '*' || validHTTPToken(value)) &&
+    (!values.includes('*') || values.length === 1)
+  )
+}
+
+const originsError = computed(() => {
+  const values = cors.value.allowed_origins
+  if (cors.value.enabled && values.length === 0) return t('settings.browserAccess.errors.origins')
+  if (
+    !unique(values) ||
+    values.some((value) => !validOrigin(value)) ||
+    (values.includes('*') && values.length > 1) ||
+    (values.includes('*') && cors.value.allow_credentials)
+  ) {
+    return t('settings.browserAccess.errors.origins')
+  }
+  return undefined
+})
+const methodsError = computed(() => {
+  const values = cors.value.allowed_methods
+  return (cors.value.enabled && values.length === 0) ||
+    !unique(values, true) ||
+    !values.every((method) => method !== '*' && validHTTPToken(method))
+    ? t('settings.browserAccess.errors.methods')
+    : undefined
+})
+const allowedHeadersError = computed(() =>
+  !validHeaderList(cors.value.allowed_headers, cors.value.enabled)
+    ? t('settings.browserAccess.errors.headers')
+    : undefined,
+)
+const exposedHeadersError = computed(() =>
+  !validHeaderList(cors.value.exposed_headers, false) ||
+  (cors.value.allow_credentials && cors.value.exposed_headers.includes('*'))
+    ? t('settings.browserAccess.errors.headers')
+    : undefined,
+)
+const maxAgeError = computed(() =>
+  Number.isSafeInteger(cors.value.max_age) && cors.value.max_age >= 0
+    ? undefined
+    : t('settings.browserAccess.errors.maxAge'),
+)
+
+function sourceLabel(overridden: boolean, pendingRestore: boolean): string {
+  if (overridden) return t('settings.runtime.overrideSource')
+  if (pendingRestore) return t('settings.runtime.pendingRestoreSource')
+  return t('settings.runtime.defaultSource')
+}
+</script>
+
+<template>
+  <section id="settings-browser-access" class="settings-section" tabindex="-1">
+    <header class="settings-section__heading">
+      <h2>{{ t('settings.browserAccess.title') }}</h2>
+      <p>{{ t('settings.browserAccess.description') }}</p>
+    </header>
+
+    <div class="browser-access__blocks">
+      <article class="browser-access__block">
+        <header class="browser-access__block-heading">
+          <div class="browser-access__identity">
+            <strong>{{ t('settings.browserAccess.cors.title') }}</strong>
+            <small>{{ t('settings.browserAccess.cors.description') }}</small>
+          </div>
+          <div class="browser-access__meta">
+            <StatusBadge
+              size="compact"
+              :tone="corsPendingRestore ? 'warning' : corsOverridden ? 'info' : 'neutral'"
+              :icon="corsPendingRestore ? 'alert' : corsOverridden ? 'edit' : 'check'"
+            >
+              {{ sourceLabel(corsOverridden, corsPendingRestore) }}
+            </StatusBadge>
+            <AppButton
+              variant="secondary"
+              :tone="corsOverridden ? 'warning' : 'action'"
+              size="compact"
+              :disabled="disabled"
+              @click="toggleOverride('cors')"
+            >
+              {{
+                corsOverridden
+                  ? t('settings.runtime.restoreDefault')
+                  : t('settings.runtime.override')
+              }}
+            </AppButton>
+          </div>
+        </header>
+
+        <div v-if="corsOverridden" class="browser-access__cors-form">
+          <div class="browser-access__switch-field browser-access__field--wide">
+            <div>
+              <strong>{{ t('settings.browserAccess.cors.enabled') }}</strong>
+              <small>{{ t('settings.browserAccess.cors.enabledHelp') }}</small>
+            </div>
+            <AppSwitch
+              :model-value="cors.enabled"
+              :disabled="disabled"
+              :label="t('settings.browserAccess.cors.enabled')"
+              @update:model-value="setCORSEnabled"
+            />
+          </div>
+
+          <div class="browser-access__field browser-access__field--wide">
+            <span>{{ t('settings.browserAccess.cors.allowedOrigins') }}</span>
+            <CompactFieldError id="settings-value-cors-origins" :error="originsError">
+              <template #default="{ invalid, describedBy }">
+                <AppTextInput
+                  id="settings-value-cors-origins"
+                  :model-value="joined(cors.allowed_origins)"
+                  :label="t('settings.browserAccess.cors.allowedOrigins')"
+                  :placeholder="t('settings.browserAccess.cors.allowedOriginsPlaceholder')"
+                  appearance="surface"
+                  size="compact"
+                  monospace
+                  :disabled="disabled"
+                  :invalid="invalid"
+                  :described-by="describedBy"
+                  @update:model-value="setCORSList('allowed_origins', $event)"
+                />
+              </template>
+            </CompactFieldError>
+          </div>
+
+          <div class="browser-access__field">
+            <span>{{ t('settings.browserAccess.cors.allowedMethods') }}</span>
+            <CompactFieldError id="settings-value-cors-methods" :error="methodsError">
+              <template #default="{ invalid, describedBy }">
+                <AppTextInput
+                  id="settings-value-cors-methods"
+                  :model-value="joined(cors.allowed_methods)"
+                  :label="t('settings.browserAccess.cors.allowedMethods')"
+                  appearance="surface"
+                  size="compact"
+                  monospace
+                  :disabled="disabled"
+                  :invalid="invalid"
+                  :described-by="describedBy"
+                  @update:model-value="setCORSList('allowed_methods', $event)"
+                />
+              </template>
+            </CompactFieldError>
+          </div>
+
+          <div class="browser-access__field">
+            <span>{{ t('settings.browserAccess.cors.allowedHeaders') }}</span>
+            <CompactFieldError id="settings-value-cors-headers" :error="allowedHeadersError">
+              <template #default="{ invalid, describedBy }">
+                <AppTextInput
+                  id="settings-value-cors-headers"
+                  :model-value="joined(cors.allowed_headers)"
+                  :label="t('settings.browserAccess.cors.allowedHeaders')"
+                  appearance="surface"
+                  size="compact"
+                  monospace
+                  :disabled="disabled"
+                  :invalid="invalid"
+                  :described-by="describedBy"
+                  @update:model-value="setCORSList('allowed_headers', $event)"
+                />
+              </template>
+            </CompactFieldError>
+          </div>
+
+          <div class="browser-access__field">
+            <span>{{ t('settings.browserAccess.cors.exposedHeaders') }}</span>
+            <CompactFieldError id="settings-value-cors-exposed" :error="exposedHeadersError">
+              <template #default="{ invalid, describedBy }">
+                <AppTextInput
+                  id="settings-value-cors-exposed"
+                  :model-value="joined(cors.exposed_headers)"
+                  :label="t('settings.browserAccess.cors.exposedHeaders')"
+                  appearance="surface"
+                  size="compact"
+                  monospace
+                  :disabled="disabled"
+                  :invalid="invalid"
+                  :described-by="describedBy"
+                  @update:model-value="setCORSList('exposed_headers', $event)"
+                />
+              </template>
+            </CompactFieldError>
+          </div>
+
+          <div class="browser-access__field">
+            <span>{{ t('settings.browserAccess.cors.maxAge') }}</span>
+            <CompactFieldError id="settings-value-cors-max-age" :error="maxAgeError">
+              <template #default="{ invalid, describedBy }">
+                <AppTextInput
+                  id="settings-value-cors-max-age"
+                  type="number"
+                  :model-value="String(cors.max_age)"
+                  :label="t('settings.browserAccess.cors.maxAge')"
+                  appearance="surface"
+                  size="compact"
+                  monospace
+                  min="0"
+                  step="1"
+                  inputmode="numeric"
+                  :disabled="disabled"
+                  :invalid="invalid"
+                  :described-by="describedBy"
+                  @update:model-value="setMaxAge"
+                />
+              </template>
+            </CompactFieldError>
+          </div>
+
+          <div class="browser-access__switch-field">
+            <div>
+              <strong>{{ t('settings.browserAccess.cors.allowCredentials') }}</strong>
+              <small>{{ t('settings.browserAccess.cors.allowCredentialsHelp') }}</small>
+            </div>
+            <AppSwitch
+              :model-value="cors.allow_credentials"
+              :disabled="disabled"
+              :label="t('settings.browserAccess.cors.allowCredentials')"
+              @update:model-value="setAllowCredentials"
+            />
+          </div>
+
+          <p class="browser-access__notice" role="note">
+            {{ t('settings.browserAccess.cors.securityNotice') }}
+          </p>
+        </div>
+        <p v-else class="browser-access__summary">
+          {{
+            cors.enabled
+              ? t('settings.browserAccess.cors.enabledSummary', {
+                  count: cors.allowed_origins.length,
+                })
+              : t('settings.browserAccess.cors.disabledSummary')
+          }}
+        </p>
+      </article>
+
+      <article class="browser-access__block">
+        <header class="browser-access__block-heading">
+          <div class="browser-access__identity">
+            <strong>{{ t('settings.browserAccess.responseHeaders.title') }}</strong>
+            <small>{{ t('settings.browserAccess.responseHeaders.description') }}</small>
+          </div>
+          <div class="browser-access__meta">
+            <span>{{ t('settings.headers.ruleCount', { count: responseRuleCount }) }}</span>
+            <StatusBadge
+              size="compact"
+              :tone="
+                responseRulesPendingRestore
+                  ? 'warning'
+                  : responseRulesOverridden
+                    ? 'info'
+                    : 'neutral'
+              "
+              :icon="
+                responseRulesPendingRestore ? 'alert' : responseRulesOverridden ? 'edit' : 'check'
+              "
+            >
+              {{ sourceLabel(responseRulesOverridden, responseRulesPendingRestore) }}
+            </StatusBadge>
+            <AppButton
+              variant="secondary"
+              :tone="responseRulesOverridden ? 'warning' : 'action'"
+              size="compact"
+              :disabled="disabled"
+              @click="toggleOverride('response_header_rules')"
+            >
+              {{
+                responseRulesOverridden
+                  ? t('settings.runtime.restoreDefault')
+                  : t('settings.runtime.override')
+              }}
+            </AppButton>
+          </div>
+        </header>
+
+        <HeaderRulesEditor
+          appearance="ledger"
+          validation-policy="response"
+          :model-value="responseRules"
+          :disabled="disabled || !responseRulesOverridden"
+          :reset-key="responseEditorResetKey"
+          :show-notice="false"
+          :show-add="responseRulesOverridden"
+          :remove-hint="t('settings.browserAccess.responseHeaders.removeHint')"
+          @update:model-value="updateResponseRules"
+          @update:valid="responseRulesValid = $event"
+          @update:invalid-edits="responseRulesInvalidEdits = $event"
+        />
+      </article>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.settings-section,
+.settings-section__heading,
+.browser-access__blocks,
+.browser-access__block,
+.browser-access__identity,
+.browser-access__meta,
+.browser-access__field,
+.browser-access__switch-field {
+  display: grid;
+}
+
+.settings-section {
+  gap: var(--space-4);
+  scroll-margin-top: 76px;
+}
+
+.settings-section__heading h2,
+.settings-section__heading p,
+.browser-access__identity strong,
+.browser-access__identity small,
+.browser-access__summary,
+.browser-access__notice {
+  margin: 0;
+}
+
+.settings-section__heading h2 {
+  font-size: var(--text-body);
+  font-weight: 650;
+}
+
+.settings-section__heading p,
+.browser-access__identity small,
+.browser-access__summary {
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+}
+
+.browser-access__blocks {
+  gap: var(--space-5);
+}
+
+.browser-access__block {
+  gap: var(--space-3);
+}
+
+.browser-access__block + .browser-access__block {
+  border-top: 1px dashed var(--color-border-subtle);
+  padding-top: var(--space-4);
+}
+
+.browser-access__block-heading {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: var(--space-4);
+}
+
+.browser-access__identity {
+  gap: var(--space-1);
+}
+
+.browser-access__identity strong,
+.browser-access__switch-field strong {
+  font-size: var(--text-meta);
+}
+
+.browser-access__meta {
+  justify-items: end;
+  gap: var(--space-1);
+  color: var(--color-text-muted);
+  font-size: var(--text-label-xs);
+  text-align: end;
+}
+
+.browser-access__cors-form {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-3) var(--space-4);
+  border-left: 2px solid var(--color-border-subtle);
+  padding: var(--space-2) 0 var(--space-2) var(--space-4);
+}
+
+.browser-access__field {
+  min-width: 0;
+  gap: var(--space-1);
+}
+
+.browser-access__field > span {
+  color: var(--color-text-muted);
+  font-size: var(--text-label-xs);
+}
+
+.browser-access__field--wide,
+.browser-access__notice {
+  grid-column: 1 / -1;
+}
+
+.browser-access__switch-field {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.browser-access__switch-field div {
+  display: grid;
+  gap: var(--space-1);
+}
+
+.browser-access__switch-field small {
+  color: var(--color-text-muted);
+  font-size: var(--text-label-xs);
+}
+
+.browser-access__notice {
+  border: 1px solid color-mix(in srgb, var(--color-warning) 34%, var(--color-border-subtle));
+  border-radius: var(--radius-control);
+  background: var(--color-warning-bg);
+  color: var(--color-warning);
+  padding: 10px 12px;
+  font-size: var(--text-sm);
+  line-height: 1.5;
+}
+
+@media (max-width: 800px) {
+  .browser-access__block-heading,
+  .browser-access__cors-form {
+    grid-template-columns: 1fr;
+  }
+
+  .browser-access__meta {
+    justify-items: start;
+    text-align: start;
+  }
+
+  .browser-access__field--wide,
+  .browser-access__notice {
+    grid-column: auto;
+  }
+}
+</style>

--- a/web/src/features/settings/SettingsView.vue
+++ b/web/src/features/settings/SettingsView.vue
@@ -32,6 +32,7 @@ import { formatLocalInstant } from '@/lib/format'
 
 import GlobalHeaderRulesSection from './GlobalHeaderRulesSection.vue'
 import AffinitySettingsSection from './AffinitySettingsSection.vue'
+import BrowserAccessSection from './BrowserAccessSection.vue'
 import LogsMaintenanceSection from './LogsMaintenanceSection.vue'
 import RuntimeSettingsSection from './RuntimeSettingsSection.vue'
 import SystemInfoSection from './SystemInfoSection.vue'
@@ -64,6 +65,8 @@ const settingsRefreshing = computed(
 )
 const headerRulesInvalidEdits = ref(false)
 const headerRulesEditorRevision = ref(0)
+const browserAccessInvalidEdits = ref(false)
+const browserAccessEditorRevision = ref(0)
 const discardDialogOpen = ref(false)
 const {
   value: savedFeedback,
@@ -78,7 +81,9 @@ const proxyState = computed(() =>
     ? proxyDraftState(proxyBaseView.value, proxyMode.value, proxyEndpoint.value)
     : { dirty: false, invalid: false, value: undefined },
 )
-const hasLocalEdits = computed(() => headerRulesInvalidEdits.value || proxyState.value.dirty)
+const hasLocalEdits = computed(
+  () => headerRulesInvalidEdits.value || browserAccessInvalidEdits.value || proxyState.value.dirty,
+)
 const {
   base,
   draft,
@@ -113,6 +118,7 @@ const navItems = computed(() => [
   { id: 'settings-forwarding', label: t('settings.navigation.forwarding') },
   { id: 'settings-affinity', label: t('settings.navigation.affinity') },
   { id: 'settings-headers', label: t('settings.navigation.headers') },
+  { id: 'settings-browser-access', label: t('settings.navigation.browserAccess') },
   { id: 'settings-logs', label: t('settings.navigation.logs') },
   { id: 'settings-system', label: t('settings.navigation.system') },
 ])
@@ -123,14 +129,22 @@ const { activeSection, selectSection } = useSectionNavigation({
   topOffset: 76,
 })
 const headerRulesValid = ref(true)
+const browserAccessValid = ref(true)
+const corsValid = ref(true)
+const responseHeaderRulesValid = ref(true)
 const pageOperationLocked = computed(() => operationLocked.value)
 const dirty = computed(
-  () => controllerDirty.value || headerRulesInvalidEdits.value || proxyState.value.dirty,
+  () =>
+    controllerDirty.value ||
+    headerRulesInvalidEdits.value ||
+    browserAccessInvalidEdits.value ||
+    proxyState.value.dirty,
 )
 const valid = computed(
   () =>
     controllerValid.value &&
     (!draft.value?.overrides.has('header_rules') || headerRulesValid.value) &&
+    browserAccessValid.value &&
     !proxyState.value.invalid,
 )
 const timeoutKeys = [
@@ -146,6 +160,8 @@ const changedKeys = computed(() => {
   ) as RuntimeSettingKey[]
   if (headerRulesInvalidEdits.value && !changed.includes('header_rules'))
     changed.push('header_rules')
+  if (browserAccessInvalidEdits.value && !changed.includes('response_header_rules'))
+    changed.push('response_header_rules')
   return changed
 })
 const changedLabels = computed(() => [
@@ -160,6 +176,8 @@ const invalidKeys = computed<RuntimeSettingKey[]>(() => {
     if (timeoutKeys.includes(key as (typeof timeoutKeys)[number]))
       return !isValidTimeout(current.values[key as (typeof timeoutKeys)[number]])
     if (key === 'header_rules') return !headerRulesValid.value
+    if (key === 'cors') return !corsValid.value
+    if (key === 'response_header_rules') return !responseHeaderRulesValid.value
     if (key === 'request_log_retention_days')
       return !isValidRetention(current.values.request_log_retention_days)
     if (key === 'affinity_capacity')
@@ -183,6 +201,13 @@ watch(
   () => draft.value?.overrides.has('header_rules'),
   (hasOverride) => {
     if (!hasOverride) headerRulesInvalidEdits.value = false
+  },
+)
+
+watch(
+  () => draft.value?.overrides.has('response_header_rules'),
+  (hasOverride) => {
+    if (!hasOverride) browserAccessInvalidEdits.value = false
   },
 )
 
@@ -216,6 +241,7 @@ function sectionFromID(id: string): SettingsSection | undefined {
   return section === 'forwarding' ||
     section === 'affinity' ||
     section === 'headers' ||
+    section === 'browser-access' ||
     section === 'logs' ||
     section === 'system'
     ? section
@@ -234,6 +260,8 @@ function discard(): void {
   discardDraft()
   headerRulesInvalidEdits.value = false
   headerRulesEditorRevision.value += 1
+  browserAccessInvalidEdits.value = false
+  browserAccessEditorRevision.value += 1
   if (proxyBaseView.value) resetProxyDraft(proxyBaseView.value)
 }
 
@@ -252,11 +280,14 @@ function settingLabel(key: RuntimeSettingKey): string {
     return t(`settings.affinity.${key}`)
   if (key === 'request_log_retention_days') return t('settings.logs.retention')
   if (key === 'header_rules') return t('settings.headers.title')
+  if (key === 'cors') return t('settings.browserAccess.cors.title')
+  if (key === 'response_header_rules') return t('settings.browserAccess.responseHeaders.title')
   return t(`settings.runtime.${key}`)
 }
 
 function settingTarget(key: RuntimeSettingKey): string {
   if (key === 'header_rules') return 'settings-headers'
+  if (key === 'cors' || key === 'response_header_rules') return 'settings-browser-access'
   return `settings-value-${key}`
 }
 
@@ -265,11 +296,13 @@ async function focusTarget(key: RuntimeSettingKey): Promise<void> {
   const section =
     key === 'header_rules'
       ? 'settings-headers'
-      : key === 'affinity_enabled' || key === 'affinity_ttl' || key === 'affinity_capacity'
-        ? 'settings-affinity'
-        : key === 'request_log_retention_days'
-          ? 'settings-logs'
-          : 'settings-forwarding'
+      : key === 'cors' || key === 'response_header_rules'
+        ? 'settings-browser-access'
+        : key === 'affinity_enabled' || key === 'affinity_ttl' || key === 'affinity_capacity'
+          ? 'settings-affinity'
+          : key === 'request_log_retention_days'
+            ? 'settings-logs'
+            : 'settings-forwarding'
   await navigateSection(section)
   await nextTick()
   const target =
@@ -278,7 +311,12 @@ async function focusTarget(key: RuntimeSettingKey): Promise<void> {
           .getElementById('settings-headers')
           ?.querySelector<HTMLElement>('[aria-invalid="true"]') ??
         document.getElementById('settings-headers'))
-      : document.getElementById(id)
+      : key === 'cors' || key === 'response_header_rules'
+        ? (document
+            .getElementById('settings-browser-access')
+            ?.querySelector<HTMLElement>('[aria-invalid="true"]') ??
+          document.getElementById('settings-browser-access'))
+        : document.getElementById(id)
   target?.focus()
 }
 
@@ -375,6 +413,17 @@ onBeforeUnmount(() => {
               @change="updateDraft"
               @update:valid="headerRulesValid = $event"
               @update:invalid-edits="headerRulesInvalidEdits = $event"
+            />
+            <BrowserAccessSection
+              :base="base"
+              :draft="draft"
+              :disabled="pageOperationLocked"
+              :reset-key="browserAccessEditorRevision"
+              @change="updateDraft"
+              @update:valid="browserAccessValid = $event"
+              @update:cors-valid="corsValid = $event"
+              @update:response-rules-valid="responseHeaderRulesValid = $event"
+              @update:invalid-edits="browserAccessInvalidEdits = $event"
             />
             <LogsMaintenanceSection
               :base="base"

--- a/web/src/features/settings/settings-patch.ts
+++ b/web/src/features/settings/settings-patch.ts
@@ -122,7 +122,7 @@ function normalizedWireValue(
 function normalizeCORSConfig(value: CORSConfigDto): CORSConfigDto {
   return {
     ...cloneCORSConfig(value),
-    allowed_origins: value.allowed_origins.map((entry) => entry.trim()),
+    allowed_origins: value.allowed_origins.map(normalizeCORSOrigin),
     allowed_methods: value.allowed_methods.map((entry) => entry.trim().toUpperCase()),
     allowed_headers: value.allowed_headers.map((entry) => entry.trim()),
     exposed_headers: value.exposed_headers.map((entry) => entry.trim()),
@@ -226,9 +226,10 @@ export function isValidNonNegativeInteger(value: number): boolean {
 }
 
 export function isValidCORSConfig(value: CORSConfigDto): boolean {
+  const allowedOrigins = value.allowed_origins.map(normalizeCORSOrigin)
   if (!isValidNonNegativeInteger(value.max_age)) return false
-  if (!validUniqueList(value.allowed_origins, false, (entry) => validOrigin(entry))) return false
-  if (value.allowed_origins.includes('*') && value.allowed_origins.length > 1) return false
+  if (!validUniqueList(allowedOrigins, false, (entry) => validOrigin(entry))) return false
+  if (allowedOrigins.includes('*') && allowedOrigins.length > 1) return false
   if (!validUniqueList(value.allowed_methods, true, (entry) => entry !== '*' && isHTTPToken(entry)))
     return false
   if (!validHeaderList(value.allowed_headers, value.enabled)) return false
@@ -236,18 +237,39 @@ export function isValidCORSConfig(value: CORSConfigDto): boolean {
   if (value.enabled && (value.allowed_origins.length === 0 || value.allowed_methods.length === 0))
     return false
   if (value.enabled && value.allowed_headers.length === 0) return false
-  if (value.allow_credentials && value.allowed_origins.includes('*')) return false
+  if (value.allow_credentials && allowedOrigins.includes('*')) return false
   if (value.allow_credentials && value.exposed_headers.includes('*')) return false
   return true
 }
 
 function validOrigin(value: string): boolean {
   if (value === '*' || value === 'null') return true
-  return (
-    value === value.trim() &&
-    !value.includes('@') &&
-    /^[A-Za-z][A-Za-z0-9+.-]*:\/\/[^/?#\s,]+$/u.test(value)
+  return parseCORSOriginURL(value) !== null
+}
+
+function normalizeCORSOrigin(value: string): string {
+  const origin = value.trim()
+  if (origin === '*' || origin === 'null') return origin
+  const parsed = parseCORSOriginURL(origin)
+  if (parsed === null) return origin
+  const protocol = asciiLower(parsed.protocol)
+  if (protocol === 'http:' || protocol === 'https:') return parsed.origin
+  return `${protocol}//${asciiLower(parsed.host)}`
+}
+
+function parseCORSOriginURL(value: string): URL | null {
+  if (
+    value !== value.trim() ||
+    value.includes('@') ||
+    !/^[A-Za-z][A-Za-z0-9+.-]*:\/\/[^/?#\s,]+$/u.test(value)
   )
+    return null
+  try {
+    const parsed = new URL(value)
+    return parsed.protocol && parsed.host ? parsed : null
+  } catch {
+    return null
+  }
 }
 
 function validHeaderList(values: string[], required: boolean): boolean {

--- a/web/src/features/settings/settings-patch.ts
+++ b/web/src/features/settings/settings-patch.ts
@@ -2,6 +2,7 @@ import type { HeaderRulesDto } from '@/app/resources/groups'
 import type {
   RuntimeSettingKey,
   PolicyCountSettingKey,
+  CORSConfigDto,
   SettingsDto,
   SettingsPatch,
   SettingsValues,
@@ -10,7 +11,7 @@ import type {
 import { runtimeSettingKeys } from '@/app/resources/settings'
 
 export type SettingsSection =
-  'request-forwarding' | 'affinity' | 'logs-maintenance' | 'model-prices'
+  'request-forwarding' | 'affinity' | 'browser-access' | 'logs-maintenance' | 'model-prices'
 export type SettingsScope = SettingsSection | 'all'
 
 export interface SettingsDraft {
@@ -31,14 +32,30 @@ const requestForwardingKeys: RuntimeSettingKey[] = [
 ]
 const logsMaintenanceKeys: RuntimeSettingKey[] = ['request_log_retention_days']
 const affinityKeys: RuntimeSettingKey[] = ['affinity_enabled', 'affinity_ttl', 'affinity_capacity']
+const browserAccessKeys: RuntimeSettingKey[] = ['cors', 'response_header_rules']
 const modelPriceKeys: RuntimeSettingKey[] = ['models_dev_auto_sync_enabled']
 
 function cloneHeaderRules(value: HeaderRulesDto): HeaderRulesDto {
   return { set: { ...value.set }, remove: [...value.remove] }
 }
 
+function cloneCORSConfig(value: CORSConfigDto): CORSConfigDto {
+  return {
+    ...value,
+    allowed_origins: [...value.allowed_origins],
+    allowed_methods: [...value.allowed_methods],
+    allowed_headers: [...value.allowed_headers],
+    exposed_headers: [...value.exposed_headers],
+  }
+}
+
 function cloneValues(value: SettingsValues): SettingsValues {
-  return { ...value, header_rules: cloneHeaderRules(value.header_rules) }
+  return {
+    ...value,
+    header_rules: cloneHeaderRules(value.header_rules),
+    cors: cloneCORSConfig(value.cors),
+    response_header_rules: cloneHeaderRules(value.response_header_rules),
+  }
 }
 
 export function createSettingsDraft(settings: SettingsDto): SettingsDraft {
@@ -69,12 +86,17 @@ export function setSettingsOverride(
       next.values.affinity_enabled = base.values.affinity_enabled
     } else if (key === 'models_dev_auto_sync_enabled') {
       next.values.models_dev_auto_sync_enabled = base.values.models_dev_auto_sync_enabled
+    } else if (key === 'cors') {
+      next.values.cors = cloneCORSConfig(base.values.cors)
+    } else if (key === 'response_header_rules') {
+      next.values.response_header_rules = cloneHeaderRules(base.values.response_header_rules)
     } else if (key !== 'header_rules') {
       next.values[key] = base.values[key]
     }
   } else {
     next.overrides.delete(key)
     if (key === 'header_rules') next.values.header_rules = { set: {}, remove: [] }
+    if (key === 'response_header_rules') next.values.response_header_rules = { set: {}, remove: [] }
   }
   return next
 }
@@ -90,9 +112,21 @@ function normalizeHeaderRules(value: HeaderRulesDto): HeaderRulesDto {
 function normalizedWireValue(
   settings: SettingsValues,
   key: RuntimeSettingKey,
-): number | boolean | HeaderRulesDto {
-  if (key === 'header_rules') return normalizeHeaderRules(settings.header_rules)
+): number | boolean | HeaderRulesDto | CORSConfigDto {
+  if (key === 'header_rules' || key === 'response_header_rules')
+    return normalizeHeaderRules(settings[key])
+  if (key === 'cors') return normalizeCORSConfig(settings.cors)
   return settings[key]
+}
+
+function normalizeCORSConfig(value: CORSConfigDto): CORSConfigDto {
+  return {
+    ...cloneCORSConfig(value),
+    allowed_origins: value.allowed_origins.map((entry) => entry.trim()),
+    allowed_methods: value.allowed_methods.map((entry) => entry.trim().toUpperCase()),
+    allowed_headers: value.allowed_headers.map((entry) => entry.trim()),
+    exposed_headers: value.exposed_headers.map((entry) => entry.trim()),
+  }
 }
 
 function canonicalHeaderRulesIdentity(value: HeaderRulesDto): HeaderRulesDto {
@@ -110,9 +144,22 @@ function canonicalHeaderRulesIdentity(value: HeaderRulesDto): HeaderRulesDto {
 function normalizedIdentityValue(
   settings: SettingsValues,
   key: RuntimeSettingKey,
-): number | boolean | HeaderRulesDto {
-  if (key === 'header_rules') return canonicalHeaderRulesIdentity(settings.header_rules)
+): number | boolean | HeaderRulesDto | CORSConfigDto {
+  if (key === 'header_rules' || key === 'response_header_rules')
+    return canonicalHeaderRulesIdentity(settings[key])
+  if (key === 'cors') return canonicalCORSIdentity(settings.cors)
   return normalizedWireValue(settings, key)
+}
+
+function canonicalCORSIdentity(value: CORSConfigDto): CORSConfigDto {
+  const normalized = normalizeCORSConfig(value)
+  return {
+    ...normalized,
+    allowed_origins: [...normalized.allowed_origins].sort(),
+    allowed_methods: [...normalized.allowed_methods].sort(),
+    allowed_headers: normalized.allowed_headers.map(asciiLower).sort(),
+    exposed_headers: normalized.exposed_headers.map(asciiLower).sort(),
+  }
 }
 
 function sameValue(left: unknown, right: unknown): boolean {
@@ -122,6 +169,7 @@ function sameValue(left: unknown, right: unknown): boolean {
 export function settingsSectionKeys(section: SettingsSection): RuntimeSettingKey[] {
   if (section === 'request-forwarding') return [...requestForwardingKeys]
   if (section === 'affinity') return [...affinityKeys]
+  if (section === 'browser-access') return [...browserAccessKeys]
   if (section === 'logs-maintenance') return [...logsMaintenanceKeys]
   return [...modelPriceKeys]
 }
@@ -177,6 +225,56 @@ export function isValidNonNegativeInteger(value: number): boolean {
   return Number.isSafeInteger(value) && value >= 0
 }
 
+export function isValidCORSConfig(value: CORSConfigDto): boolean {
+  if (!isValidNonNegativeInteger(value.max_age)) return false
+  if (!validUniqueList(value.allowed_origins, false, (entry) => validOrigin(entry))) return false
+  if (value.allowed_origins.includes('*') && value.allowed_origins.length > 1) return false
+  if (!validUniqueList(value.allowed_methods, true, (entry) => entry !== '*' && isHTTPToken(entry)))
+    return false
+  if (!validHeaderList(value.allowed_headers, true)) return false
+  if (!validHeaderList(value.exposed_headers, false)) return false
+  if (value.enabled && (value.allowed_origins.length === 0 || value.allowed_methods.length === 0))
+    return false
+  if (value.enabled && value.allowed_headers.length === 0) return false
+  if (value.allow_credentials && value.allowed_origins.includes('*')) return false
+  if (value.allow_credentials && value.exposed_headers.includes('*')) return false
+  return true
+}
+
+function validOrigin(value: string): boolean {
+  if (value === '*' || value === 'null') return true
+  return (
+    value === value.trim() &&
+    !value.includes('@') &&
+    /^[A-Za-z][A-Za-z0-9+.-]*:\/\/[^/?#\s,]+$/u.test(value)
+  )
+}
+
+function validHeaderList(values: string[], required: boolean): boolean {
+  if (required && values.length === 0) return false
+  if (!validUniqueList(values, true, (entry) => entry === '*' || isHTTPToken(entry))) return false
+  return !values.includes('*') || values.length === 1
+}
+
+function validUniqueList(
+  values: string[],
+  caseInsensitive: boolean,
+  validate: (value: string) => boolean,
+): boolean {
+  const seen = new Set<string>()
+  for (const value of values) {
+    if (!validate(value)) return false
+    const identity = caseInsensitive ? asciiLower(value) : value
+    if (seen.has(identity)) return false
+    seen.add(identity)
+  }
+  return true
+}
+
+function isHTTPToken(value: string): boolean {
+  return value.length > 0 && /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/u.test(value)
+}
+
 function asciiLower(value: string): string {
   return value.replace(/[A-Z]/g, (character) => String.fromCharCode(character.charCodeAt(0) + 32))
 }
@@ -195,6 +293,9 @@ export function validateSettingsSection(draft: SettingsDraft, section: SettingsS
       !draft.overrides.has('request_log_retention_days') ||
       isValidRetention(draft.values.request_log_retention_days)
     )
+  }
+  if (section === 'browser-access') {
+    return !draft.overrides.has('cors') || isValidCORSConfig(draft.values.cors)
   }
   const timeouts: TimeoutSettingKey[] = [
     'first_byte_timeout',

--- a/web/src/features/settings/settings-patch.ts
+++ b/web/src/features/settings/settings-patch.ts
@@ -231,7 +231,7 @@ export function isValidCORSConfig(value: CORSConfigDto): boolean {
   if (value.allowed_origins.includes('*') && value.allowed_origins.length > 1) return false
   if (!validUniqueList(value.allowed_methods, true, (entry) => entry !== '*' && isHTTPToken(entry)))
     return false
-  if (!validHeaderList(value.allowed_headers, true)) return false
+  if (!validHeaderList(value.allowed_headers, value.enabled)) return false
   if (!validHeaderList(value.exposed_headers, false)) return false
   if (value.enabled && (value.allowed_origins.length === 0 || value.allowed_methods.length === 0))
     return false

--- a/web/src/features/settings/settings-route.ts
+++ b/web/src/features/settings/settings-route.ts
@@ -2,9 +2,17 @@ import type { LocationQuery, LocationQueryRaw } from 'vue-router'
 
 import { isCanonicalRouteQuery, scalarRouteQuery } from '@/app/route-query'
 
-export type SettingsSection = 'forwarding' | 'affinity' | 'headers' | 'logs' | 'system'
+export type SettingsSection =
+  'forwarding' | 'affinity' | 'headers' | 'browser-access' | 'logs' | 'system'
 
-const sections = new Set<SettingsSection>(['forwarding', 'affinity', 'headers', 'logs', 'system'])
+const sections = new Set<SettingsSection>([
+  'forwarding',
+  'affinity',
+  'headers',
+  'browser-access',
+  'logs',
+  'system',
+])
 
 export function parseSettingsSection(query: LocationQuery): SettingsSection {
   const value = scalarRouteQuery(query.section)

--- a/web/src/features/settings/use-settings-controller.ts
+++ b/web/src/features/settings/use-settings-controller.ts
@@ -83,6 +83,7 @@ export function useSettingsController(
       draft.value !== null &&
       validateSettingsSection(draft.value, 'request-forwarding') &&
       validateSettingsSection(draft.value, 'affinity') &&
+      validateSettingsSection(draft.value, 'browser-access') &&
       validateSettingsSection(draft.value, 'logs-maintenance') &&
       validateSettingsSection(draft.value, 'model-prices'),
   )

--- a/web/src/i18n/locales/en-US/settings.ts
+++ b/web/src/i18n/locales/en-US/settings.ts
@@ -29,6 +29,7 @@ export default {
       forwarding: 'Request and forwarding',
       affinity: 'Request affinity',
       headers: 'Global Header Rules',
+      browserAccess: 'Browser access',
       logs: 'Logs and maintenance',
       system: 'System information',
     },
@@ -108,6 +109,42 @@ export default {
         'A Group Header Rules override replaces the complete global object; individual rules are not merged.',
       securityNotice:
         'Fixed Header values are ordinary configuration. Do not store long-lived credentials; credential Headers must use the literal {template} template.',
+    },
+    browserAccess: {
+      title: 'Browser access and downstream headers',
+      description:
+        'Applies only to the /v1 and /v1beta data plane; management APIs remain cross-origin restricted.',
+      cors: {
+        title: 'CORS policy',
+        description: 'Allowed browser preflights return 204 before AccessKey authentication.',
+        enabled: 'Enable CORS',
+        enabledHelp: 'When disabled, existing OPTIONS and authentication behavior is preserved.',
+        allowedOrigins: 'Allowed origins',
+        allowedOriginsPlaceholder: 'app://obsidian.md, https://notes.example',
+        allowedMethods: 'Allowed methods',
+        allowedHeaders: 'Allowed request headers',
+        exposedHeaders: 'Response headers exposed to browsers',
+        maxAge: 'Preflight cache duration (seconds)',
+        allowCredentials: 'Allow browser credentials',
+        allowCredentialsHelp:
+          'Used for cookies or client certificates; incompatible with origin *.',
+        securityNotice:
+          'Prefer an explicit origin allowlist. Origin * lets any web page call the data plane with an API key held by its visitor. Separate list values with commas.',
+        enabledSummary: 'Enabled for {count} origins',
+        disabledSummary: 'CORS is disabled; OPTIONS keeps its existing behavior.',
+      },
+      responseHeaders: {
+        title: 'Downstream response header rules',
+        description:
+          'Set, override, or remove custom headers before every data-plane response is committed.',
+        removeHint: 'Remove this Header from the downstream response.',
+      },
+      errors: {
+        origins: 'Enter unique valid origins. * must be used alone and cannot allow credentials.',
+        methods: 'Enter unique HTTP methods separated by commas.',
+        headers: 'Enter unique Header names separated by commas. * must be used alone.',
+        maxAge: 'Enter zero or a positive safe integer.',
+      },
     },
     logs: {
       title: 'Logs and maintenance',

--- a/web/src/i18n/locales/ja-JP/settings.ts
+++ b/web/src/i18n/locales/ja-JP/settings.ts
@@ -29,6 +29,7 @@ export default {
       forwarding: 'リクエストと転送',
       affinity: 'リクエストアフィニティ',
       headers: 'グローバル Header Rules',
+      browserAccess: 'ブラウザーアクセス',
       logs: 'ログとメンテナンス',
       system: 'システム情報',
     },
@@ -106,6 +107,43 @@ export default {
         'グループのヘッダールール上書きはグローバルオブジェクト全体を置き換え、個別のルールをマージしません。',
       securityNotice:
         '固定 Header 値は通常の設定です。長期認証情報を保存しないでください。認証 Header はリテラルの {template} テンプレートを使用する必要があります。',
+    },
+    browserAccess: {
+      title: 'ブラウザーアクセスとダウンストリームヘッダー',
+      description:
+        '/v1 と /v1beta のデータプレーンだけに適用し、管理 API はクロスオリジンで公開しません。',
+      cors: {
+        title: 'CORS ポリシー',
+        description: '許可されたプリフライトは AccessKey 認証前に 204 を返します。',
+        enabled: 'CORS を有効化',
+        enabledHelp: '無効時は既存の OPTIONS と認証動作を維持します。',
+        allowedOrigins: '許可するオリジン',
+        allowedOriginsPlaceholder: 'app://obsidian.md, https://notes.example',
+        allowedMethods: '許可するメソッド',
+        allowedHeaders: '許可するリクエストヘッダー',
+        exposedHeaders: 'ブラウザーに公開するレスポンスヘッダー',
+        maxAge: 'プリフライトキャッシュ時間（秒）',
+        allowCredentials: 'ブラウザー資格情報を許可',
+        allowCredentialsHelp:
+          'Cookie またはクライアント証明書用です。オリジン * とは併用できません。',
+        securityNotice:
+          '明示的なオリジン許可リストを推奨します。オリジン * は、訪問者が保持する API Key を使って任意の Web ページからデータプレーンを呼び出せるようにします。リストはカンマで区切ります。',
+        enabledSummary: '{count} 個のオリジンに対して有効',
+        disabledSummary: 'CORS は無効です。OPTIONS は既存の動作を維持します。',
+      },
+      responseHeaders: {
+        title: 'ダウンストリームレスポンスヘッダールール',
+        description:
+          'すべてのデータプレーンレスポンスを確定する前にカスタムヘッダーを設定、上書き、または削除します。',
+        removeHint: 'ダウンストリームレスポンスからこの Header を削除します。',
+      },
+      errors: {
+        origins:
+          '一意で有効なオリジンを入力してください。* は単独で使用し、資格情報を許可できません。',
+        methods: '一意の HTTP メソッドをカンマ区切りで入力してください。',
+        headers: '一意の Header 名をカンマ区切りで入力してください。* は単独で使用します。',
+        maxAge: '0 または正の安全な整数を入力してください。',
+      },
     },
     logs: {
       title: 'ログとメンテナンス',

--- a/web/src/i18n/locales/zh-CN/settings.ts
+++ b/web/src/i18n/locales/zh-CN/settings.ts
@@ -29,6 +29,7 @@ export default {
       forwarding: '请求与转发',
       affinity: '请求亲和',
       headers: '全局 Header Rules',
+      browserAccess: '浏览器访问',
       logs: '日志与维护',
       system: '系统信息',
     },
@@ -98,6 +99,39 @@ export default {
       replacementWarning: '分组请求头规则覆盖会替换整个全局对象，不会逐项合并。',
       securityNotice:
         '固定 Header 值属于普通配置；不要保存长期凭证。凭证 Header 必须使用字面量模板 {template}。',
+    },
+    browserAccess: {
+      title: '浏览器访问与下游响应头',
+      description: '仅作用于 /v1 与 /v1beta 数据面；管理 API 不开放跨域访问。',
+      cors: {
+        title: 'CORS 策略',
+        description: '允许匹配的浏览器预检在 AccessKey 鉴权前直接返回 204。',
+        enabled: '启用 CORS',
+        enabledHelp: '关闭时保留现有 OPTIONS 与鉴权行为。',
+        allowedOrigins: '允许的来源',
+        allowedOriginsPlaceholder: 'app://obsidian.md, https://notes.example',
+        allowedMethods: '允许的方法',
+        allowedHeaders: '允许的请求头',
+        exposedHeaders: '向浏览器暴露的响应头',
+        maxAge: '预检缓存时间（秒）',
+        allowCredentials: '允许浏览器凭据',
+        allowCredentialsHelp: '用于 Cookie 或客户端证书；不能与来源 * 同时启用。',
+        securityNotice:
+          '建议填写明确的来源白名单。来源 * 会允许任意网页使用访问者持有的 API Key 调用数据面。列表字段使用英文逗号分隔。',
+        enabledSummary: '已启用，允许 {count} 个来源',
+        disabledSummary: '当前未启用 CORS；OPTIONS 保持原有处理。',
+      },
+      responseHeaders: {
+        title: '下游响应头规则',
+        description: '在所有数据面响应提交前设置、覆盖或移除自定义响应头。',
+        removeHint: '从下游响应中移除此 Header。',
+      },
+      errors: {
+        origins: '请输入唯一且合法的来源；* 必须单独使用，且不能允许凭据。',
+        methods: '请输入以英文逗号分隔的唯一 HTTP 方法。',
+        headers: '请输入以英文逗号分隔的唯一 Header 名称；* 必须单独使用。',
+        maxAge: '请输入 0 或正安全整数。',
+      },
     },
     logs: {
       title: '日志与维护',


### PR DESCRIPTION
### 关联 Issue / Related Issue
Closes #566

### 变更内容 / Change Content
- [ ] Bug 修复 / Bug fix
- [x] 新功能 / New feature
- [ ] 其他改动 / Other changes

- 新增系统级 CORS 策略，可配置允许的来源、方法、请求头、暴露头、凭据与预检缓存时间。
- 新增响应头规则，可为数据面响应设置或移除自定义 Header。
- CORS 与响应头规则仅作用于 /v1 和 /v1beta 数据面；允许的预检请求在 AccessKey 认证前返回 204，/api 管理面不受影响。
- 默认关闭 CORS，保持现有部署行为；配置入口与字段说明已加入系统设置页及中英日文案。
- 验证：make check。

### 自查清单 / Checklist
- [x] 我已运行 make check，或在说明中写明无法运行的原因和未验证范围。 / I ran make check, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.

兼容性说明：无数据库迁移；CORS 默认关闭，未配置响应头规则时行为不变。
