### PR TITLE
chore(deps): Upgrade the SDK version

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -23,7 +23,7 @@ The complete Apache License 2.0 text is distributed in
 ## CLIProxyAPI
 
 - Module: `github.com/router-for-me/CLIProxyAPI/v7`
-- Version: `v7.2.144`
+- Version: `v7.2.151`
 - Copyright: 2025-2005.9 Luis Pater; 2025.9-present Router-For.ME
 - License: MIT License
 

--- a/go.mod
+++ b/go.mod
@@ -97,7 +97,7 @@ require (
 	github.com/redis/go-redis/v9 v9.19.0 // indirect
 	github.com/refraction-networking/utls v1.8.2 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	github.com/router-for-me/CLIProxyAPI/v7 v7.2.144 // indirect
+	github.com/router-for-me/CLIProxyAPI/v7 v7.2.151 // indirect
 	github.com/rs/zerolog v1.34.0 // indirect
 	github.com/savsgio/gotils v0.0.0-20250408102913-196191ec6287 // indirect
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 // indirect

--- a/go.sum
+++ b/go.sum
@@ -205,8 +205,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.15.0 h1:D0RCU5rMAp+SpgkiNdrjfJ+LX4J1M32V2NeCY7EJ6hc=
 github.com/rogpeppe/go-internal v1.15.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
-github.com/router-for-me/CLIProxyAPI/v7 v7.2.144 h1:ZNLmwkaMZ+4KbR8BqLHUUDdDzWsQKpXZQbLYesh4ttk=
-github.com/router-for-me/CLIProxyAPI/v7 v7.2.144/go.mod h1:lTHwMAGajc1wKGQiRtDvYbwV0FWsM7sy+N0ZU5/gxJQ=
+github.com/router-for-me/CLIProxyAPI/v7 v7.2.151 h1:b713YWa1uaEFmM3cgXiUpbdV1nC9NMmyfnkjUXFrCeg=
+github.com/router-for-me/CLIProxyAPI/v7 v7.2.151/go.mod h1:lTHwMAGajc1wKGQiRtDvYbwV0FWsM7sy+N0ZU5/gxJQ=
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=
 github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6wYQ=

--- a/third_party/cpaembedded/README.md
+++ b/third_party/cpaembedded/README.md
@@ -38,7 +38,7 @@ watcher, WebSocket/Auto executors, fallback, and internal retry loops.
 ## Pinned upstream
 
 - Module: `github.com/router-for-me/CLIProxyAPI/v7`
-- Version: `v7.2.144`
+- Version: `v7.2.151`
 
 The root module consumes this bridge through a local `replace`; releases still
 resolve CPA itself at the exact version recorded in both `go.mod` files and

--- a/third_party/cpaembedded/go.mod
+++ b/third_party/cpaembedded/go.mod
@@ -5,7 +5,7 @@ go 1.26.6
 require (
 	github.com/andybalholm/brotli v1.2.3
 	github.com/google/uuid v1.6.0
-	github.com/router-for-me/CLIProxyAPI/v7 v7.2.144
+	github.com/router-for-me/CLIProxyAPI/v7 v7.2.151
 	github.com/tidwall/gjson v1.19.0
 	github.com/tidwall/sjson v1.2.5
 )

--- a/third_party/cpaembedded/go.sum
+++ b/third_party/cpaembedded/go.sum
@@ -71,8 +71,8 @@ github.com/redis/go-redis/v9 v9.19.0 h1:XPVaaPSnG6RhYf7p+rmSa9zZfeVAnWsH5h3lxthO
 github.com/redis/go-redis/v9 v9.19.0/go.mod h1:v/M13XI1PVCDcm01VtPFOADfZtHf8YW3baQf57KlIkA=
 github.com/refraction-networking/utls v1.8.2 h1:j4Q1gJj0xngdeH+Ox/qND11aEfhpgoEvV+S9iJ2IdQo=
 github.com/refraction-networking/utls v1.8.2/go.mod h1:jkSOEkLqn+S/jtpEHPOsVv/4V4EVnelwbMQl4vCWXAM=
-github.com/router-for-me/CLIProxyAPI/v7 v7.2.144 h1:ZNLmwkaMZ+4KbR8BqLHUUDdDzWsQKpXZQbLYesh4ttk=
-github.com/router-for-me/CLIProxyAPI/v7 v7.2.144/go.mod h1:lTHwMAGajc1wKGQiRtDvYbwV0FWsM7sy+N0ZU5/gxJQ=
+github.com/router-for-me/CLIProxyAPI/v7 v7.2.151 h1:b713YWa1uaEFmM3cgXiUpbdV1nC9NMmyfnkjUXFrCeg=
+github.com/router-for-me/CLIProxyAPI/v7 v7.2.151/go.mod h1:lTHwMAGajc1wKGQiRtDvYbwV0FWsM7sy+N0ZU5/gxJQ=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EEf9cgbU6AtGPK4CTG3Zf6CKMNqf0MHTggAUA=


### PR DESCRIPTION
### 关联 Issue / Related Issue
无

### 变更内容 / Change Content
- [ ] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [x] 其他改动 / Other changes

将 sdk CPA 从 v7.2.144 升级至 v7.2.151，使现有模型发现机制能够合并包含 gpt-6-astra 的 CPA 静态目录。同步根模块和 embedded 桥接模块的依赖、校验文件及第三方版本说明。

变更仅涉及依赖和版本说明，没有修改 GPT-Load 功能代码。Bifrost Core v1.8.4 已是最新稳定版，本次无需更新。

兼容性：接受 CPA 新版执行与协议转换行为，包括 Claude 2.1.258 指纹、Fable 5.1 服务端模型回退及子代理请求缓存 TTL 调整。现有模型发现、调度和配置机制保持原样，无数据库迁移。

验证：
- `make check` 通过。
- `third_party/cpaembedded` 下 `go test -count=1 ./...` 通过。
- 推送前重新运行 CPA 执行适配器及订阅 Provider 定向测试，通过。
- 未使用真实 OAuth 账号进行上游实测。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.
