### PR TITLE
fix(web): 补齐 sub2api 图标缺失的 svg 尺寸属性

### DIFF
--- a/web/src/assets/channels/sub2api.svg
+++ b/web/src/assets/channels/sub2api.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+<svg height="1em" style="flex:none;line-height:1" viewBox="0 0 512 512" width="1em" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <linearGradient id="s2a-bg" x1="72" y1="44" x2="442" y2="478" gradientUnits="userSpaceOnUse">
       <stop stop-color="#142B56"/>


### PR DESCRIPTION
## 问题

分组列表、日志详情、创建分组时的渠道选择器里，Sub2API 的图标都不显示，其他渠道正常。

## 根因

`ChannelIcon.vue` 给 v-html 注入的 SVG 定的尺寸样式是 scoped CSS（`.channel-icon svg[data-v-xxx]{width:1em;height:1em}`），但这个属性选择器永远不会命中——`v-html` 注入的内容完全绕过 Vue 编译期的属性标记，所以这条尺寸规则对所有渠道图标都不生效。

其他 21 个渠道图标之所以显示正常，是因为它们的 SVG 源文件（多是从图标库导出的）根标签自带 `width="1em" height="1em"` 属性，靠这个固有尺寸兜底。唯独 `sub2api.svg` 是手工绘制的，只有 `viewBox`，没有尺寸属性，在没有额外布局约束的场景（分组列表、日志详情、渠道选择器的"更多"按钮）里被渲染成 0×0；只在下拉搜索列表里因为该行使用了固定 20px 的 CSS Grid 列才意外显示正常。

## 修复

给 `sub2api.svg` 根 `<svg>` 标签补上 `width="1em" height="1em" style="flex:none;line-height:1"`，与其余 21 个渠道图标文件的写法保持一致。未改动共享组件 `ChannelIcon.vue`，也未改动颜色/路径。

## 验证

- `git diff --check` 无空白问题，diff 仅一行改动。
- 本地静态页面按实际 CSS（`display:inline-flex; width:1em; height:1em`）分别以 96px 与 20px（真实按钮尺寸）渲染验证，图标正常显示，颜色与之前一致，20px 尺寸下不再是 0×0。
- 纯前端 SVG 资源改动，未跑全量 `make check`。