### PR TITLE
fix(gateway): 修复协议查询参数与零输出边界

### DIFF
--- a/internal/dialect/anthropic.go
+++ b/internal/dialect/anthropic.go
@@ -1,6 +1,8 @@
 package dialect
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 
 	"gpt-load/internal/execution"
@@ -17,6 +19,22 @@ func NewAnthropic() *Anthropic {
 
 func (*Anthropic) Protocol() protocol.Protocol {
 	return protocol.Anthropic
+}
+
+// AnthropicRequestsZeroOutput 判断请求是否显式要求零输出，不把缺失、null 或字符串视为数值零。
+func AnthropicRequestsZeroOutput(body []byte) bool {
+	var request struct {
+		MaxTokens json.RawMessage `json:"max_tokens"`
+	}
+	if err := json.Unmarshal(body, &request); err != nil {
+		return false
+	}
+	mantissa := request.MaxTokens
+	if index := bytes.IndexAny(mantissa, "eE"); index >= 0 {
+		mantissa = mantissa[:index]
+	}
+	// 按有效数字判断，避免极小的非零数值经浮点下溢被误判为零。
+	return bytes.IndexByte(mantissa, '0') >= 0 && len(bytes.Trim(mantissa, "-0.")) == 0
 }
 
 func (d *Anthropic) InspectRequest(req *ParsedRequest) (RequestMetadata, error) {

--- a/internal/execution/bifrost/executor.go
+++ b/internal/execution/bifrost/executor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 
 	"gpt-load/internal/channel"
+	"gpt-load/internal/dialect"
 	"gpt-load/internal/execution"
 	"gpt-load/internal/protocol"
 	"gpt-load/internal/reasoning"
@@ -456,6 +457,16 @@ func (r *Runtime) prepare(spec execution.AttemptSpec, stream bool) (preparedAtte
 		return preparedAttempt{}, &failure
 	}
 	safeQuery := safeAttemptQuery(spec)
+	if mode == channel.RouteConverted {
+		// 源协议的调用标记和响应格式不能继承到其他协议的目标 URL。
+		switch spec.ClientProtocol {
+		case protocol.Anthropic:
+			safeQuery = removeRawQueryValue(safeQuery, "beta")
+		case protocol.Gemini:
+			safeQuery = removeRawQueryValue(safeQuery, "alt")
+			safeQuery = removeRawQueryValue(safeQuery, "$alt")
+		}
+	}
 	if mode == channel.RouteNative && spec.ClientProtocol == protocol.Gemini &&
 		(providerKind == channel.ProviderGemini || providerKind == channel.ProviderGoogleVertex ||
 			providerKind == channel.ProviderMultiProtocolGateway) {
@@ -658,6 +669,16 @@ func (r *Runtime) prepare(spec execution.AttemptSpec, stream bool) (preparedAtte
 			directKey: directKey,
 			secrets:   secrets,
 		}, nil
+	}
+	if spec.ClientProtocol == protocol.Anthropic && spec.Operation == execution.OperationChatCompletion &&
+		dialect.AnthropicRequestsZeroOutput(spec.Body) {
+		failure := notSentConversionFailure(
+			execution.ErrorCodeCriticalSemanticLoss,
+			"typed conversion cannot preserve Anthropic zero-output semantics",
+		)
+		failure.Error.OriginHint = execution.ErrorOriginInternal
+		failure.Error.ScopeHint = execution.ErrorScopeGroup
+		return preparedAttempt{}, &failure
 	}
 	if spec.Operation == execution.OperationListModels {
 		typedURL, upstreamProtocol, targetErr := convertedListModelsTarget(providerKind, customTargetBaseURL, safeQuery)

--- a/internal/execution/bifrost/query_test.go
+++ b/internal/execution/bifrost/query_test.go
@@ -1,0 +1,185 @@
+package bifrost
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+)
+
+func TestRuntimeNormalizesConvertedProtocolQueries(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name           string
+		clientProtocol protocol.Protocol
+		channelID      channel.ID
+		rawQuery       string
+		query          url.Values
+		wantQuery      string
+	}{
+		{
+			name: "Anthropic to Gemini", clientProtocol: protocol.Anthropic, channelID: channel.Gemini,
+			rawQuery:  "beta=true&%62eta=false&trace=%2f&&cursor=next&api_key=removed",
+			wantQuery: "trace=%2f&&cursor=next",
+		},
+		{
+			name: "Gemini to Anthropic", clientProtocol: protocol.Gemini, channelID: channel.Anthropic,
+			rawQuery:  "alt=json&$alt=proto&%24alt=sse&trace=%2F&trace=%2f&key=removed",
+			wantQuery: "trace=%2F&trace=%2f",
+		},
+		{
+			name: "Gemini query values to OpenAI", clientProtocol: protocol.Gemini, channelID: channel.OpenAI,
+			query:     url.Values{"alt": {"json"}, "$alt": {"sse"}, "trace": {"kept"}, "key": {"removed"}},
+			wantQuery: "trace=kept",
+		},
+		{
+			name: "native Anthropic preserves beta", clientProtocol: protocol.Anthropic, channelID: channel.Anthropic,
+			rawQuery: "beta=true&trace=%2f&key=removed", wantQuery: "beta=true&trace=%2f",
+		},
+		{
+			name: "native Gemini retains existing format handling", clientProtocol: protocol.Gemini, channelID: channel.Gemini,
+			rawQuery: "alt=json&trace=%2f&key=removed", wantQuery: "trace=%2f",
+		},
+	} {
+		for _, stream := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/stream=%t", test.name, stream), func(t *testing.T) {
+				wantQuery := test.wantQuery
+				if test.channelID == channel.Gemini && stream {
+					wantQuery += "&alt=sse"
+				}
+				wantPath := "/v1/messages"
+				responseBody := anthropicResponsesConvertedFixture
+				if stream {
+					responseBody = anthropicResponsesStreamFixture
+				}
+				switch test.channelID {
+				case channel.Gemini:
+					wantPath = "/v1beta/models/upstream-model:generateContent"
+					responseBody = geminiResponsesConvertedFixture
+					if stream {
+						wantPath = "/v1beta/models/upstream-model:streamGenerateContent"
+						responseBody = geminiResponsesStreamFixture
+					}
+				case channel.OpenAI:
+					wantPath = "/v1/responses"
+					responseBody = openAIResponsesConvertedFixture
+					if stream {
+						responseBody = openAIResponsesStreamFixture
+					}
+				}
+				server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+					if request.URL.Path != wantPath || request.URL.RawQuery != wantQuery {
+						t.Errorf("target = %s?%s, want %s?%s", request.URL.Path, request.URL.RawQuery, wantPath, wantQuery)
+					}
+					if request.Header.Get("Anthropic-Beta") != "test-feature" {
+						t.Error("query normalization changed the request header")
+					}
+					writer.Header().Set("Content-Type", "application/json")
+					if stream {
+						writer.Header().Set("Content-Type", "text/event-stream")
+					}
+					_, _ = io.WriteString(writer, responseBody)
+				}))
+				defer server.Close()
+
+				runtime := newProtocolTestRuntime(t, testRuntimeOptions{
+					allowPrivateNetwork: true, openAIBaseURL: server.URL,
+					anthropicBaseURL: server.URL, geminiBaseURL: server.URL + "/v1beta",
+				})
+				path := "/v1/messages"
+				body := []byte(`{"model":"client-model","max_tokens":16,"messages":[{"role":"user","content":"hello"}]}`)
+				if test.clientProtocol == protocol.Gemini {
+					path = "/v1beta/models/client-model:generateContent"
+					if stream {
+						path = "/v1beta/models/client-model:streamGenerateContent"
+					}
+					body = []byte(`{"contents":[{"role":"user","parts":[{"text":"hello"}]}]}`)
+				}
+				spec := convertedSpec(test.channelID, test.clientProtocol, execution.OperationChatCompletion, path, body)
+				spec.RawQuery = test.rawQuery
+				spec.Query = test.query
+				spec.Header.Set("Anthropic-Beta", "test-feature")
+				original := spec.Clone()
+				if stream {
+					result := runtime.ExecuteStream(context.Background(), spec, func(execution.StreamEvent) error { return nil })
+					if result.Error != nil || result.StatusCode != http.StatusOK {
+						t.Fatalf("stream result = %+v", result)
+					}
+				} else {
+					result := runtime.Execute(context.Background(), spec)
+					if result.Error != nil || result.StatusCode != http.StatusOK {
+						t.Fatalf("result = %+v", result)
+					}
+				}
+				if !reflect.DeepEqual(spec, original) {
+					t.Error("execution mutated the original attempt")
+				}
+			})
+		}
+	}
+}
+
+func TestConvertedCountTokensDropsAnthropicBetaQuery(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/v1beta/models/upstream-model:countTokens" || request.URL.RawQuery != "trace=%2f" {
+			t.Errorf("count tokens target = %s?%s", request.URL.Path, request.URL.RawQuery)
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(writer, `{"totalTokens":7}`)
+	}))
+	defer server.Close()
+	runtime := newProtocolTestRuntime(t, testRuntimeOptions{allowPrivateNetwork: true, geminiBaseURL: server.URL + "/v1beta"})
+	spec := convertedSpec(channel.Gemini, protocol.Anthropic, execution.OperationCountTokens,
+		"/v1/messages/count_tokens", []byte(`{"model":"client-model","messages":[{"role":"user","content":"hello"}]}`))
+	spec.RawQuery = "beta=true&trace=%2f"
+	result := runtime.Execute(context.Background(), spec)
+	if result.Error != nil || result.StatusCode != http.StatusOK {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestConvertedProtocolQueriesDoNotBlockProviderPreparation(t *testing.T) {
+	t.Parallel()
+
+	for _, target := range []struct {
+		channelID channel.ID
+		config    json.RawMessage
+	}{
+		{channel.Groq, json.RawMessage(`{}`)},
+		{channel.AzureOpenAI, json.RawMessage(`{"endpoint":"https://resource.openai.azure.com"}`)},
+		{channel.AWSBedrock, json.RawMessage(`{"region":"us-east-1"}`)},
+	} {
+		for _, clientProtocol := range []protocol.Protocol{protocol.Anthropic, protocol.Gemini} {
+			t.Run(fmt.Sprintf("%s/%s", target.channelID, clientProtocol), func(t *testing.T) {
+				runtime := newProtocolTestRuntime(t, testRuntimeOptions{})
+				path := "/v1/messages"
+				body := []byte(`{"model":"client-model","max_tokens":16,"messages":[{"role":"user","content":"hello"}]}`)
+				query := "beta=true"
+				if clientProtocol == protocol.Gemini {
+					path = "/v1beta/models/client-model:streamGenerateContent"
+					body = []byte(`{"contents":[{"role":"user","parts":[{"text":"hello"}]}]}`)
+					query = "alt=sse&%24alt=json"
+				}
+				spec := convertedSpec(target.channelID, clientProtocol, execution.OperationChatCompletion, path, body)
+				spec.TargetConfig = target.config
+				spec = freezeTestAttempt(spec)
+				spec.RawQuery = query
+				if _, failure := runtime.prepare(spec, true); failure != nil {
+					t.Fatalf("prepare() error = %+v", failure.Error)
+				}
+			})
+		}
+	}
+}

--- a/internal/execution/bifrost/zero_output_test.go
+++ b/internal/execution/bifrost/zero_output_test.go
@@ -1,0 +1,120 @@
+package bifrost
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+)
+
+func TestRuntimeRejectsAnthropicZeroOutputBeforeTypedConversion(t *testing.T) {
+	t.Parallel()
+
+	for _, channelID := range []channel.ID{channel.Gemini, channel.OpenAI, channel.OpenAICompatible, channel.DeepSeek} {
+		for _, stream := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/stream=%t", channelID, stream), func(t *testing.T) {
+				var calls atomic.Int64
+				server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+					calls.Add(1)
+					writer.Header().Set("Content-Type", "application/json")
+					writer.WriteHeader(http.StatusBadRequest)
+					_, _ = io.WriteString(writer, `{"error":{"message":"unexpected generation request"}}`)
+				}))
+				defer server.Close()
+				runtime := newProtocolTestRuntime(t, testRuntimeOptions{
+					allowPrivateNetwork: true, geminiBaseURL: server.URL + "/v1beta", openAIBaseURL: server.URL,
+				})
+				runtime.baseURLs[channel.OpenAICompatible] = server.URL
+				runtime.baseURLs[channel.DeepSeek] = server.URL
+				spec := convertedSpec(channelID, protocol.Anthropic, execution.OperationChatCompletion,
+					"/v1/messages", []byte(`{"model":"client-model","max_tokens":0,"messages":[{"role":"user","content":"hello"}]}`))
+				var evidence *execution.ErrorEvidence
+				if stream {
+					events := 0
+					result := runtime.ExecuteStream(t.Context(), spec, func(execution.StreamEvent) error {
+						events++
+						return nil
+					})
+					if result.DispatchState != execution.DispatchNotSent || result.ResponseStarted || events != 0 {
+						t.Errorf("stream result = %+v, events = %d", result, events)
+					}
+					evidence = result.Error
+				} else {
+					result := runtime.Execute(t.Context(), spec)
+					if result.DispatchState != execution.DispatchNotSent || result.ResponseStarted {
+						t.Errorf("result = %+v", result)
+					}
+					evidence = result.Error
+				}
+				if evidence == nil || evidence.Kind != execution.ErrorKindConversionUnsupported ||
+					evidence.Code != execution.ErrorCodeCriticalSemanticLoss ||
+					evidence.ScopeHint != execution.ErrorScopeGroup || evidence.OriginHint != execution.ErrorOriginInternal {
+					t.Errorf("error = %+v", evidence)
+				}
+				if calls.Load() != 0 {
+					t.Errorf("upstream calls = %d, want 0", calls.Load())
+				}
+			})
+		}
+	}
+}
+
+func TestNativeAnthropicZeroOutputPreservesLimitAndResponse(t *testing.T) {
+	t.Parallel()
+
+	const responseBody = `{"id":"msg_1","type":"message","role":"assistant","model":"upstream-model","content":[],"stop_reason":"max_tokens","stop_sequence":null,"usage":{"input_tokens":4,"output_tokens":0}}`
+	for _, channelID := range []channel.ID{channel.Anthropic, channel.NewAPI} {
+		t.Run(string(channelID), func(t *testing.T) {
+			var calls atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				calls.Add(1)
+				var body map[string]json.RawMessage
+				if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+					t.Error(err)
+				}
+				if string(body["max_tokens"]) != "0" || request.URL.Path != "/v1/messages" {
+					t.Errorf("native path/limit = %s/%s", request.URL.Path, body["max_tokens"])
+				}
+				writer.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(writer, responseBody)
+			}))
+			defer server.Close()
+			runtime := newProtocolTestRuntime(t, testRuntimeOptions{allowPrivateNetwork: true, anthropicBaseURL: server.URL})
+			runtime.baseURLs[channel.NewAPI] = server.URL
+			spec := convertedSpec(channelID, protocol.Anthropic, execution.OperationChatCompletion,
+				"/v1/messages", []byte(`{"model":"client-model","max_tokens":0,"messages":[{"role":"user","content":"hello"}]}`))
+			spec.ClientModel = spec.UpstreamModel
+			result := runtime.Execute(t.Context(), spec)
+			if result.Error != nil || result.StatusCode != http.StatusOK || calls.Load() != 1 || string(result.Body) != responseBody {
+				t.Fatalf("result = %+v, calls = %d, body = %s", result, calls.Load(), result.Body)
+			}
+		})
+	}
+}
+
+func TestCountTokensDoesNotApplyZeroOutputGuard(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/v1beta/models/upstream-model:countTokens" {
+			t.Errorf("path = %s", request.URL.Path)
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(writer, `{"totalTokens":7}`)
+	}))
+	defer server.Close()
+	runtime := newProtocolTestRuntime(t, testRuntimeOptions{allowPrivateNetwork: true, geminiBaseURL: server.URL + "/v1beta"})
+	spec := convertedSpec(channel.Gemini, protocol.Anthropic, execution.OperationCountTokens,
+		"/v1/messages/count_tokens", []byte(`{"model":"client-model","max_tokens":0,"messages":[{"role":"user","content":"hello"}]}`))
+	result := runtime.Execute(t.Context(), spec)
+	if result.Error != nil || result.StatusCode != http.StatusOK {
+		t.Fatalf("count tokens result = %+v", result)
+	}
+}

--- a/internal/gateway/zero_output_test.go
+++ b/internal/gateway/zero_output_test.go
@@ -1,0 +1,86 @@
+package gateway
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/dialect"
+	"gpt-load/internal/platform/config"
+	"gpt-load/internal/protocol"
+	"gpt-load/internal/state"
+	"gpt-load/internal/testutil/fakeupstream"
+)
+
+func TestGatewayZeroOutputProtectionUsesGroupEffectiveParameters(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		original   int
+		override   any
+		wantReject bool
+	}{
+		{name: "zero limit is protected", original: 0, wantReject: true},
+		{name: "group requests zero output", original: 16, override: 0, wantReject: true},
+		{name: "explicit group override permits generation", original: 0, override: 16},
+		{name: "ordinary generation", original: 16},
+	} {
+		for _, stream := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/stream=%t", test.name, stream), func(t *testing.T) {
+				fixture := "gemini/success.json"
+				if stream {
+					fixture = "gemini/stream.sse"
+				}
+				upstream := fakeupstream.New(fakeupstream.Step{Status: http.StatusOK, Fixture: fixture})
+				defer upstream.Close()
+				params, err := json.Marshal(map[string]string{"base_url": upstream.URL + "/v1beta"})
+				if err != nil {
+					t.Fatal(err)
+				}
+				var settings config.Settings
+				if test.override != nil {
+					settings = config.Settings{state.SettingParameterOverrides: []any{
+						map[string]any{"set": map[string]any{"max_tokens": test.override}},
+					}}
+				}
+				engine, registry := newDialectGatewayEngine(t, protocol.Anthropic, "public",
+					dialect.NewSet(dialect.NewAnthropic()), dialectGatewayGroup{
+						id: 1, name: "gemini", channelID: channel.Gemini, params: params,
+						apiKeys: []string{"upstream-key"}, settings: settings,
+					})
+				before := registry.Snapshot()
+				body := fmt.Sprintf(`{"model":"public","max_tokens":%d,"stream":%t,"messages":[{"role":"user","content":"hello"}]}`, test.original, stream)
+				request := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+				request.Header.Set("Authorization", "Bearer gl-client")
+				response := httptest.NewRecorder()
+				engine.ServeHTTP(response, request)
+				if test.wantReject {
+					if response.Code != http.StatusUnprocessableEntity ||
+						!strings.Contains(response.Body.String(), `"code":"protocol_conversion_unsupported"`) ||
+						len(upstream.Requests()) != 0 || strings.Contains(response.Body.String(), "event: message_start") {
+						t.Fatalf("response = %d %s, upstream calls = %d", response.Code, response.Body.String(), len(upstream.Requests()))
+					}
+					if !reflect.DeepEqual(before, registry.Snapshot()) {
+						t.Fatal("local conversion rejection changed credential health")
+					}
+					return
+				}
+				if response.Code != http.StatusOK || len(upstream.Requests()) != 1 {
+					t.Fatalf("generation response = %d %s, upstream calls = %d", response.Code, response.Body.String(), len(upstream.Requests()))
+				}
+				var received struct {
+					GenerationConfig struct {
+						MaxOutputTokens int `json:"maxOutputTokens"`
+					} `json:"generationConfig"`
+				}
+				if err := json.Unmarshal(upstream.Requests()[0].Body, &received); err != nil || received.GenerationConfig.MaxOutputTokens != 16 {
+					t.Fatalf("effective output limit = %d, decode error = %v", received.GenerationConfig.MaxOutputTokens, err)
+				}
+			})
+		}
+	}
+}

--- a/internal/provideradapter/registry.go
+++ b/internal/provideradapter/registry.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"gpt-load/internal/channel"
+	"gpt-load/internal/dialect"
 	"gpt-load/internal/execution"
 	"gpt-load/internal/outboundproxy"
 	"gpt-load/internal/protocol"
@@ -157,6 +158,14 @@ func (registry *Registry) resolve(spec execution.AttemptSpec) (execution.Executo
 			execution.ErrorKindInvalidRequest,
 			"undeclared_channel_route",
 			"attempt route is not declared by channel",
+		)
+	}
+	if spec.RouteMode == execution.RouteConverted && spec.ClientProtocol == protocol.Anthropic &&
+		spec.Operation == execution.OperationChatCompletion && dialect.AnthropicRequestsZeroOutput(spec.Body) {
+		return nil, localAdapterEvidence(
+			execution.ErrorKindConversionUnsupported,
+			execution.ErrorCodeCriticalSemanticLoss,
+			"protocol conversion cannot preserve Anthropic zero-output semantics",
 		)
 	}
 	if spec.ResponsesStoreDowngraded && target.ResponsesStoreHandling(

--- a/internal/provideradapter/zero_output_test.go
+++ b/internal/provideradapter/zero_output_test.go
@@ -1,0 +1,130 @@
+package provideradapter
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+)
+
+func TestRegistryRejectsConvertedAnthropicZeroOutputBeforeDispatch(t *testing.T) {
+	t.Parallel()
+
+	for _, target := range []struct {
+		channelID channel.ID
+		config    json.RawMessage
+	}{
+		{channel.Gemini, nil},
+		{channel.OpenAI, nil},
+		{channel.OpenAICompatible, json.RawMessage(`{"base_url":"https://upstream.example/v1"}`)},
+		{channel.Codex, json.RawMessage(`{"base_url":"https://chatgpt.com/backend-api/codex"}`)},
+	} {
+		for _, stream := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/stream=%t", target.channelID, stream), func(t *testing.T) {
+				adapter := &recordingAdapter{}
+				registry, err := NewRegistry(channel.NewRegistry(), completeBindings(adapter, adapter))
+				if err != nil {
+					t.Fatal(err)
+				}
+				spec := execution.AttemptSpec{
+					ChannelID: string(target.channelID), TargetConfig: target.config,
+					ClientProtocol: protocol.Anthropic, Operation: execution.OperationChatCompletion,
+					RouteMode: execution.RouteConverted, UpstreamModel: "upstream-model",
+					Body: []byte(`{"model":"client-model","max_tokens":0,"messages":[{"role":"user","content":"hello"}]}`),
+				}
+				var evidence *execution.ErrorEvidence
+				if stream {
+					events := 0
+					result := registry.ExecuteStream(t.Context(), spec, func(execution.StreamEvent) error {
+						events++
+						return nil
+					})
+					if result.DispatchState != execution.DispatchNotSent || result.ResponseStarted || events != 0 {
+						t.Errorf("stream result = %+v, events = %d", result, events)
+					}
+					evidence = result.Error
+				} else {
+					result := registry.Execute(t.Context(), spec)
+					if result.DispatchState != execution.DispatchNotSent || result.ResponseStarted {
+						t.Errorf("result = %+v", result)
+					}
+					evidence = result.Error
+				}
+				if evidence == nil || evidence.Kind != execution.ErrorKindConversionUnsupported ||
+					evidence.Code != execution.ErrorCodeCriticalSemanticLoss ||
+					evidence.OriginHint != execution.ErrorOriginInternal || evidence.ScopeHint != execution.ErrorScopeGroup {
+					t.Errorf("conversion evidence = %+v", evidence)
+				}
+				if adapter.unaryCalls != 0 || adapter.streamCalls != 0 {
+					t.Errorf("zero-output request reached adapter: %+v", adapter)
+				}
+			})
+		}
+	}
+}
+
+func TestRegistryZeroOutputGuardUsesEffectiveRequestAndOperation(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name       string
+		body       string
+		protocol   protocol.Protocol
+		operation  execution.Operation
+		native     bool
+		wantReject bool
+	}{
+		{name: "zero", body: `{"max_tokens":0}`, wantReject: true},
+		{name: "negative zero", body: `{"max_tokens":-0}`, wantReject: true},
+		{name: "decimal zero", body: `{"max_tokens":0.0}`, wantReject: true},
+		{name: "exponent zero", body: `{"max_tokens":0e12}`, wantReject: true},
+		{name: "small exponent zero", body: `{"max_tokens":0e-10000}`, wantReject: true},
+		{name: "effective positive limit", body: `{"max_tokens":16}`},
+		{name: "missing limit", body: `{}`},
+		{name: "null limit", body: `{"max_tokens":null}`},
+		{name: "string is not numeric zero", body: `{"max_tokens":"0"}`},
+		{name: "nonzero must not underflow to zero", body: `{"max_tokens":1e-10000}`},
+		{name: "nested limit", body: `{"metadata":{"max_tokens":0}}`},
+		{name: "last value zero", body: `{"max_tokens":16,"max_tokens":0}`, wantReject: true},
+		{name: "last value positive", body: `{"max_tokens":0,"max_tokens":16}`},
+		{name: "malformed body keeps existing validation", body: `{"max_tokens":0`},
+		{name: "native Anthropic", body: `{"max_tokens":0}`, native: true},
+		{name: "count tokens", body: `{"max_tokens":0}`, operation: execution.OperationCountTokens},
+		{name: "OpenAI zero retains existing behavior", body: `{"max_tokens":0}`, protocol: protocol.OpenAICompletions},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			adapter := &recordingAdapter{}
+			registry, err := NewRegistry(channel.NewRegistry(), completeBindings(adapter, adapter))
+			if err != nil {
+				t.Fatal(err)
+			}
+			clientProtocol := test.protocol
+			if clientProtocol == "" {
+				clientProtocol = protocol.Anthropic
+			}
+			operation := test.operation
+			if operation == "" {
+				operation = execution.OperationChatCompletion
+			}
+			spec := execution.AttemptSpec{
+				ChannelID: string(channel.Gemini), ClientProtocol: clientProtocol, Operation: operation,
+				RouteMode: execution.RouteConverted, UpstreamModel: "upstream-model", Body: []byte(test.body),
+			}
+			if test.native {
+				spec.ChannelID = string(channel.Anthropic)
+				spec.RouteMode = execution.RouteNative
+			}
+			result := registry.Execute(t.Context(), spec)
+			if test.wantReject {
+				if result.Error == nil || result.Error.Code != execution.ErrorCodeCriticalSemanticLoss || adapter.unaryCalls != 0 {
+					t.Fatalf("result = %+v, adapter calls = %d", result, adapter.unaryCalls)
+				}
+			} else if result.Error != nil || adapter.unaryCalls != 1 {
+				t.Fatalf("unrelated request changed: result = %+v, adapter calls = %d", result, adapter.unaryCalls)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### 关联 Issue / Related Issue
<!-- 请填写此 PR 关联的 issue 编号，例如：Closes #123 / Please link the issue number, e.g., Closes #123 -->
Closes #586

### 变更内容 / Change Content
<!-- 请简要描述本次变更的核心内容 / Please briefly describe the core changes of this PR -->
- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

<!-- 请在下方详细描述你的变更 / Please describe your changes in detail below -->
Anthropic、Gemini 请求转换协议时会携带源协议的查询参数，导致上游拒绝或本地目标构造失败；Anthropic 的显式 `max_tokens: 0` 还可能在 SDK 重建请求时丢失，错误地变成普通生成请求。

- 仅对转换请求清理 Anthropic 的 `beta` 和 Gemini 的 `alt` / `$alt`，由现有目标构造器设置流式参数。覆盖普通、流式和 `count_tokens`，保留原生 query 行为及其他参数的原始编码。
- 按 Group 参数覆盖后的实际 body 识别零输出请求。在统一 adapter 分发及 Bifrost typed 请求构造前拒绝无法保留零输出语义的尝试，原生透传继续保留 `0`。
- 补充上游请求捕获、普通/流式对照、参数类型和重复字段、计数操作、Group 参数覆盖及凭据健康回归。

兼容性：受保护的零输出尝试不再发出生成请求；所有目标均无法保持该语义时，沿用 `422 protocol_conversion_unsupported` 响应。Group 明确将上限覆盖为正数时仍按现有配置生成。无数据库迁移；未修改停止序列、SDK 依赖或 CPA 内部行为。

验证：`make check`、`git --no-pager diff --check` 通过。测试使用本地模拟上游，未进行真实厂商联调。

文档：实施及验证记录按要求保留在本地 `docs/`，本 PR 不包含公开文档更新。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [ ] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.
