### PR TITLE
feat(images): 支持 Antigravity 与 Gemini 共享生图转换

### DIFF
--- a/internal/channel/antigravity_module_test.go
+++ b/internal/channel/antigravity_module_test.go
@@ -62,6 +62,7 @@ func TestAntigravityModuleDeclaresSubscriptionContract(t *testing.T) {
 		{protocol.Anthropic, execution.OperationChatCompletion, RouteConverted},
 		{protocol.Anthropic, execution.OperationCountTokens, RouteConverted},
 		{protocol.OpenAICompletions, execution.OperationChatCompletion, RouteConverted},
+		{protocol.OpenAIImages, execution.OperationImagesGenerate, RouteConverted},
 		{protocol.OpenAIResponses, execution.OperationResponsesCreate, RouteConverted},
 		{protocol.OpenAIResponses, execution.OperationResponsesInputTokens, RouteConverted},
 	} {
@@ -71,5 +72,8 @@ func TestAntigravityModuleDeclaresSubscriptionContract(t *testing.T) {
 	}
 	if _, exists := target.Mode(protocol.OpenAIResponses, execution.OperationResponsesCompact); exists {
 		t.Fatal("Antigravity unexpectedly declares responses compact")
+	}
+	if _, exists := target.Mode(protocol.OpenAIImages, execution.OperationImagesEdit); exists {
+		t.Fatal("Antigravity unexpectedly declares image edits")
 	}
 }

--- a/internal/channel/modules/antigravity.go
+++ b/internal/channel/modules/antigravity.go
@@ -46,6 +46,7 @@ func Antigravity() spec.Module {
 				spec.NewRoute(protocol.Anthropic, execution.OperationChatCompletion, execution.RouteConverted),
 				spec.NewRoute(protocol.Anthropic, execution.OperationCountTokens, execution.RouteConverted),
 				spec.NewRoute(protocol.OpenAICompletions, execution.OperationChatCompletion, execution.RouteConverted),
+				spec.NewRoute(protocol.OpenAIImages, execution.OperationImagesGenerate, execution.RouteConverted),
 				spec.NewResponsesCreateRoute(execution.RouteConverted, spec.ResponsesStoreHandlingStateless),
 				spec.NewRoute(protocol.OpenAIResponses, execution.OperationResponsesInputTokens, execution.RouteConverted),
 			},

--- a/internal/channel/modules/gemini.go
+++ b/internal/channel/modules/gemini.go
@@ -33,6 +33,7 @@ func Gemini() spec.Module {
 				EndpointPolicy:    spec.EndpointSDKDefault,
 			},
 			Routes: []spec.Route{
+				spec.NewRoute(protocol.OpenAIImages, execution.OperationImagesGenerate, execution.RouteConverted),
 				spec.NewRoute(protocol.OpenAICompletions, execution.OperationChatCompletion, execution.RouteConverted),
 				spec.NewRoute(protocol.OpenAICompletions, execution.OperationListModels, execution.RouteConverted),
 				spec.NewRoute(protocol.OpenAICompletions, execution.OperationProbe, execution.RouteConverted),

--- a/internal/channel/route_golden_test.go
+++ b/internal/channel/route_golden_test.go
@@ -41,7 +41,7 @@ func TestBuiltInRouteGolden(t *testing.T) {
 	}
 
 	digest := fmt.Sprintf("%x", sha256.Sum256([]byte(strings.Join(got, "\n"))))
-	const wantDigest = "661dd96120845d8e9a61cab4c32a82c3dacb50be2791e73a90b743987f81eabf"
+	const wantDigest = "4aa392df0a83779d14c94748be596dfa019a5c1c66dab8550f2288d8beeb3604"
 	if digest != wantDigest {
 		t.Fatalf("built-in routes changed: digest = %s, want %s\n%s", digest, wantDigest, strings.Join(got, "\n"))
 	}

--- a/internal/channel/route_golden_test.go
+++ b/internal/channel/route_golden_test.go
@@ -41,7 +41,7 @@ func TestBuiltInRouteGolden(t *testing.T) {
 	}
 
 	digest := fmt.Sprintf("%x", sha256.Sum256([]byte(strings.Join(got, "\n"))))
-	const wantDigest = "4aa392df0a83779d14c94748be596dfa019a5c1c66dab8550f2288d8beeb3604"
+	const wantDigest = "4ae1835a06b87aa3b6cff9958ca9aaf81f287c84883af6b241dd910bacf9bdaf"
 	if digest != wantDigest {
 		t.Fatalf("built-in routes changed: digest = %s, want %s\n%s", digest, wantDigest, strings.Join(got, "\n"))
 	}

--- a/internal/control/route_inspect_test.go
+++ b/internal/control/route_inspect_test.go
@@ -287,7 +287,7 @@ func TestRouteInspectDerivesStandardRequestMetadataFromProtocol(t *testing.T) {
 	}{
 		{protocol: protocol.OpenAICompletions, operation: execution.OperationChatCompletion, routeMode: execution.RouteNative, routeRequirement: execution.RouteRequirementAny},
 		{protocol: protocol.OpenAIResponses, operation: execution.OperationResponsesCreate, routeMode: execution.RouteNative, routeRequirement: execution.RouteRequirementAny},
-		{protocol: protocol.OpenAIImages, operation: execution.OperationImagesGenerate, routeMode: execution.RouteNative, routeRequirement: execution.RouteRequirementNative},
+		{protocol: protocol.OpenAIImages, operation: execution.OperationImagesGenerate, routeMode: execution.RouteNative, routeRequirement: execution.RouteRequirementAny},
 		{protocol: protocol.OpenAIEmbeddings, operation: execution.OperationEmbeddingsCreate, routeMode: execution.RouteNative, routeRequirement: execution.RouteRequirementNative},
 		{protocol: protocol.Anthropic, operation: execution.OperationChatCompletion, routeMode: execution.RouteConverted, routeRequirement: execution.RouteRequirementAny},
 		{protocol: protocol.Gemini, operation: execution.OperationChatCompletion, routeMode: execution.RouteConverted, routeRequirement: execution.RouteRequirementAny},

--- a/internal/dialect/openai_images.go
+++ b/internal/dialect/openai_images.go
@@ -80,6 +80,9 @@ func (d *OpenAIImages) InspectRequest(request *ParsedRequest) (RequestMetadata, 
 	}
 	metadata.Operation = operation
 	metadata.RouteRequirement = execution.RouteRequirementNative
+	if operation == execution.OperationImagesGenerate {
+		metadata.RouteRequirement = execution.RouteRequirementAny
+	}
 	metadata.ObserveUsage = true
 	return metadata, nil
 }

--- a/internal/dialect/openai_images_test.go
+++ b/internal/dialect/openai_images_test.go
@@ -73,9 +73,13 @@ func TestOpenAIImagesInspectJSONRequests(t *testing.T) {
 			if err != nil {
 				t.Fatalf("InspectRequest() error = %v", err)
 			}
+			wantRequirement := execution.RouteRequirementNative
+			if test.operation == execution.OperationImagesGenerate {
+				wantRequirement = execution.RouteRequirementAny
+			}
 			if metadata.Model == nil || *metadata.Model != "gpt-image-2" ||
 				metadata.Operation != test.operation || metadata.Stream != test.stream ||
-				metadata.RouteRequirement != execution.RouteRequirementNative ||
+				metadata.RouteRequirement != wantRequirement ||
 				!metadata.ObserveUsage {
 				t.Fatalf("metadata = %#v", metadata)
 			}
@@ -172,7 +176,7 @@ func TestOpenAIImagesStandardRequestUsesGeneration(t *testing.T) {
 	}
 	if metadata.Model == nil || *metadata.Model != "gpt-image-2" ||
 		metadata.Operation != execution.OperationImagesGenerate ||
-		metadata.RouteRequirement != execution.RouteRequirementNative {
+		metadata.RouteRequirement != execution.RouteRequirementAny {
 		t.Fatalf("metadata = %#v", metadata)
 	}
 }

--- a/internal/execution/bifrost/capabilities.go
+++ b/internal/execution/bifrost/capabilities.go
@@ -23,7 +23,7 @@ func (manager *RuntimeManager) ValidateRouteCapability(
 		return fmt.Errorf("provider is not implemented by Bifrost")
 	}
 	if route.RouteMode == execution.RouteConverted {
-		if convertedRouteImplemented(route.ClientProtocol, route.Operation) {
+		if convertedRouteImplemented(providerKind, route.ClientProtocol, route.Operation) {
 			return nil
 		}
 		return fmt.Errorf("converted route is not implemented")
@@ -34,8 +34,10 @@ func (manager *RuntimeManager) ValidateRouteCapability(
 	return nil
 }
 
-func convertedRouteImplemented(clientProtocol protocol.Protocol, operation execution.Operation) bool {
+func convertedRouteImplemented(providerKind channel.ProviderKind, clientProtocol protocol.Protocol, operation execution.Operation) bool {
 	switch operation {
+	case execution.OperationImagesGenerate:
+		return providerKind == channel.ProviderGemini && clientProtocol == protocol.OpenAIImages
 	case execution.OperationListModels:
 		return clientProtocol != protocol.OpenAIResponses && clientProtocol.Valid()
 	case execution.OperationProbe:

--- a/internal/execution/bifrost/executor.go
+++ b/internal/execution/bifrost/executor.go
@@ -20,6 +20,7 @@ import (
 
 	"gpt-load/internal/channel"
 	"gpt-load/internal/execution"
+	"gpt-load/internal/execution/geminiimage"
 	"gpt-load/internal/protocol"
 	"gpt-load/internal/reasoning"
 )
@@ -90,7 +91,7 @@ func (r *Runtime) Execute(parent context.Context, spec execution.AttemptSpec) (r
 		return r.executeEmbedding(parent, spec, prepared)
 	}
 	if prepared.passthrough != nil {
-		return r.executeNative(parent, spec, prepared)
+		return r.executePassthrough(parent, spec, prepared)
 	}
 	if prepared.countTokensRequest != nil {
 		return r.executeCountTokens(parent, spec, prepared)
@@ -456,7 +457,8 @@ func (r *Runtime) prepare(spec execution.AttemptSpec, stream bool) (preparedAtte
 		return preparedAttempt{}, &failure
 	}
 	safeQuery := safeAttemptQuery(spec)
-	if mode == channel.RouteNative && spec.ClientProtocol == protocol.Gemini &&
+	convertedImages := mode == channel.RouteConverted && spec.ClientProtocol == protocol.OpenAIImages && providerKind == channel.ProviderGemini
+	if convertedImages || mode == channel.RouteNative && spec.ClientProtocol == protocol.Gemini &&
 		(providerKind == channel.ProviderGemini || providerKind == channel.ProviderGoogleVertex ||
 			providerKind == channel.ProviderMultiProtocolGateway) {
 		safeQuery = removeRawQueryValue(safeQuery, "alt")
@@ -585,7 +587,7 @@ func (r *Runtime) prepare(spec execution.AttemptSpec, stream bool) (preparedAtte
 			clientProtocol: spec.ClientProtocol, directKey: directKey, secrets: secrets,
 		}, nil
 	}
-	if mode == channel.RouteNative && providerSupportsPassthrough(providerKind, customTargetBaseURL, spec.ClientProtocol) {
+	if convertedImages || mode == channel.RouteNative && providerSupportsPassthrough(providerKind, customTargetBaseURL, spec.ClientProtocol) {
 		body, sanitizedHeaders, err := sanitizeNativePassthroughRequest(spec, stream)
 		if err != nil {
 			failure := notSentUnaryFailure(execution.ErrorKindInvalidRequest, "invalid native request body")
@@ -596,7 +598,18 @@ func (r *Runtime) prepare(spec execution.AttemptSpec, stream bool) (preparedAtte
 			}
 			return preparedAttempt{}, &failure
 		}
-		passthroughPath, err := nativePassthroughPath(spec, providerKind)
+		passthroughPath := ""
+		if convertedImages {
+			body, err = geminiimage.ConvertRequest(body)
+			if err != nil {
+				failure := notSentUnaryFailure(execution.ErrorKindInvalidRequest, "unsupported Gemini image generation input")
+				failure.Error.OriginHint, failure.Error.ScopeHint = execution.ErrorOriginClient, execution.ErrorScopeRequest
+				return preparedAttempt{}, &failure
+			}
+			passthroughPath = "/models/" + url.PathEscape(spec.UpstreamModel) + ":generateContent"
+		} else {
+			passthroughPath, err = nativePassthroughPath(spec, providerKind)
+		}
 		if err != nil {
 			failure := notSentUnaryFailure(execution.ErrorKindInvalidRequest, "invalid native request path")
 			return preparedAttempt{}, &failure
@@ -641,6 +654,10 @@ func (r *Runtime) prepare(spec execution.AttemptSpec, stream bool) (preparedAtte
 			}
 		}
 		upstreamProtocol := spec.ClientProtocol
+		if convertedImages {
+			upstreamProtocol = protocol.Gemini
+			passthroughHeaders["Accept-Encoding"] = "identity"
+		}
 		return preparedAttempt{
 			provider:         provider,
 			mode:             mode,
@@ -893,7 +910,8 @@ func supportedRequestShape(spec execution.AttemptSpec, stream bool) bool {
 			return validResponsesPassthroughShape(spec, stream)
 		}
 	case protocol.OpenAIImages:
-		if spec.RouteMode != execution.RouteNative || spec.Method != http.MethodPost {
+		convertedGeneration := spec.RouteMode == execution.RouteConverted && spec.Operation == execution.OperationImagesGenerate && !stream
+		if (spec.RouteMode != execution.RouteNative && !convertedGeneration) || spec.Method != http.MethodPost {
 			return false
 		}
 		switch spec.Operation {
@@ -943,7 +961,9 @@ func normalizeImagesAttemptResult(spec execution.AttemptSpec, result *execution.
 	if result == nil || spec.ClientProtocol != protocol.OpenAIImages {
 		return
 	}
-	result.Usage = nil
+	if spec.RouteMode != execution.RouteConverted {
+		result.Usage = nil
+	}
 	if openAIResponseModel(result.Body, "") == "" {
 		result.Model = ""
 	}

--- a/internal/execution/bifrost/executor.go
+++ b/internal/execution/bifrost/executor.go
@@ -613,6 +613,11 @@ func (r *Runtime) prepare(spec execution.AttemptSpec, stream bool) (preparedAtte
 		if convertedImages {
 			body, err = geminiimage.ConvertRequest(body)
 			if err != nil {
+				var classified interface{ ConversionCode() string }
+				if errors.As(err, &classified) {
+					failure := notSentConversionFailure(classified.ConversionCode(), err.Error())
+					return preparedAttempt{}, &failure
+				}
 				failure := notSentUnaryFailure(execution.ErrorKindInvalidRequest, "unsupported Gemini image generation input")
 				failure.Error.OriginHint, failure.Error.ScopeHint = execution.ErrorOriginClient, execution.ErrorScopeRequest
 				return preparedAttempt{}, &failure
@@ -931,7 +936,7 @@ func supportedRequestShape(spec execution.AttemptSpec, stream bool) bool {
 			return validResponsesPassthroughShape(spec, stream)
 		}
 	case protocol.OpenAIImages:
-		convertedGeneration := spec.RouteMode == execution.RouteConverted && spec.Operation == execution.OperationImagesGenerate && !stream
+		convertedGeneration := spec.RouteMode == execution.RouteConverted && spec.Operation == execution.OperationImagesGenerate
 		if (spec.RouteMode != execution.RouteNative && !convertedGeneration) || spec.Method != http.MethodPost {
 			return false
 		}

--- a/internal/execution/bifrost/gemini_images_test.go
+++ b/internal/execution/bifrost/gemini_images_test.go
@@ -33,9 +33,6 @@ func geminiImagesSpec() execution.AttemptSpec {
 }
 
 func TestGeminiImagesRouteAndCapability(t *testing.T) {
-	if !supportedRequestShape(geminiImagesSpec(), false) || supportedRequestShape(geminiImagesSpec(), true) {
-		t.Fatal("converted Gemini Images must only allow non-streaming generations")
-	}
 	target, err := channel.NewRegistry().Resolve(channel.Gemini, json.RawMessage(`{}`))
 	if err != nil {
 		t.Fatal(err)
@@ -120,10 +117,15 @@ func TestGeminiImagesRejectsUnsupportedInputsWithoutDispatch(t *testing.T) {
 	for _, test := range []struct {
 		name, body string
 		stream     bool
+		invalid    bool
 	}{
 		{name: "multiple", body: `{"model":"public-image","prompt":"draw","n":2}`},
 		{name: "size", body: `{"model":"public-image","prompt":"draw","size":"1024x1024"}`},
 		{name: "stream", body: `{"model":"public-image","prompt":"draw","stream":true}`, stream: true},
+		{name: "stream without flag", body: `{"model":"public-image","prompt":"draw"}`, stream: true},
+		{name: "invalid count", body: `{"model":"public-image","prompt":"draw","n":"2"}`, invalid: true},
+		{name: "missing prompt", body: `{"model":"public-image","n":2}`, invalid: true},
+		{name: "invalid stream", body: `{"model":"public-image","prompt":"draw","stream":"true"}`, stream: true, invalid: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			spec := geminiImagesSpec()
@@ -137,6 +139,13 @@ func TestGeminiImagesRejectsUnsupportedInputsWithoutDispatch(t *testing.T) {
 			}
 			if result.DispatchState != execution.DispatchNotSent || result.Error == nil || calls.Load() != 0 {
 				t.Fatalf("unsupported input = %+v, upstream calls = %d", result, calls.Load())
+			}
+			wantKind := execution.ErrorKindConversionUnsupported
+			if test.invalid {
+				wantKind = execution.ErrorKindInvalidRequest
+			}
+			if result.Error.Kind != wantKind || !test.invalid && result.Error.Code != execution.ErrorCodeTargetConversionNotSupported {
+				t.Fatalf("input error = %+v, want %s", result.Error, wantKind)
 			}
 		})
 	}

--- a/internal/execution/bifrost/gemini_images_test.go
+++ b/internal/execution/bifrost/gemini_images_test.go
@@ -1,0 +1,221 @@
+package bifrost
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/dialect"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+	"gpt-load/internal/usage"
+)
+
+const geminiImagesResponse = `{"modelVersion":"gemini-3.1-flash-image","candidates":[{"content":{"parts":[{"text":"private text"},{"inlineData":{"mimeType":"image/png","data":"aW1hZ2U="}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":100,"cachedContentTokenCount":40,"candidatesTokenCount":20,"thoughtsTokenCount":5,"totalTokenCount":125}}`
+
+func geminiImagesSpec() execution.AttemptSpec {
+	spec := geminiSpec(false)
+	spec.ClientProtocol, spec.Operation = protocol.OpenAIImages, execution.OperationImagesGenerate
+	spec.RouteMode, spec.RouteRequirement = execution.RouteConverted, execution.RouteRequirementAny
+	spec.ClientModel, spec.UpstreamModel = "public-image", "gemini-3.1-flash-image"
+	spec.Path = "/v1/images/generations"
+	spec.Header.Set("Content-Type", "application/json")
+	spec.Body = []byte(`{"model":"public-image","prompt":"draw","size":"auto","n":1,"provider":"injected","api_key":"body-secret"}`)
+	return execution.NewAttemptSpec(spec)
+}
+
+func TestGeminiImagesRouteAndCapability(t *testing.T) {
+	if !supportedRequestShape(geminiImagesSpec(), false) || supportedRequestShape(geminiImagesSpec(), true) {
+		t.Fatal("converted Gemini Images must only allow non-streaming generations")
+	}
+	target, err := channel.NewRegistry().Resolve(channel.Gemini, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode, ok := target.Mode(protocol.OpenAIImages, execution.OperationImagesGenerate); !ok || mode != execution.RouteConverted {
+		t.Fatalf("Gemini Images route = %s, %t", mode, ok)
+	}
+	if _, ok := target.Mode(protocol.OpenAIImages, execution.OperationImagesEdit); ok {
+		t.Fatal("Gemini unexpectedly declares image edits")
+	}
+	manager := &RuntimeManager{}
+	route := channel.RouteDescriptor{ClientProtocol: protocol.OpenAIImages, Operation: execution.OperationImagesGenerate, RouteMode: execution.RouteConverted}
+	if err := manager.ValidateRouteCapability(channel.ProviderGemini, route); err != nil {
+		t.Fatal(err)
+	}
+	for _, provider := range []channel.ProviderKind{channel.ProviderOpenAI, channel.ProviderAnthropic, channel.ProviderGoogleVertex, channel.ProviderOpenAICompatible} {
+		if err := manager.ValidateRouteCapability(provider, route); err == nil {
+			t.Errorf("unexpected converted Images capability for %s", provider)
+		}
+	}
+}
+
+func TestGeminiImagesConvertsThroughExistingPassthrough(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		calls.Add(1)
+		if request.Method != http.MethodPost || request.URL.Path != "/v1beta/models/gemini-3.1-flash-image:generateContent" || request.URL.RawQuery != "vendor=one" {
+			t.Errorf("upstream target = %s %s", request.Method, request.URL)
+		}
+		if request.Header.Get("X-Goog-Api-Key") != testAPIKey || request.Header.Get("Authorization") != "" {
+			t.Error("request did not use the selected Gemini API key")
+		}
+		body, err := io.ReadAll(request.Body)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		var got, want any
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Error(err)
+		}
+		if err := json.Unmarshal([]byte(`{"contents":[{"role":"user","parts":[{"text":"draw"}]}],"generationConfig":{"responseModalities":["TEXT","IMAGE"]}}`), &want); err != nil {
+			t.Error(err)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("Gemini request = %s", body)
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		writer.Header().Set("X-Request-Id", "gemini-image-request")
+		writer.Header().Set("ETag", "old-gemini-representation")
+		if _, err := io.WriteString(writer, geminiImagesResponse); err != nil {
+			t.Error(err)
+		}
+	}))
+	defer server.Close()
+	runtime := newProtocolTestRuntime(t, testRuntimeOptions{allowPrivateNetwork: true, geminiBaseURL: server.URL + "/v1beta"})
+	spec := geminiImagesSpec()
+	spec.RawQuery = "vendor=one&api_key=client-secret&alt=sse"
+	result := runtime.Execute(t.Context(), spec)
+	if err := result.Validate(); err != nil || result.Error != nil || result.StatusCode != http.StatusOK {
+		t.Fatalf("Images result = %+v, validation = %v", result, err)
+	}
+	if calls.Load() != 1 || result.UpstreamProtocol != protocol.Gemini || result.Model != spec.UpstreamModel ||
+		result.UpstreamRequestID != "gemini-image-request" || result.Header.Get("ETag") != "" ||
+		!bytes.Contains(result.Body, []byte(`"b64_json":"aW1hZ2U="`)) || !bytes.Contains(result.Body, []byte(`"model":"public-image"`)) ||
+		bytes.Contains(result.Body, []byte("private text")) {
+		t.Fatalf("Images result = %+v, calls = %d", result, calls.Load())
+	}
+	assertUsage(t, result.Usage, usage.Tokens{UncachedInput: 60, CacheRead: 40, Output: 25})
+	if runtime.keyPoolCalls() != 0 {
+		t.Fatal("Bifrost selected a credential instead of using DirectKey")
+	}
+}
+
+func TestGeminiImagesRejectsUnsupportedInputsWithoutDispatch(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) { calls.Add(1); writer.WriteHeader(500) }))
+	defer server.Close()
+	runtime := newProtocolTestRuntime(t, testRuntimeOptions{allowPrivateNetwork: true, geminiBaseURL: server.URL + "/v1beta"})
+	for _, test := range []struct {
+		name, body string
+		stream     bool
+	}{
+		{name: "multiple", body: `{"model":"public-image","prompt":"draw","n":2}`},
+		{name: "size", body: `{"model":"public-image","prompt":"draw","size":"1024x1024"}`},
+		{name: "stream", body: `{"model":"public-image","prompt":"draw","stream":true}`, stream: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			spec := geminiImagesSpec()
+			spec.Body = []byte(test.body)
+			var result execution.AttemptResult
+			if test.stream {
+				stream := runtime.ExecuteStream(t.Context(), spec, func(execution.StreamEvent) error { t.Error("unexpected streaming event"); return nil })
+				result.DispatchState, result.Error = stream.DispatchState, stream.Error
+			} else {
+				result = runtime.Execute(t.Context(), spec)
+			}
+			if result.DispatchState != execution.DispatchNotSent || result.Error == nil || calls.Load() != 0 {
+				t.Fatalf("unsupported input = %+v, upstream calls = %d", result, calls.Load())
+			}
+		})
+	}
+}
+
+func TestGeminiImagesPreservesErrorsAndUsageDiagnostics(t *testing.T) {
+	for _, test := range []struct {
+		name, body string
+		status     int
+		wantError  bool
+	}{
+		{name: "rate limit", body: `{"error":{"code":429,"message":"rate limited","status":"RESOURCE_EXHAUSTED"}}`, status: 429, wantError: true},
+		{name: "no image", body: `{"candidates":[]}`, status: 200, wantError: true},
+		{name: "invalid usage", body: strings.Replace(geminiImagesResponse, `"promptTokenCount":100,"cachedContentTokenCount":40,"candidatesTokenCount":20,"thoughtsTokenCount":5,"totalTokenCount":125`, `"promptTokenCount":"invalid","candidatesTokenCount":"invalid"`, 1), status: 200},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var calls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				calls.Add(1)
+				writer.Header().Set("Content-Type", "application/json")
+				writer.WriteHeader(test.status)
+				if _, err := io.WriteString(writer, test.body); err != nil {
+					t.Error(err)
+				}
+			}))
+			defer server.Close()
+			runtime := newProtocolTestRuntime(t, testRuntimeOptions{allowPrivateNetwork: true, geminiBaseURL: server.URL + "/v1beta"})
+			result := runtime.Execute(t.Context(), geminiImagesSpec())
+			if err := result.Validate(); err != nil || calls.Load() != 1 || (result.Error != nil) != test.wantError {
+				t.Fatalf("result = %+v, validation = %v, calls = %d", result, err, calls.Load())
+			}
+			if test.wantError {
+				wantStatus := test.status
+				if wantStatus == 200 {
+					wantStatus = http.StatusBadGateway
+				}
+				if result.StatusCode != wantStatus || result.DispatchState != execution.DispatchMaybeSent || result.Error.ReplaySafety != execution.ReplaySafetyUnknown {
+					t.Fatalf("failure = %+v", result)
+				}
+			} else {
+				want, err := dialect.NewGemini().ExtractUsage([]byte(test.body))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if result.Usage == nil || !reflect.DeepEqual(result.Usage.Normalized, want) {
+					t.Fatalf("usage = %+v, want %+v", result.Usage, want)
+				}
+			}
+		})
+	}
+}
+
+func TestGeminiImagesKeepsPassthroughResponseBounds(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		limit   int64
+		summary string
+	}{
+		{name: "compressed", summary: "encoded upstream response cannot be safely forwarded"},
+		{name: "oversized", limit: 128, summary: "upstream response exceeds size limit"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				writer.Header().Set("Content-Type", "application/json")
+				writer.Header().Set("Content-Encoding", "gzip")
+				compressed := gzip.NewWriter(writer)
+				if _, err := io.WriteString(compressed, geminiImagesResponse); err != nil {
+					t.Error(err)
+				}
+				if err := compressed.Close(); err != nil {
+					t.Error(err)
+				}
+			}))
+			defer server.Close()
+			runtime := newProtocolTestRuntime(t, testRuntimeOptions{allowPrivateNetwork: true, geminiBaseURL: server.URL + "/v1beta", maxUnaryResponseBodyBytes: test.limit})
+			result := runtime.Execute(t.Context(), geminiImagesSpec())
+			if result.Error == nil || result.Error.Summary != test.summary || result.Error.ReplaySafety != execution.ReplaySafetyUnknown || len(result.Body) != 0 {
+				t.Fatalf("unsafe response = %+v, evidence = %+v", result, result.Error)
+			}
+		})
+	}
+}

--- a/internal/execution/bifrost/images_test.go
+++ b/internal/execution/bifrost/images_test.go
@@ -402,7 +402,6 @@ func TestOpenAIImagesRequestShapeAndCapabilityAreExact(t *testing.T) {
 		func(spec *execution.AttemptSpec) { spec.Method = http.MethodGet },
 		func(spec *execution.AttemptSpec) { spec.Path = "/v1/images/variations" },
 		func(spec *execution.AttemptSpec) { spec.Operation = execution.OperationImagesEdit },
-		func(spec *execution.AttemptSpec) { spec.RouteMode = execution.RouteConverted },
 	} {
 		invalid := valid.Clone()
 		mutate(&invalid)

--- a/internal/execution/bifrost/passthrough.go
+++ b/internal/execution/bifrost/passthrough.go
@@ -12,8 +12,11 @@ import (
 
 	"github.com/maximhq/bifrost/core/schemas"
 
+	"gpt-load/internal/channel"
 	"gpt-load/internal/dialect"
 	"gpt-load/internal/execution"
+	"gpt-load/internal/execution/geminiimage"
+	"gpt-load/internal/platform/httpheader"
 	"gpt-load/internal/protocol"
 )
 
@@ -263,7 +266,7 @@ func encodeNativeJSONObject(object map[string]json.RawMessage) ([]byte, error) {
 	return encoded, nil
 }
 
-func (r *Runtime) executeNative(
+func (r *Runtime) executePassthrough(
 	parent context.Context,
 	spec execution.AttemptSpec,
 	prepared preparedAttempt,
@@ -374,6 +377,21 @@ complete:
 	}
 	model := openAIResponseModel(bodyBytes, spec.UpstreamModel)
 	if status >= http.StatusOK && status < http.StatusMultipleChoices {
+		if prepared.mode == channel.RouteConverted && spec.ClientProtocol == protocol.OpenAIImages {
+			var err error
+			bodyBytes, usageEvidence, err = geminiimage.ConvertResponse(bodyBytes)
+			httpheader.StripRepresentationMetadata(headers)
+			headers.Set("Content-Type", "application/json")
+			if err != nil {
+				failure := startedUnaryFailure(http.StatusBadGateway, headers, execution.ErrorKindProvider, geminiimage.ErrInvalidResponse.Error())
+				failure.Error.Code = "invalid_image_response"
+				failure.Error.StatusCode = http.StatusBadGateway
+				failure.Error.Hint = execution.FailureHintRequestRejected
+				failure.Error.OriginHint, failure.Error.ScopeHint = execution.ErrorOriginUpstream, execution.ErrorScopeRequest
+				return failure
+			}
+			model = openAIResponseModel(bodyBytes, "")
+		}
 		if needsClientModelAlias(spec) && headers.Get("Content-Encoding") == "" {
 			var err error
 			bodyBytes, err = rewriteClientResponseModel(spec.ClientProtocol, bodyBytes, spec.ClientModel)

--- a/internal/execution/cpa/adapter.go
+++ b/internal/execution/cpa/adapter.go
@@ -136,12 +136,7 @@ func (a *Adapter) Execute(ctx context.Context, spec execution.AttemptSpec) (resu
 	}
 	if validator, ok := provider.(providerRequestValidator); ok {
 		if err := validator.ValidateRequest(request); err != nil {
-			return unaryNotSent(
-				execution.ErrorKindInvalidRequest,
-				"subscription request input is not supported",
-				"unsupported_subscription_input",
-				err,
-			)
+			return execution.AttemptResult{DispatchState: execution.DispatchNotSent, Error: requestValidationEvidence(err)}
 		}
 	}
 	if countTokensOperation(spec.Operation) {
@@ -308,7 +303,7 @@ func (a *Adapter) ExecuteStream(
 	}
 	if validator, ok := provider.(providerRequestValidator); ok {
 		if err := validator.ValidateRequest(request); err != nil {
-			return streamNotSent(execution.ErrorKindInvalidRequest, "subscription request input is not supported", "unsupported_subscription_input")
+			return execution.StreamResult{DispatchState: execution.DispatchNotSent, Error: requestValidationEvidence(err)}
 		}
 	}
 	preparedCredential, evidence := a.credentials.Prepare(ctx, channel.ID(spec.ChannelID), spec.Credential, spec.ForceCredentialRefresh)
@@ -801,6 +796,14 @@ func modelAttemptPreparationEvidence(evidence *execution.ErrorEvidence) *executi
 	projected := evidence.Clone()
 	projected.StatusCode = 0
 	return &projected
+}
+
+func requestValidationEvidence(err error) *execution.ErrorEvidence {
+	var classified interface{ ConversionCode() string }
+	if errors.As(err, &classified) {
+		return notSentEvidence(execution.ErrorKindConversionUnsupported, "subscription request conversion is not supported", classified.ConversionCode())
+	}
+	return notSentEvidence(execution.ErrorKindInvalidRequest, "subscription request input is not supported", "unsupported_subscription_input")
 }
 
 func notSentEvidence(kind execution.ErrorKind, summary, code string) *execution.ErrorEvidence {

--- a/internal/execution/cpa/adapter.go
+++ b/internal/execution/cpa/adapter.go
@@ -244,11 +244,16 @@ func unaryProviderSuccess(
 			StatusCode: http.StatusOK, Header: headers, Body: body,
 		}
 	}
+	observedUsage := responseUsage(spec, body)
+	if response.Usage != nil {
+		cloned := response.Usage.Clone()
+		observedUsage = &cloned
+	}
 	return execution.AttemptResult{
 		DispatchState: execution.DispatchMaybeSent, ResponseStarted: true,
 		UpstreamProtocol: effectiveUpstreamProtocol(provider, response.UpstreamProtocol), AppliedReasoning: appliedReasoning(response.AppliedReasoningEffort), StatusCode: http.StatusOK,
 		Header: headers, Body: body, Model: responseModel(body, spec.UpstreamModel),
-		UpstreamRequestID: upstreamRequestID(headers), Usage: responseUsage(spec, body),
+		UpstreamRequestID: upstreamRequestID(headers), Usage: observedUsage,
 	}
 }
 
@@ -572,7 +577,8 @@ func formatFor(clientProtocol protocol.Protocol) string {
 }
 
 func canonicalCPAImagesRequestPath(spec execution.AttemptSpec) (string, error) {
-	if spec.ClientProtocol != protocol.OpenAIImages || spec.RouteMode != execution.RouteNative ||
+	convertedGeneration := spec.RouteMode == execution.RouteConverted && spec.Operation == execution.OperationImagesGenerate
+	if spec.ClientProtocol != protocol.OpenAIImages || (spec.RouteMode != execution.RouteNative && !convertedGeneration) ||
 		spec.Method != http.MethodPost {
 		return "", fmt.Errorf("unsupported Images route tuple")
 	}
@@ -595,7 +601,9 @@ func normalizeCPAImagesAttemptResult(spec execution.AttemptSpec, result *executi
 	if result == nil || spec.ClientProtocol != protocol.OpenAIImages {
 		return
 	}
-	result.Usage = nil
+	if spec.RouteMode != execution.RouteConverted {
+		result.Usage = nil
+	}
 	if responseModel(result.Body, "") == "" {
 		result.Model = ""
 	}

--- a/internal/execution/cpa/antigravity_images.go
+++ b/internal/execution/cpa/antigravity_images.go
@@ -1,0 +1,172 @@
+package cpa
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"gpt-load/internal/dialect"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/usage"
+)
+
+var errAntigravityImagesResponse = errors.New("Antigravity image response could not be converted")
+
+// antigravityImagesPrompt 校验首期单图、非流式合同，避免静默丢弃 Images 参数。
+func antigravityImagesPrompt(request providerRequest) (string, error) {
+	if request.RequestPath != "/v1/images/generations" {
+		return "", errors.New("Antigravity only supports image generations")
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(request.Payload, &object); err != nil || object == nil {
+		return "", errors.New("Antigravity Images request must be a JSON object")
+	}
+	var prompt string
+	if err := json.Unmarshal(object["prompt"], &prompt); err != nil || strings.TrimSpace(prompt) == "" {
+		return "", errors.New("Antigravity Images requires a non-empty prompt")
+	}
+	for name, raw := range object {
+		switch name {
+		case "model", "prompt":
+		case "n":
+			var count int
+			if json.Unmarshal(raw, &count) != nil || count != 1 {
+				return "", errors.New("Antigravity Images only supports n=1")
+			}
+		case "stream":
+			if !bytes.Equal(bytes.TrimSpace(raw), []byte("false")) {
+				return "", errors.New("Antigravity Images does not support streaming")
+			}
+		case "size", "quality", "response_format":
+			want := "auto"
+			if name == "response_format" {
+				want = "b64_json"
+			}
+			var value string
+			if json.Unmarshal(raw, &value) != nil || value != want {
+				return "", fmt.Errorf("Antigravity Images only supports %s=%s", name, want)
+			}
+		default:
+			return "", errors.New("Antigravity Images request contains an unsupported field")
+		}
+	}
+	return prompt, nil
+}
+
+func antigravityImagesRequestPayload(request providerRequest) ([]byte, error) {
+	prompt, err := antigravityImagesPrompt(request)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(map[string]any{
+		"contents": []any{map[string]any{
+			"role": "user", "parts": []any{map[string]string{"text": prompt}},
+		}},
+		"generationConfig": map[string]any{"responseModalities": []string{"TEXT", "IMAGE"}},
+	})
+}
+
+type antigravityImageData struct {
+	MIMEType      string `json:"mimeType"`
+	SnakeMIMEType string `json:"mime_type"`
+	Data          string `json:"data"`
+}
+
+func convertAntigravityImagesResponse(payload []byte) ([]byte, *execution.UsageEvidence, error) {
+	var root struct {
+		ModelVersion  string          `json:"modelVersion"`
+		UsageMetadata json.RawMessage `json:"usageMetadata"`
+		Candidates    []struct {
+			Content struct {
+				Parts []struct {
+					Thought         bool                  `json:"thought"`
+					InlineData      *antigravityImageData `json:"inlineData"`
+					SnakeInlineData *antigravityImageData `json:"inline_data"`
+				} `json:"parts"`
+			} `json:"content"`
+		} `json:"candidates"`
+	}
+	if err := json.Unmarshal(payload, &root); err != nil {
+		return nil, nil, errAntigravityImagesResponse
+	}
+	image := ""
+	for _, candidate := range root.Candidates {
+		for _, part := range candidate.Content.Parts {
+			if part.Thought {
+				continue
+			}
+			data := part.InlineData
+			if data == nil {
+				data = part.SnakeInlineData
+			}
+			if data == nil {
+				continue
+			}
+			mimeType := data.MIMEType
+			if mimeType == "" {
+				mimeType = data.SnakeMIMEType
+			}
+			switch mimeType {
+			case "image/png", "image/jpeg", "image/webp":
+			default:
+				return nil, nil, errAntigravityImagesResponse
+			}
+			if image != "" || data.Data == "" {
+				return nil, nil, errAntigravityImagesResponse
+			}
+			// 流式校验 Base64，避免额外分配整张解码图片。
+			decoded, err := io.Copy(io.Discard, base64.NewDecoder(base64.StdEncoding.Strict(), strings.NewReader(data.Data)))
+			if err != nil || decoded == 0 {
+				return nil, nil, errAntigravityImagesResponse
+			}
+			image = data.Data
+		}
+	}
+	if image == "" {
+		return nil, nil, errAntigravityImagesResponse
+	}
+	normalized, err := dialect.NewGemini().ExtractUsage(payload)
+	if err != nil {
+		// 用量算术失败不丢弃已生成的图片，但不能据此产生正常报价。
+		normalized = usage.Result{State: usage.StateMissing}
+		normalized.Diagnostics.Add(usage.DiagnosticInvalidNumber)
+	}
+	evidence := &execution.UsageEvidence{Normalized: normalized, Raw: bytes.Clone(root.UsageMetadata)}
+	response := map[string]any{
+		"created": time.Now().Unix(), "data": []map[string]string{{"b64_json": image}},
+	}
+	if model := strings.TrimSpace(root.ModelVersion); model != "" {
+		response["model"] = model
+	}
+	// 对外只映射可信计数；内部保留原始 Gemini 的完整状态和缓存计价语义。
+	if normalized.State != usage.StateMissing && normalized.Diagnostics == (usage.Diagnostics{}) {
+		var metadata map[string]json.RawMessage
+		if err := json.Unmarshal(root.UsageMetadata, &metadata); err != nil {
+			return nil, nil, errAntigravityImagesResponse
+		}
+		wireUsage := map[string]any{}
+		if raw, ok := metadata["promptTokenCount"]; ok {
+			wireUsage["input_tokens"] = raw
+		}
+		if _, candidates := metadata["candidatesTokenCount"]; candidates || metadata["thoughtsTokenCount"] != nil {
+			wireUsage["output_tokens"] = normalized.Tokens.Output
+		}
+		if raw, ok := metadata["totalTokenCount"]; ok {
+			wireUsage["total_tokens"] = raw
+		}
+		if _, ok := metadata["cachedContentTokenCount"]; ok {
+			wireUsage["input_tokens_details"] = map[string]int64{"cached_tokens": normalized.Tokens.CacheRead}
+		}
+		response["usage"] = wireUsage
+	}
+	body, err := json.Marshal(response)
+	if err != nil {
+		return nil, nil, errAntigravityImagesResponse
+	}
+	return body, evidence, nil
+}

--- a/internal/execution/cpa/antigravity_images_integration_test.go
+++ b/internal/execution/cpa/antigravity_images_integration_test.go
@@ -1,0 +1,265 @@
+package cpa
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/dialect"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/gateway"
+	"gpt-load/internal/health"
+	"gpt-load/internal/platform/httproute"
+	"gpt-load/internal/pricing"
+	"gpt-load/internal/protocol"
+	"gpt-load/internal/state"
+	"gpt-load/internal/subscription/providers/antigravity"
+	"gpt-load/internal/telemetry"
+	"gpt-load/internal/usage"
+)
+
+type antigravityImagesObservations struct {
+	events []telemetry.RequestEvent
+	table  *pricing.Table
+}
+
+func (o *antigravityImagesObservations) Emit(event telemetry.RequestEvent) {
+	o.events = append(o.events, event)
+}
+func (o *antigravityImagesObservations) Load() *pricing.Table { return o.table }
+
+type localAntigravityImagesExecutor struct {
+	antigravity.Executor
+	baseURL string
+}
+
+func (executor localAntigravityImagesExecutor) Execute(ctx context.Context, id string, credential antigravity.Credential, request antigravity.ExecuteRequest) (antigravity.ExecuteResponse, error) {
+	request.BaseURL = executor.baseURL
+	return executor.Executor.Execute(ctx, id, credential, request)
+}
+
+func newAntigravityImagesRuntime(t *testing.T) (*gin.Engine, *Adapter, *antigravityImagesObservations, execution.AttemptSpec) {
+	t.Helper()
+	canonical, err := antigravity.MarshalCredential(antigravityProviderTestCredential().value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter, _, credentials, keyService, row := newSubscriptionAdapterFixture(t, string(channel.Antigravity), canonical, "account")
+	ref, ok := credentials.CredentialRef(row.ID)
+	if !ok {
+		t.Fatal("credential is unavailable")
+	}
+	manager := state.NewManager()
+	if _, err := manager.Publish(state.CompileInput{
+		ChannelRegistry: channel.NewRegistry(),
+		Groups: []state.GroupConfig{{
+			ID: row.GroupID, Name: "antigravity", ChannelID: channel.Antigravity, ConnectionType: "subscription",
+			Params: json.RawMessage(`{}`), Models: []state.ModelConfig{{ID: "gemini-3.1-flash-image", Alias: "public-image"}}, Enabled: true,
+		}},
+		Credentials: []state.CredentialConfig{{
+			ID: row.ID, GroupID: row.GroupID, Status: state.CredentialStatusActive,
+			Version: ref.Version, IdentityGeneration: ref.IdentityGeneration, Fingerprint: ref.Fingerprint,
+		}},
+		AccessKeys: []state.AccessKeyConfig{{ID: 1, Name: "client", KeyHash: keyService.Hash("gl-images-client"), Status: state.AccessKeyStatusActive}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	table, err := pricing.NewTable([]pricing.Rule{{
+		Identity: pricing.Identity{ChannelID: string(channel.Antigravity), ModelID: "gemini-3.1-flash-image"},
+		Prices: pricing.Prices{
+			Input:     pricing.Price{NanoUSDPerMillion: 1_000_000, Set: true},
+			CacheRead: pricing.Price{NanoUSDPerMillion: 500_000, Set: true},
+			Output:    pricing.Price{NanoUSDPerMillion: 2_000_000, Set: true},
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	observations := &antigravityImagesObservations{table: table}
+	handler := gateway.NewHandler(manager, credentials, keyService, gateway.NewExecutionForwarder(adapter),
+		dialect.NewSet(dialect.NewOpenAIImages(), dialect.NewGemini()), health.NewStatsStore(), health.NewMutationCoordinator(), nil, observations, observations)
+	engine := gin.New()
+	routes, err := httproute.NewRegistry(handler.HTTPModule())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := routes.Bind(engine); err != nil {
+		t.Fatal(err)
+	}
+	spec := validSpec(t, row, keyService)
+	spec.ChannelID, spec.Credential.IdentityGeneration = string(channel.Antigravity), ref.IdentityGeneration
+	spec.ClientProtocol, spec.Operation = protocol.OpenAIImages, execution.OperationImagesGenerate
+	spec.RouteMode, spec.RouteRequirement = execution.RouteConverted, execution.RouteRequirementAny
+	spec.ClientModel, spec.UpstreamModel = "public-image", "gemini-3.1-flash-image"
+	spec.Path, spec.Header = "/v1/images/generations", http.Header{"Content-Type": {"application/json"}}
+	spec.Body = []byte(`{"model":"public-image","prompt":"draw"}`)
+	return engine, adapter, observations, spec
+}
+
+func TestAntigravityImagesHTTPGenerationReachesGeminiAndUsesExistingPricing(t *testing.T) {
+	engine, adapter, observations, _ := newAntigravityImagesRuntime(t)
+	var upstreamPayload []byte
+	var upstreamPath string
+	var upstreamMu sync.Mutex
+	calls := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		upstreamMu.Lock()
+		defer upstreamMu.Unlock()
+		calls++
+		upstreamPath = request.URL.Path
+		var err error
+		upstreamPayload, err = io.ReadAll(request.Body)
+		if err != nil {
+			t.Error(err)
+			writer.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		payload := antigravityImagesResponse(t, `{"promptTokenCount":100,"cachedContentTokenCount":40,"candidatesTokenCount":20,"thoughtsTokenCount":5,"totalTokenCount":125}`)
+		writer.Header().Set("Content-Type", "text/event-stream")
+		if _, err := io.WriteString(writer, "data: {\"response\":"+string(payload)+"}\n\n"); err != nil {
+			t.Error(err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	// CPA 会建立自己的隔离 transport；只允许该测试的本地 TLS 服务，禁止访问外部端点。
+	transport := server.Client().Transport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		if address != server.Listener.Addr().String() {
+			return nil, errors.New("unexpected external test destination")
+		}
+		return (&net.Dialer{}).DialContext(ctx, network, address)
+	}
+	originalTransport := http.DefaultTransport
+	http.DefaultTransport = transport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport; transport.CloseIdleConnections() })
+	adapter.providers[channel.ProviderAntigravity].(*antigravityProviderBridge).executor = localAntigravityImagesExecutor{Executor: antigravity.NewExecutor(), baseURL: server.URL}
+	request := httptest.NewRequest(http.MethodPost, "/v1/images/generations", strings.NewReader(`{"model":"public-image","prompt":"draw","n":1,"response_format":"b64_json"}`))
+	request.Header.Set("Authorization", "Bearer gl-images-client")
+	request.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	engine.ServeHTTP(recorder, request)
+	upstreamMu.Lock()
+	defer upstreamMu.Unlock()
+	if recorder.Code != http.StatusOK || !strings.Contains(recorder.Body.String(), `"b64_json":"`+antigravityTestImage+`"`) {
+		t.Fatalf("HTTP response = %d %s", recorder.Code, recorder.Body.String())
+	}
+	var upstream struct {
+		Model       string `json:"model"`
+		RequestType string `json:"requestType"`
+		Request     struct {
+			GenerationConfig struct {
+				Modalities []string `json:"responseModalities"`
+			} `json:"generationConfig"`
+			Contents []struct {
+				Parts []struct {
+					Text string `json:"text"`
+				} `json:"parts"`
+			} `json:"contents"`
+		} `json:"request"`
+	}
+	if err := json.Unmarshal(upstreamPayload, &upstream); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 || upstreamPath != "/v1internal:streamGenerateContent" || upstream.Model != "gemini-3.1-flash-image" ||
+		upstream.RequestType != "image_gen" || len(upstream.Request.Contents) != 1 || len(upstream.Request.Contents[0].Parts) != 1 ||
+		upstream.Request.Contents[0].Parts[0].Text != "draw" || !reflect.DeepEqual(upstream.Request.GenerationConfig.Modalities, []string{"TEXT", "IMAGE"}) {
+		t.Fatalf("upstream calls/path/payload = %d %s %s", calls, upstreamPath, upstreamPayload)
+	}
+	if len(observations.events) != 1 {
+		t.Fatalf("request events = %d", len(observations.events))
+	}
+	event := observations.events[0]
+	if event.Usage.Result.Tokens != (usage.Tokens{UncachedInput: 60, CacheRead: 40, Output: 25}) ||
+		event.Usage.Pricing.CostState != "priced" || event.Usage.Pricing.EstimatedCostNanoUSD != 130 ||
+		event.Protocol != protocol.OpenAIImages || event.Operation != execution.OperationImagesGenerate ||
+		event.ClientModel != "public-image" || event.UpstreamModel != "gemini-3.1-flash-image" {
+		t.Fatalf("request observation = %+v", event)
+	}
+}
+
+func TestAntigravityImagesAdapterRejectsUnsupportedInputsBeforeDispatch(t *testing.T) {
+	_, adapter, _, spec := newAntigravityImagesRuntime(t)
+	preparer := &fakeCredentialPreparer{delegate: adapter.credentials}
+	adapter.credentials = preparer
+	for _, payload := range []string{
+		`{"model":"public-image","prompt":"draw","n":2}`,
+		`{"model":"public-image","prompt":"draw","stream":true}`,
+		`{"model":"public-image","prompt":"draw","size":"1024x1024"}`,
+	} {
+		spec.Body = []byte(payload)
+		var result execution.AttemptResult
+		if strings.Contains(payload, `"stream":true`) {
+			stream := adapter.ExecuteStream(t.Context(), spec, func(execution.StreamEvent) error { return nil })
+			result.DispatchState, result.Error = stream.DispatchState, stream.Error
+		} else {
+			result = adapter.Execute(t.Context(), spec)
+		}
+		if result.DispatchState != execution.DispatchNotSent || result.Error == nil || result.Error.Code != "unsupported_subscription_input" || preparer.calls != 0 {
+			t.Fatalf("unsupported input result = %+v, credential preparations = %d", result, preparer.calls)
+		}
+	}
+}
+
+func TestAntigravityImagesHTTPPreservesMissingInvalidUsage(t *testing.T) {
+	engine, adapter, observations, _ := newAntigravityImagesRuntime(t)
+	upstream := antigravityImagesResponse(t, `{"promptTokenCount":"invalid","candidatesTokenCount":"invalid"}`)
+	adapter.providers[channel.ProviderAntigravity].(*antigravityProviderBridge).executor = &recordingAntigravityExecutor{response: upstream}
+	request := httptest.NewRequest(http.MethodPost, "/v1/images/generations", strings.NewReader(`{"model":"public-image","prompt":"draw"}`))
+	request.Header.Set("Authorization", "Bearer gl-images-client")
+	request.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	engine.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK || len(observations.events) != 1 {
+		t.Fatalf("HTTP response = %d %s, events = %d", recorder.Code, recorder.Body.String(), len(observations.events))
+	}
+	want, err := dialect.NewGemini().ExtractUsage(upstream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event := observations.events[0]; !reflect.DeepEqual(event.Usage.Result, want) || event.Usage.Pricing.CostState != "unpriced" {
+		t.Fatalf("usage observation = %+v, want %+v", event.Usage, want)
+	}
+}
+
+func TestAntigravityImagesHTTPRejectsUnsupportedRequestsAndInvalidOutput(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		request    string
+		response   string
+		wantStatus int
+	}{
+		{name: "stream", request: `{"model":"public-image","prompt":"draw","stream":true}`, wantStatus: http.StatusBadRequest},
+		{name: "multiple images", request: `{"model":"public-image","prompt":"draw","n":2}`, wantStatus: http.StatusBadRequest},
+		{name: "no image output", request: `{"model":"public-image","prompt":"private prompt"}`, response: `{"candidates":[{"content":{"parts":[{"text":"private response"}]}}]}`, wantStatus: http.StatusBadGateway},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			engine, adapter, observations, _ := newAntigravityImagesRuntime(t)
+			fake := &recordingAntigravityExecutor{response: []byte(test.response)}
+			adapter.providers[channel.ProviderAntigravity].(*antigravityProviderBridge).executor = fake
+			request := httptest.NewRequest(http.MethodPost, "/v1/images/generations", strings.NewReader(test.request))
+			request.Header.Set("Authorization", "Bearer gl-images-client")
+			request.Header.Set("Content-Type", "application/json")
+			recorder := httptest.NewRecorder()
+			engine.ServeHTTP(recorder, request)
+			if recorder.Code != test.wantStatus || strings.Contains(recorder.Body.String(), "private") ||
+				len(observations.events) != 1 || len(observations.events[0].Attempts) != 1 {
+				t.Fatalf("response = %d %s; events = %+v", recorder.Code, recorder.Body.String(), observations.events)
+			}
+			if test.wantStatus == http.StatusBadRequest && fake.request.Format != "" {
+				t.Fatal("unsupported request reached the upstream executor")
+			}
+		})
+	}
+}

--- a/internal/execution/cpa/antigravity_images_integration_test.go
+++ b/internal/execution/cpa/antigravity_images_integration_test.go
@@ -193,21 +193,36 @@ func TestAntigravityImagesAdapterRejectsUnsupportedInputsBeforeDispatch(t *testi
 	_, adapter, _, spec := newAntigravityImagesRuntime(t)
 	preparer := &fakeCredentialPreparer{delegate: adapter.credentials}
 	adapter.credentials = preparer
-	for _, payload := range []string{
-		`{"model":"public-image","prompt":"draw","n":2}`,
-		`{"model":"public-image","prompt":"draw","stream":true}`,
-		`{"model":"public-image","prompt":"draw","size":"1024x1024"}`,
+	for _, test := range []struct {
+		payload string
+		stream  bool
+		invalid bool
+	}{
+		{payload: `{"model":"public-image","prompt":"draw","n":2}`},
+		{payload: `{"model":"public-image","prompt":"draw","stream":true}`, stream: true},
+		{payload: `{"model":"public-image","prompt":"draw"}`, stream: true},
+		{payload: `{"model":"public-image","prompt":"draw","size":"1024x1024"}`},
+		{payload: `{"model":"public-image","prompt":"draw","n":"2"}`, invalid: true},
+		{payload: `{"model":"public-image","n":2}`, invalid: true},
+		{payload: `{"model":"public-image","prompt":"draw","stream":"true"}`, stream: true, invalid: true},
 	} {
-		spec.Body = []byte(payload)
+		spec.Body = []byte(test.payload)
 		var result execution.AttemptResult
-		if strings.Contains(payload, `"stream":true`) {
+		if test.stream {
 			stream := adapter.ExecuteStream(t.Context(), spec, func(execution.StreamEvent) error { return nil })
 			result.DispatchState, result.Error = stream.DispatchState, stream.Error
 		} else {
 			result = adapter.Execute(t.Context(), spec)
 		}
-		if result.DispatchState != execution.DispatchNotSent || result.Error == nil || result.Error.Code != "unsupported_subscription_input" || preparer.calls != 0 {
+		if result.DispatchState != execution.DispatchNotSent || result.Error == nil || preparer.calls != 0 {
 			t.Fatalf("unsupported input result = %+v, credential preparations = %d", result, preparer.calls)
+		}
+		wantKind := execution.ErrorKindConversionUnsupported
+		if test.invalid {
+			wantKind = execution.ErrorKindInvalidRequest
+		}
+		if result.Error.Kind != wantKind || !test.invalid && result.Error.Code != execution.ErrorCodeTargetConversionNotSupported {
+			t.Fatalf("input error = %+v, want %s", result.Error, wantKind)
 		}
 	}
 }
@@ -240,8 +255,9 @@ func TestAntigravityImagesHTTPRejectsUnsupportedRequestsAndInvalidOutput(t *test
 		response   string
 		wantStatus int
 	}{
-		{name: "stream", request: `{"model":"public-image","prompt":"draw","stream":true}`, wantStatus: http.StatusBadRequest},
-		{name: "multiple images", request: `{"model":"public-image","prompt":"draw","n":2}`, wantStatus: http.StatusBadRequest},
+		{name: "stream", request: `{"model":"public-image","prompt":"draw","stream":true}`, wantStatus: http.StatusUnprocessableEntity},
+		{name: "multiple images", request: `{"model":"public-image","prompt":"draw","n":2}`, wantStatus: http.StatusUnprocessableEntity},
+		{name: "invalid count", request: `{"model":"public-image","prompt":"draw","n":"2"}`, wantStatus: http.StatusBadRequest},
 		{name: "no image output", request: `{"model":"public-image","prompt":"private prompt"}`, response: `{"candidates":[{"content":{"parts":[{"text":"private response"}]}}]}`, wantStatus: http.StatusBadGateway},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -257,8 +273,11 @@ func TestAntigravityImagesHTTPRejectsUnsupportedRequestsAndInvalidOutput(t *test
 				len(observations.events) != 1 || len(observations.events[0].Attempts) != 1 {
 				t.Fatalf("response = %d %s; events = %+v", recorder.Code, recorder.Body.String(), observations.events)
 			}
-			if test.wantStatus == http.StatusBadRequest && fake.request.Format != "" {
+			if test.wantStatus != http.StatusBadGateway && fake.request.Format != "" {
 				t.Fatal("unsupported request reached the upstream executor")
+			}
+			if test.wantStatus == http.StatusUnprocessableEntity && !strings.Contains(recorder.Body.String(), `"code":"protocol_conversion_unsupported"`) {
+				t.Fatalf("conversion error = %s", recorder.Body.String())
 			}
 		})
 	}

--- a/internal/execution/cpa/antigravity_images_test.go
+++ b/internal/execution/cpa/antigravity_images_test.go
@@ -1,0 +1,218 @@
+package cpa
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"gpt-load/internal/dialect"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+	"gpt-load/internal/usage"
+)
+
+const antigravityTestImage = "aW1hZ2U="
+
+func antigravityImagesRequest(payload string) providerRequest {
+	return providerRequest{
+		AttemptID: "images-attempt", Model: "gemini-3.1-flash-image", Format: "openai-image",
+		RequestPath: "/v1/images/generations", Payload: []byte(payload), OriginalRequest: []byte(payload),
+		Headers: http.Header{"Content-Type": {"application/json"}},
+		BaseURL: "https://antigravity.example.test", ProxyURL: "http://proxy.example.test",
+	}
+}
+
+func antigravityImagesResponse(t *testing.T, metadata string) []byte {
+	t.Helper()
+	root := map[string]any{
+		"modelVersion": "gemini-3.1-flash-image",
+		"candidates": []any{map[string]any{
+			"finishReason": "STOP",
+			"content": map[string]any{"parts": []any{
+				map[string]any{"text": "private generated text"},
+				map[string]any{"inlineData": map[string]any{"mimeType": "image/png", "data": antigravityTestImage}},
+			}},
+		}},
+	}
+	if metadata != "" {
+		root["usageMetadata"] = json.RawMessage(metadata)
+	}
+	encoded, err := json.Marshal(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return encoded
+}
+
+func antigravityImagesAttempt(response providerResponse, bridge *antigravityProviderBridge) execution.AttemptResult {
+	spec := execution.AttemptSpec{
+		ClientProtocol: protocol.OpenAIImages, Operation: execution.OperationImagesGenerate,
+		RouteMode: execution.RouteConverted, UpstreamModel: "gemini-3.1-flash-image",
+	}
+	result := unaryProviderSuccess(bridge, spec, response)
+	normalizeCPAImagesAttemptResult(spec, &result)
+	return result
+}
+
+func TestAntigravityImagesConvertsGenerationAndPreservesUsage(t *testing.T) {
+	executor := &recordingAntigravityExecutor{response: antigravityImagesResponse(t,
+		`{"promptTokenCount":100,"cachedContentTokenCount":40,"candidatesTokenCount":20,"thoughtsTokenCount":5,"totalTokenCount":125}`,
+	)}
+	bridge := &antigravityProviderBridge{executor: executor}
+	request := antigravityImagesRequest(`{"model":"gemini-3.1-flash-image","prompt":"  画一只猫  ","n":1,"stream":false,"size":"auto","quality":"auto","response_format":"b64_json"}`)
+	original := bytes.Clone(request.Payload)
+	before := time.Now().Unix()
+	response, err := bridge.Execute(t.Context(), "17", antigravityProviderTestCredential(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantPayload := `{"contents":[{"role":"user","parts":[{"text":"  画一只猫  "}]}],"generationConfig":{"responseModalities":["TEXT","IMAGE"]}}`
+	var got, want any
+	if err := json.Unmarshal(executor.request.Payload, &got); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal([]byte(wantPayload), &want); err != nil {
+		t.Fatal(err)
+	}
+	if executor.request.Format != "gemini" || !reflect.DeepEqual(got, want) ||
+		executor.request.Model != request.Model || executor.request.AttemptID != request.AttemptID ||
+		executor.request.BaseURL != request.BaseURL || executor.request.ProxyURL != request.ProxyURL ||
+		!bytes.Equal(executor.request.OriginalRequest, executor.request.Payload) {
+		t.Fatalf("Gemini request = %#v, payload = %s", executor.request, executor.request.Payload)
+	}
+	if !bytes.Equal(request.Payload, original) || !bytes.Equal(request.OriginalRequest, original) {
+		t.Fatal("conversion mutated the caller's request")
+	}
+	var body struct {
+		Created int64  `json:"created"`
+		Model   string `json:"model"`
+		Data    []struct {
+			Base64 string `json:"b64_json"`
+		} `json:"data"`
+		Usage struct {
+			Input  int64 `json:"input_tokens"`
+			Output int64 `json:"output_tokens"`
+			Total  int64 `json:"total_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(response.Payload, &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Created < before || body.Created > time.Now().Unix() || body.Model != request.Model ||
+		len(body.Data) != 1 || body.Data[0].Base64 != antigravityTestImage ||
+		body.Usage.Input != 100 || body.Usage.Output != 25 || body.Usage.Total != 125 ||
+		strings.Contains(string(response.Payload), "private generated text") {
+		t.Fatalf("Images response = %s", response.Payload)
+	}
+	result := antigravityImagesAttempt(response, bridge)
+	if err := result.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if result.Usage == nil || result.Usage.Normalized.State != usage.StateComplete ||
+		result.Usage.Normalized.Tokens != (usage.Tokens{UncachedInput: 60, CacheRead: 40, Output: 25}) {
+		t.Fatalf("canonical usage = %+v", result.Usage)
+	}
+}
+
+func TestAntigravityImagesRejectsUnsupportedInputs(t *testing.T) {
+	tests := []string{
+		`{}`, `{"prompt":""}`, `{"prompt":"   "}`, `{"prompt":5}`,
+		`{"prompt":"draw","n":2}`, `{"prompt":"draw","n":1.5}`, `{"prompt":"draw","n":null}`,
+		`{"prompt":"draw","stream":true}`, `{"prompt":"draw","stream":"false"}`,
+		`{"prompt":"draw","response_format":"url"}`, `{"prompt":"draw","size":"1024x1024"}`,
+		`{"prompt":"draw","quality":"high"}`, `{"prompt":"draw","image":"private data"}`,
+		`{"prompt":"draw","unknown_option":true}`, `null`, `[]`,
+	}
+	bridge := &antigravityProviderBridge{}
+	for _, payload := range tests {
+		t.Run(payload, func(t *testing.T) {
+			if err := bridge.ValidateRequest(antigravityImagesRequest(payload)); err == nil {
+				t.Fatal("unsupported Images request was accepted")
+			}
+		})
+	}
+	if err := bridge.ValidateRequest(antigravityImagesRequest(`{"prompt":"draw"}`)); err != nil {
+		t.Fatalf("default request rejected: %v", err)
+	}
+	request := antigravityImagesRequest(`{"prompt":"draw"}`)
+	request.RequestPath = "/v1/images/edits"
+	if err := bridge.ValidateRequest(request); err == nil {
+		t.Fatal("image edits were accepted")
+	}
+}
+
+func TestAntigravityImagesRejectsInvalidResponses(t *testing.T) {
+	for name, payload := range map[string]string{
+		"invalid JSON": "not JSON private response",
+		"empty":        `{}`,
+		"blocked":      `{"promptFeedback":{"blockReason":"SAFETY"}}`,
+		"text only":    `{"candidates":[{"content":{"parts":[{"text":"private response"}]}}]}`,
+		"empty image":  `{"candidates":[{"content":{"parts":[{"inlineData":{"mimeType":"image/png","data":""}}]}}]}`,
+		"bad base64":   `{"candidates":[{"content":{"parts":[{"inlineData":{"mimeType":"image/png","data":"!private response!"}}]}}]}`,
+		"wrong MIME":   `{"candidates":[{"content":{"parts":[{"inlineData":{"mimeType":"text/plain","data":"AA=="}}]}}]}`,
+		"two images":   `{"candidates":[{"content":{"parts":[{"inlineData":{"mimeType":"image/png","data":"AA=="}},{"inlineData":{"mimeType":"image/png","data":"AA=="}}]}}]}`,
+		"thought only": `{"candidates":[{"content":{"parts":[{"thought":true,"inlineData":{"mimeType":"image/png","data":"AA=="}}]}}]}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			bridge := &antigravityProviderBridge{executor: &recordingAntigravityExecutor{response: []byte(payload)}}
+			_, err := bridge.Execute(t.Context(), "17", antigravityProviderTestCredential(), antigravityImagesRequest(`{"prompt":"draw"}`))
+			if err == nil {
+				t.Fatal("invalid image output was accepted")
+			}
+			result := unaryExecutionError(t.Context(), bridge, err, antigravityProviderTestCredential())
+			normalizeCPAImagesAttemptResult(execution.AttemptSpec{ClientProtocol: protocol.OpenAIImages}, &result)
+			if result.Error == nil || result.StatusCode != http.StatusBadGateway ||
+				result.DispatchState != execution.DispatchMaybeSent || result.Error.ReplaySafety != execution.ReplaySafetyUnknown ||
+				strings.Contains(err.Error(), "private response") || strings.Contains(result.Error.Summary, "private response") {
+				t.Fatalf("invalid image error = %+v / %v", result, err)
+			}
+		})
+	}
+}
+
+func TestAntigravityImagesPreservesGeminiUsageStates(t *testing.T) {
+	for name, metadata := range map[string]string{
+		"missing":         "",
+		"empty":           `{}`,
+		"partial":         `{"promptTokenCount":10}`,
+		"invalid":         `{"promptTokenCount":"invalid","candidatesTokenCount":20}`,
+		"negative cached": `{"promptTokenCount":10,"cachedContentTokenCount":20,"candidatesTokenCount":5}`,
+		"missing invalid": `{"promptTokenCount":"invalid","candidatesTokenCount":"invalid"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			upstream := antigravityImagesResponse(t, metadata)
+			bridge := &antigravityProviderBridge{executor: &recordingAntigravityExecutor{response: upstream}}
+			response, err := bridge.Execute(t.Context(), "17", antigravityProviderTestCredential(), antigravityImagesRequest(`{"prompt":"draw"}`))
+			if err != nil {
+				t.Fatal(err)
+			}
+			want, err := dialect.NewGemini().ExtractUsage(upstream)
+			if err != nil {
+				t.Fatal(err)
+			}
+			result := antigravityImagesAttempt(response, bridge)
+			if result.Usage == nil || !reflect.DeepEqual(result.Usage.Normalized, want) {
+				t.Fatalf("Images canonical usage = %+v, want %+v", result.Usage, want)
+			}
+		})
+	}
+}
+
+func TestAntigravityImagesAcceptsSnakeCaseImageAndPreservesUpstreamError(t *testing.T) {
+	executor := &recordingAntigravityExecutor{response: []byte(`{"candidates":[{"content":{"parts":[{"inline_data":{"mime_type":"image/jpeg","data":"AA=="}}]}}]}`)}
+	bridge := &antigravityProviderBridge{executor: executor}
+	response, err := bridge.Execute(t.Context(), "17", antigravityProviderTestCredential(), antigravityImagesRequest(`{"prompt":"draw"}`))
+	if err != nil || !bytes.Contains(response.Payload, []byte(`"b64_json":"AA=="`)) {
+		t.Fatalf("snake case image = %s, error = %v", response.Payload, err)
+	}
+	upstreamError := antigravityClassifiedTestError{status: http.StatusTooManyRequests, code: "RESOURCE_EXHAUSTED"}
+	executor.err = upstreamError
+	_, err = bridge.Execute(t.Context(), "17", antigravityProviderTestCredential(), antigravityImagesRequest(`{"prompt":"draw"}`))
+	if err != upstreamError {
+		t.Fatalf("upstream error changed: %v", err)
+	}
+}

--- a/internal/execution/cpa/antigravity_images_test.go
+++ b/internal/execution/cpa/antigravity_images_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"gpt-load/internal/dialect"
 	"gpt-load/internal/execution"
 	"gpt-load/internal/protocol"
 	"gpt-load/internal/usage"
@@ -118,87 +117,11 @@ func TestAntigravityImagesConvertsGenerationAndPreservesUsage(t *testing.T) {
 	}
 }
 
-func TestAntigravityImagesRejectsUnsupportedInputs(t *testing.T) {
-	tests := []string{
-		`{}`, `{"prompt":""}`, `{"prompt":"   "}`, `{"prompt":5}`,
-		`{"prompt":"draw","n":2}`, `{"prompt":"draw","n":1.5}`, `{"prompt":"draw","n":null}`,
-		`{"prompt":"draw","stream":true}`, `{"prompt":"draw","stream":"false"}`,
-		`{"prompt":"draw","response_format":"url"}`, `{"prompt":"draw","size":"1024x1024"}`,
-		`{"prompt":"draw","quality":"high"}`, `{"prompt":"draw","image":"private data"}`,
-		`{"prompt":"draw","unknown_option":true}`, `null`, `[]`,
-	}
-	bridge := &antigravityProviderBridge{}
-	for _, payload := range tests {
-		t.Run(payload, func(t *testing.T) {
-			if err := bridge.ValidateRequest(antigravityImagesRequest(payload)); err == nil {
-				t.Fatal("unsupported Images request was accepted")
-			}
-		})
-	}
-	if err := bridge.ValidateRequest(antigravityImagesRequest(`{"prompt":"draw"}`)); err != nil {
-		t.Fatalf("default request rejected: %v", err)
-	}
+func TestAntigravityImagesRejectsEditingRoute(t *testing.T) {
 	request := antigravityImagesRequest(`{"prompt":"draw"}`)
 	request.RequestPath = "/v1/images/edits"
-	if err := bridge.ValidateRequest(request); err == nil {
+	if err := (&antigravityProviderBridge{}).ValidateRequest(request); err == nil {
 		t.Fatal("image edits were accepted")
-	}
-}
-
-func TestAntigravityImagesRejectsInvalidResponses(t *testing.T) {
-	for name, payload := range map[string]string{
-		"invalid JSON": "not JSON private response",
-		"empty":        `{}`,
-		"blocked":      `{"promptFeedback":{"blockReason":"SAFETY"}}`,
-		"text only":    `{"candidates":[{"content":{"parts":[{"text":"private response"}]}}]}`,
-		"empty image":  `{"candidates":[{"content":{"parts":[{"inlineData":{"mimeType":"image/png","data":""}}]}}]}`,
-		"bad base64":   `{"candidates":[{"content":{"parts":[{"inlineData":{"mimeType":"image/png","data":"!private response!"}}]}}]}`,
-		"wrong MIME":   `{"candidates":[{"content":{"parts":[{"inlineData":{"mimeType":"text/plain","data":"AA=="}}]}}]}`,
-		"two images":   `{"candidates":[{"content":{"parts":[{"inlineData":{"mimeType":"image/png","data":"AA=="}},{"inlineData":{"mimeType":"image/png","data":"AA=="}}]}}]}`,
-		"thought only": `{"candidates":[{"content":{"parts":[{"thought":true,"inlineData":{"mimeType":"image/png","data":"AA=="}}]}}]}`,
-	} {
-		t.Run(name, func(t *testing.T) {
-			bridge := &antigravityProviderBridge{executor: &recordingAntigravityExecutor{response: []byte(payload)}}
-			_, err := bridge.Execute(t.Context(), "17", antigravityProviderTestCredential(), antigravityImagesRequest(`{"prompt":"draw"}`))
-			if err == nil {
-				t.Fatal("invalid image output was accepted")
-			}
-			result := unaryExecutionError(t.Context(), bridge, err, antigravityProviderTestCredential())
-			normalizeCPAImagesAttemptResult(execution.AttemptSpec{ClientProtocol: protocol.OpenAIImages}, &result)
-			if result.Error == nil || result.StatusCode != http.StatusBadGateway ||
-				result.DispatchState != execution.DispatchMaybeSent || result.Error.ReplaySafety != execution.ReplaySafetyUnknown ||
-				strings.Contains(err.Error(), "private response") || strings.Contains(result.Error.Summary, "private response") {
-				t.Fatalf("invalid image error = %+v / %v", result, err)
-			}
-		})
-	}
-}
-
-func TestAntigravityImagesPreservesGeminiUsageStates(t *testing.T) {
-	for name, metadata := range map[string]string{
-		"missing":         "",
-		"empty":           `{}`,
-		"partial":         `{"promptTokenCount":10}`,
-		"invalid":         `{"promptTokenCount":"invalid","candidatesTokenCount":20}`,
-		"negative cached": `{"promptTokenCount":10,"cachedContentTokenCount":20,"candidatesTokenCount":5}`,
-		"missing invalid": `{"promptTokenCount":"invalid","candidatesTokenCount":"invalid"}`,
-	} {
-		t.Run(name, func(t *testing.T) {
-			upstream := antigravityImagesResponse(t, metadata)
-			bridge := &antigravityProviderBridge{executor: &recordingAntigravityExecutor{response: upstream}}
-			response, err := bridge.Execute(t.Context(), "17", antigravityProviderTestCredential(), antigravityImagesRequest(`{"prompt":"draw"}`))
-			if err != nil {
-				t.Fatal(err)
-			}
-			want, err := dialect.NewGemini().ExtractUsage(upstream)
-			if err != nil {
-				t.Fatal(err)
-			}
-			result := antigravityImagesAttempt(response, bridge)
-			if result.Usage == nil || !reflect.DeepEqual(result.Usage.Normalized, want) {
-				t.Fatalf("Images canonical usage = %+v, want %+v", result.Usage, want)
-			}
-		})
 	}
 }
 

--- a/internal/execution/cpa/antigravity_provider.go
+++ b/internal/execution/cpa/antigravity_provider.go
@@ -47,6 +47,9 @@ func (*antigravityProviderBridge) ValidateRouteCapability(route channel.RouteDes
 	if route.ClientProtocol == protocol.OpenAICompletions {
 		valid = route.Operation == execution.OperationChatCompletion && route.RouteMode == execution.RouteConverted
 	}
+	if route.ClientProtocol == protocol.OpenAIImages {
+		valid = route.Operation == execution.OperationImagesGenerate && route.RouteMode == execution.RouteConverted
+	}
 	if route.ClientProtocol == protocol.OpenAIResponses {
 		valid = (route.Operation == execution.OperationResponsesCreate || route.Operation == execution.OperationResponsesInputTokens) &&
 			route.RouteMode == execution.RouteConverted
@@ -69,6 +72,10 @@ func (*antigravityProviderBridge) ParseCredential(raw []byte) (providerCredentia
 // for Antigravity. General protocol validation stays with the existing
 // dialect layer so this does not become a second request schema.
 func (*antigravityProviderBridge) ValidateRequest(request providerRequest) error {
+	if strings.TrimSpace(request.Format) == "openai-image" {
+		_, err := antigravityImagesPrompt(request)
+		return err
+	}
 	if strings.TrimSpace(request.Format) == "openai-response" &&
 		strings.Contains(strings.ToLower(strings.TrimSpace(request.Model)), "image") {
 		return errors.New("Antigravity does not support Responses image output")
@@ -155,6 +162,14 @@ func (bridge *antigravityProviderBridge) Execute(
 	if !ok || bridge == nil || bridge.executor == nil {
 		return providerResponse{}, errors.New("Antigravity provider bridge credential mismatch")
 	}
+	images := strings.TrimSpace(request.Format) == "openai-image"
+	if images {
+		payload, err := antigravityImagesRequestPayload(request)
+		if err != nil {
+			return providerResponse{}, err
+		}
+		request.Format, request.Payload, request.OriginalRequest = "gemini", payload, bytes.Clone(payload)
+	}
 	response, err := bridge.executor.Execute(ctx, credentialID, value.value, antigravity.ExecuteRequest{
 		AttemptID: request.AttemptID, Model: request.Model, Payload: append([]byte(nil), request.Payload...), Format: request.Format,
 		Headers: request.Headers.Clone(), OriginalRequest: append([]byte(nil), request.OriginalRequest...),
@@ -164,9 +179,13 @@ func (bridge *antigravityProviderBridge) Execute(
 	if err == nil {
 		response.Payload, err = normalizeAntigravityResponseModel(request.Format, response.Payload, request.Model)
 	}
+	var imageUsage *execution.UsageEvidence
+	if err == nil && images {
+		response.Payload, imageUsage, err = convertAntigravityImagesResponse(response.Payload)
+	}
 	return providerResponse{
 		Payload: append([]byte(nil), response.Payload...), Headers: response.Headers.Clone(),
-		AppliedReasoningEffort: response.AppliedReasoningEffort,
+		AppliedReasoningEffort: response.AppliedReasoningEffort, Usage: imageUsage,
 	}, err
 }
 
@@ -310,6 +329,14 @@ func (*antigravityProviderBridge) ClassifyError(
 ) (int, *execution.ErrorEvidence) {
 	if err == nil {
 		return 0, nil
+	}
+	if errors.Is(err, errAntigravityImagesResponse) {
+		return http.StatusBadGateway, &execution.ErrorEvidence{
+			Kind: execution.ErrorKindProvider, StatusCode: http.StatusBadGateway,
+			Hint: execution.FailureHintRequestRejected, OriginHint: execution.ErrorOriginUpstream,
+			ScopeHint: execution.ErrorScopeRequest, Code: "invalid_image_response",
+			Summary: errAntigravityImagesResponse.Error(), ReplaySafety: execution.ReplaySafetyUnknown,
+		}
 	}
 	status := 0
 	var statusError interface{ StatusCode() int }

--- a/internal/execution/cpa/antigravity_provider.go
+++ b/internal/execution/cpa/antigravity_provider.go
@@ -13,6 +13,7 @@ import (
 
 	"gpt-load/internal/channel"
 	"gpt-load/internal/execution"
+	"gpt-load/internal/execution/geminiimage"
 	"gpt-load/internal/execution/responsealias"
 	"gpt-load/internal/protocol"
 	"gpt-load/internal/subscription/providers/antigravity"
@@ -73,8 +74,10 @@ func (*antigravityProviderBridge) ParseCredential(raw []byte) (providerCredentia
 // dialect layer so this does not become a second request schema.
 func (*antigravityProviderBridge) ValidateRequest(request providerRequest) error {
 	if strings.TrimSpace(request.Format) == "openai-image" {
-		_, err := antigravityImagesPrompt(request)
-		return err
+		if request.RequestPath != "/v1/images/generations" {
+			return errors.New("Antigravity only supports image generations")
+		}
+		return geminiimage.ValidateRequest(request.Payload)
 	}
 	if strings.TrimSpace(request.Format) == "openai-response" &&
 		strings.Contains(strings.ToLower(strings.TrimSpace(request.Model)), "image") {
@@ -164,7 +167,7 @@ func (bridge *antigravityProviderBridge) Execute(
 	}
 	images := strings.TrimSpace(request.Format) == "openai-image"
 	if images {
-		payload, err := antigravityImagesRequestPayload(request)
+		payload, err := geminiimage.ConvertRequest(request.Payload)
 		if err != nil {
 			return providerResponse{}, err
 		}
@@ -181,7 +184,7 @@ func (bridge *antigravityProviderBridge) Execute(
 	}
 	var imageUsage *execution.UsageEvidence
 	if err == nil && images {
-		response.Payload, imageUsage, err = convertAntigravityImagesResponse(response.Payload)
+		response.Payload, imageUsage, err = geminiimage.ConvertResponse(response.Payload)
 	}
 	return providerResponse{
 		Payload: append([]byte(nil), response.Payload...), Headers: response.Headers.Clone(),
@@ -330,12 +333,12 @@ func (*antigravityProviderBridge) ClassifyError(
 	if err == nil {
 		return 0, nil
 	}
-	if errors.Is(err, errAntigravityImagesResponse) {
+	if errors.Is(err, geminiimage.ErrInvalidResponse) {
 		return http.StatusBadGateway, &execution.ErrorEvidence{
 			Kind: execution.ErrorKindProvider, StatusCode: http.StatusBadGateway,
 			Hint: execution.FailureHintRequestRejected, OriginHint: execution.ErrorOriginUpstream,
 			ScopeHint: execution.ErrorScopeRequest, Code: "invalid_image_response",
-			Summary: errAntigravityImagesResponse.Error(), ReplaySafety: execution.ReplaySafetyUnknown,
+			Summary: geminiimage.ErrInvalidResponse.Error(), ReplaySafety: execution.ReplaySafetyUnknown,
 		}
 	}
 	status := 0

--- a/internal/execution/cpa/antigravity_provider_test.go
+++ b/internal/execution/cpa/antigravity_provider_test.go
@@ -14,6 +14,7 @@ type recordingAntigravityExecutor struct {
 	request      antigravity.ExecuteRequest
 	response     []byte
 	streamChunks [][]byte
+	err          error
 }
 
 type antigravityClassifiedTestError struct {
@@ -45,6 +46,9 @@ func (executor *recordingAntigravityExecutor) Execute(
 	request antigravity.ExecuteRequest,
 ) (antigravity.ExecuteResponse, error) {
 	executor.request = request
+	if executor.err != nil {
+		return antigravity.ExecuteResponse{}, executor.err
+	}
 	payload := executor.response
 	if payload == nil {
 		payload = []byte(`{"ok":true}`)

--- a/internal/execution/cpa/provider.go
+++ b/internal/execution/cpa/provider.go
@@ -151,6 +151,7 @@ func proxySettingsForAttempt(effective outboundproxy.Effective) (cpaProxySetting
 type providerResponse struct {
 	Payload                []byte
 	Headers                http.Header
+	Usage                  *execution.UsageEvidence
 	AppliedReasoningEffort string
 	UpstreamProtocol       protocol.Protocol
 	Local                  bool

--- a/internal/execution/geminiimage/convert.go
+++ b/internal/execution/geminiimage/convert.go
@@ -19,6 +19,15 @@ import (
 // ErrInvalidResponse 表示上游响应无法转换为有效的单张图片，错误不包含上游正文。
 var ErrInvalidResponse = errors.New("Gemini image response could not be converted")
 
+// unsupportedRequestError 沿用执行器的转换失败分类，允许尝试其他上游候选。
+type unsupportedRequestError string
+
+func (err unsupportedRequestError) Error() string { return string(err) }
+
+func (unsupportedRequestError) ConversionCode() string {
+	return execution.ErrorCodeTargetConversionNotSupported
+}
+
 // ValidateRequest 校验单图、非流式合同，避免静默丢弃 Images 参数。
 func ValidateRequest(payload []byte) error {
 	_, err := generationPrompt(payload)
@@ -34,32 +43,43 @@ func generationPrompt(payload []byte) (string, error) {
 	if err := json.Unmarshal(object["prompt"], &prompt); err != nil || strings.TrimSpace(prompt) == "" {
 		return "", errors.New("Gemini image conversion requires a non-empty prompt")
 	}
+	var conversionErr error
 	for name, raw := range object {
 		switch name {
 		case "model", "prompt":
 		case "n":
 			var count int
-			if json.Unmarshal(raw, &count) != nil || count != 1 {
-				return "", errors.New("Gemini image conversion only supports n=1")
+			if json.Unmarshal(raw, &count) != nil || count < 1 {
+				return "", errors.New("Images n must be a positive integer")
+			}
+			if count != 1 {
+				conversionErr = unsupportedRequestError("Gemini image conversion only supports n=1")
 			}
 		case "stream":
-			if !bytes.Equal(bytes.TrimSpace(raw), []byte("false")) {
-				return "", errors.New("Gemini image conversion does not support streaming")
+			var stream *bool
+			if json.Unmarshal(raw, &stream) != nil || stream == nil {
+				return "", errors.New("Images stream must be a boolean")
+			}
+			if *stream {
+				conversionErr = unsupportedRequestError("Gemini image conversion does not support streaming")
 			}
 		case "size", "quality", "response_format":
 			want := "auto"
 			if name == "response_format" {
 				want = "b64_json"
 			}
-			var value string
-			if json.Unmarshal(raw, &value) != nil || value != want {
-				return "", fmt.Errorf("Gemini image conversion only supports %s=%s", name, want)
+			var value *string
+			if json.Unmarshal(raw, &value) != nil || value == nil {
+				return "", fmt.Errorf("Images %s must be a string", name)
+			}
+			if *value != want {
+				conversionErr = unsupportedRequestError(fmt.Sprintf("Gemini image conversion only supports %s=%s", name, want))
 			}
 		default:
-			return "", errors.New("Gemini image conversion received an unsupported field")
+			conversionErr = unsupportedRequestError("Gemini image conversion received an unsupported field")
 		}
 	}
-	return prompt, nil
+	return prompt, conversionErr
 }
 
 // ConvertRequest 将已清理控制字段的 Images 请求转换为 Gemini generateContent 正文。

--- a/internal/execution/geminiimage/convert.go
+++ b/internal/execution/geminiimage/convert.go
@@ -1,4 +1,5 @@
-package cpa
+// Package geminiimage 实现 OpenAI Images 客户端到 Gemini 生图上游的单向格式适配。
+package geminiimage
 
 import (
 	"bytes"
@@ -15,20 +16,23 @@ import (
 	"gpt-load/internal/usage"
 )
 
-var errAntigravityImagesResponse = errors.New("Antigravity image response could not be converted")
+// ErrInvalidResponse 表示上游响应无法转换为有效的单张图片，错误不包含上游正文。
+var ErrInvalidResponse = errors.New("Gemini image response could not be converted")
 
-// antigravityImagesPrompt 校验首期单图、非流式合同，避免静默丢弃 Images 参数。
-func antigravityImagesPrompt(request providerRequest) (string, error) {
-	if request.RequestPath != "/v1/images/generations" {
-		return "", errors.New("Antigravity only supports image generations")
-	}
+// ValidateRequest 校验单图、非流式合同，避免静默丢弃 Images 参数。
+func ValidateRequest(payload []byte) error {
+	_, err := generationPrompt(payload)
+	return err
+}
+
+func generationPrompt(payload []byte) (string, error) {
 	var object map[string]json.RawMessage
-	if err := json.Unmarshal(request.Payload, &object); err != nil || object == nil {
-		return "", errors.New("Antigravity Images request must be a JSON object")
+	if err := json.Unmarshal(payload, &object); err != nil || object == nil {
+		return "", errors.New("Gemini image conversion requires a JSON object")
 	}
 	var prompt string
 	if err := json.Unmarshal(object["prompt"], &prompt); err != nil || strings.TrimSpace(prompt) == "" {
-		return "", errors.New("Antigravity Images requires a non-empty prompt")
+		return "", errors.New("Gemini image conversion requires a non-empty prompt")
 	}
 	for name, raw := range object {
 		switch name {
@@ -36,11 +40,11 @@ func antigravityImagesPrompt(request providerRequest) (string, error) {
 		case "n":
 			var count int
 			if json.Unmarshal(raw, &count) != nil || count != 1 {
-				return "", errors.New("Antigravity Images only supports n=1")
+				return "", errors.New("Gemini image conversion only supports n=1")
 			}
 		case "stream":
 			if !bytes.Equal(bytes.TrimSpace(raw), []byte("false")) {
-				return "", errors.New("Antigravity Images does not support streaming")
+				return "", errors.New("Gemini image conversion does not support streaming")
 			}
 		case "size", "quality", "response_format":
 			want := "auto"
@@ -49,17 +53,18 @@ func antigravityImagesPrompt(request providerRequest) (string, error) {
 			}
 			var value string
 			if json.Unmarshal(raw, &value) != nil || value != want {
-				return "", fmt.Errorf("Antigravity Images only supports %s=%s", name, want)
+				return "", fmt.Errorf("Gemini image conversion only supports %s=%s", name, want)
 			}
 		default:
-			return "", errors.New("Antigravity Images request contains an unsupported field")
+			return "", errors.New("Gemini image conversion received an unsupported field")
 		}
 	}
 	return prompt, nil
 }
 
-func antigravityImagesRequestPayload(request providerRequest) ([]byte, error) {
-	prompt, err := antigravityImagesPrompt(request)
+// ConvertRequest 将已清理控制字段的 Images 请求转换为 Gemini generateContent 正文。
+func ConvertRequest(payload []byte) ([]byte, error) {
+	prompt, err := generationPrompt(payload)
 	if err != nil {
 		return nil, err
 	}
@@ -71,28 +76,29 @@ func antigravityImagesRequestPayload(request providerRequest) ([]byte, error) {
 	})
 }
 
-type antigravityImageData struct {
+type imageData struct {
 	MIMEType      string `json:"mimeType"`
 	SnakeMIMEType string `json:"mime_type"`
 	Data          string `json:"data"`
 }
 
-func convertAntigravityImagesResponse(payload []byte) ([]byte, *execution.UsageEvidence, error) {
+// ConvertResponse 返回 Images 正文及保留原 Gemini 计价语义的用量证据。
+func ConvertResponse(payload []byte) ([]byte, *execution.UsageEvidence, error) {
 	var root struct {
 		ModelVersion  string          `json:"modelVersion"`
 		UsageMetadata json.RawMessage `json:"usageMetadata"`
 		Candidates    []struct {
 			Content struct {
 				Parts []struct {
-					Thought         bool                  `json:"thought"`
-					InlineData      *antigravityImageData `json:"inlineData"`
-					SnakeInlineData *antigravityImageData `json:"inline_data"`
+					Thought         bool       `json:"thought"`
+					InlineData      *imageData `json:"inlineData"`
+					SnakeInlineData *imageData `json:"inline_data"`
 				} `json:"parts"`
 			} `json:"content"`
 		} `json:"candidates"`
 	}
 	if err := json.Unmarshal(payload, &root); err != nil {
-		return nil, nil, errAntigravityImagesResponse
+		return nil, nil, ErrInvalidResponse
 	}
 	image := ""
 	for _, candidate := range root.Candidates {
@@ -114,21 +120,21 @@ func convertAntigravityImagesResponse(payload []byte) ([]byte, *execution.UsageE
 			switch mimeType {
 			case "image/png", "image/jpeg", "image/webp":
 			default:
-				return nil, nil, errAntigravityImagesResponse
+				return nil, nil, ErrInvalidResponse
 			}
 			if image != "" || data.Data == "" {
-				return nil, nil, errAntigravityImagesResponse
+				return nil, nil, ErrInvalidResponse
 			}
 			// 流式校验 Base64，避免额外分配整张解码图片。
 			decoded, err := io.Copy(io.Discard, base64.NewDecoder(base64.StdEncoding.Strict(), strings.NewReader(data.Data)))
 			if err != nil || decoded == 0 {
-				return nil, nil, errAntigravityImagesResponse
+				return nil, nil, ErrInvalidResponse
 			}
 			image = data.Data
 		}
 	}
 	if image == "" {
-		return nil, nil, errAntigravityImagesResponse
+		return nil, nil, ErrInvalidResponse
 	}
 	normalized, err := dialect.NewGemini().ExtractUsage(payload)
 	if err != nil {
@@ -147,7 +153,7 @@ func convertAntigravityImagesResponse(payload []byte) ([]byte, *execution.UsageE
 	if normalized.State != usage.StateMissing && normalized.Diagnostics == (usage.Diagnostics{}) {
 		var metadata map[string]json.RawMessage
 		if err := json.Unmarshal(root.UsageMetadata, &metadata); err != nil {
-			return nil, nil, errAntigravityImagesResponse
+			return nil, nil, ErrInvalidResponse
 		}
 		wireUsage := map[string]any{}
 		if raw, ok := metadata["promptTokenCount"]; ok {
@@ -166,7 +172,7 @@ func convertAntigravityImagesResponse(payload []byte) ([]byte, *execution.UsageE
 	}
 	body, err := json.Marshal(response)
 	if err != nil {
-		return nil, nil, errAntigravityImagesResponse
+		return nil, nil, ErrInvalidResponse
 	}
 	return body, evidence, nil
 }

--- a/internal/execution/geminiimage/convert_test.go
+++ b/internal/execution/geminiimage/convert_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"gpt-load/internal/dialect"
+	"gpt-load/internal/execution"
 )
 
 func geminiImageFixture(t *testing.T, metadata string) []byte {
@@ -25,21 +26,39 @@ func geminiImageFixture(t *testing.T, metadata string) []byte {
 	return body
 }
 
-func TestConvertRequestRejectsUnsupportedInputs(t *testing.T) {
-	tests := []string{
-		`{}`, `{"prompt":""}`, `{"prompt":"   "}`, `{"prompt":5}`,
-		`{"prompt":"draw","n":2}`, `{"prompt":"draw","n":1.5}`, `{"prompt":"draw","n":null}`,
-		`{"prompt":"draw","stream":true}`, `{"prompt":"draw","stream":"false"}`,
-		`{"prompt":"draw","response_format":"url"}`, `{"prompt":"draw","size":"1024x1024"}`,
-		`{"prompt":"draw","quality":"high"}`, `{"prompt":"draw","image":"private data"}`,
-		`{"prompt":"draw","unknown_option":true}`, `null`, `[]`,
-	}
-	for _, payload := range tests {
-		t.Run(payload, func(t *testing.T) {
-			if err := ValidateRequest([]byte(payload)); err == nil {
-				t.Fatal("unsupported Images request was accepted")
-			}
-		})
+func TestConvertRequestClassifiesRejectedInputs(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		conversion bool
+		payloads   []string
+	}{
+		{name: "invalid request", payloads: []string{
+			`{}`, `{"prompt":""}`, `{"prompt":"   "}`, `{"prompt":5}`, `null`, `[]`,
+			`{"prompt":"draw","n":1.5}`, `{"prompt":"draw","n":null}`, `{"prompt":"draw","n":0}`,
+			`{"prompt":"draw","stream":"false"}`, `{"prompt":"draw","stream":null}`,
+			`{"prompt":"draw","size":123}`, `{"prompt":"draw","quality":null}`,
+			`{"prompt":"draw","response_format":true}`,
+			`{"prompt":"draw","n":2,"size":123,"unknown_option":true}`,
+		}},
+		{name: "unsupported conversion", conversion: true, payloads: []string{
+			`{"prompt":"draw","n":2}`, `{"prompt":"draw","stream":true}`,
+			`{"prompt":"draw","response_format":"url"}`, `{"prompt":"draw","size":"1024x1024"}`,
+			`{"prompt":"draw","quality":"high"}`, `{"prompt":"draw","image":"private data"}`,
+			`{"prompt":"draw","unknown_option":true}`,
+		}},
+	} {
+		for _, payload := range test.payloads {
+			t.Run(test.name+"/"+payload, func(t *testing.T) {
+				err := ValidateRequest([]byte(payload))
+				var classified interface{ ConversionCode() string }
+				if err == nil || errors.As(err, &classified) != test.conversion {
+					t.Fatalf("request error = %v, want conversion unsupported = %t", err, test.conversion)
+				}
+				if test.conversion && classified.ConversionCode() != execution.ErrorCodeTargetConversionNotSupported {
+					t.Fatalf("conversion code = %s", classified.ConversionCode())
+				}
+			})
+		}
 	}
 	if err := ValidateRequest([]byte(`{"prompt":"draw"}`)); err != nil {
 		t.Fatalf("default request rejected: %v", err)

--- a/internal/execution/geminiimage/convert_test.go
+++ b/internal/execution/geminiimage/convert_test.go
@@ -1,0 +1,97 @@
+package geminiimage
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"gpt-load/internal/dialect"
+)
+
+func geminiImageFixture(t *testing.T, metadata string) []byte {
+	t.Helper()
+	object := map[string]any{
+		"candidates": []any{map[string]any{"content": map[string]any{"parts": []any{map[string]any{"inlineData": map[string]string{"mimeType": "image/png", "data": "aW1hZ2U="}}}}}},
+	}
+	if metadata != "" {
+		object["usageMetadata"] = json.RawMessage(metadata)
+	}
+	body, err := json.Marshal(object)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func TestConvertRequestRejectsUnsupportedInputs(t *testing.T) {
+	tests := []string{
+		`{}`, `{"prompt":""}`, `{"prompt":"   "}`, `{"prompt":5}`,
+		`{"prompt":"draw","n":2}`, `{"prompt":"draw","n":1.5}`, `{"prompt":"draw","n":null}`,
+		`{"prompt":"draw","stream":true}`, `{"prompt":"draw","stream":"false"}`,
+		`{"prompt":"draw","response_format":"url"}`, `{"prompt":"draw","size":"1024x1024"}`,
+		`{"prompt":"draw","quality":"high"}`, `{"prompt":"draw","image":"private data"}`,
+		`{"prompt":"draw","unknown_option":true}`, `null`, `[]`,
+	}
+	for _, payload := range tests {
+		t.Run(payload, func(t *testing.T) {
+			if err := ValidateRequest([]byte(payload)); err == nil {
+				t.Fatal("unsupported Images request was accepted")
+			}
+		})
+	}
+	if err := ValidateRequest([]byte(`{"prompt":"draw"}`)); err != nil {
+		t.Fatalf("default request rejected: %v", err)
+	}
+}
+
+func TestConvertResponseRejectsInvalidImages(t *testing.T) {
+	for name, payload := range map[string]string{
+		"invalid JSON": "not JSON private response",
+		"empty":        `{}`,
+		"blocked":      `{"promptFeedback":{"blockReason":"SAFETY"}}`,
+		"text only":    `{"candidates":[{"content":{"parts":[{"text":"private response"}]}}]}`,
+		"empty image":  `{"candidates":[{"content":{"parts":[{"inlineData":{"mimeType":"image/png","data":""}}]}}]}`,
+		"bad base64":   `{"candidates":[{"content":{"parts":[{"inlineData":{"mimeType":"image/png","data":"!private response!"}}]}}]}`,
+		"wrong MIME":   `{"candidates":[{"content":{"parts":[{"inlineData":{"mimeType":"text/plain","data":"AA=="}}]}}]}`,
+		"two images":   `{"candidates":[{"content":{"parts":[{"inlineData":{"mimeType":"image/png","data":"AA=="}},{"inlineData":{"mimeType":"image/png","data":"AA=="}}]}}]}`,
+		"thought only": `{"candidates":[{"content":{"parts":[{"thought":true,"inlineData":{"mimeType":"image/png","data":"AA=="}}]}}]}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, _, err := ConvertResponse([]byte(payload))
+			if err == nil {
+				t.Fatal("invalid image output was accepted")
+			}
+			if !errors.Is(err, ErrInvalidResponse) || strings.Contains(err.Error(), "private response") {
+				t.Fatalf("invalid image error = %v", err)
+			}
+		})
+	}
+}
+
+func TestConvertResponsePreservesGeminiUsageStates(t *testing.T) {
+	for name, metadata := range map[string]string{
+		"missing":         "",
+		"empty":           `{}`,
+		"partial":         `{"promptTokenCount":10}`,
+		"invalid":         `{"promptTokenCount":"invalid","candidatesTokenCount":20}`,
+		"negative cached": `{"promptTokenCount":10,"cachedContentTokenCount":20,"candidatesTokenCount":5}`,
+		"missing invalid": `{"promptTokenCount":"invalid","candidatesTokenCount":"invalid"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			upstream := geminiImageFixture(t, metadata)
+			_, evidence, err := ConvertResponse(upstream)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want, err := dialect.NewGemini().ExtractUsage(upstream)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if evidence == nil || !reflect.DeepEqual(evidence.Normalized, want) {
+				t.Fatalf("Images canonical usage = %+v, want %+v", evidence, want)
+			}
+		})
+	}
+}

--- a/internal/gateway/execution_forward.go
+++ b/internal/gateway/execution_forward.go
@@ -52,7 +52,7 @@ func (forwarder *ExecutionForwarder) Forward(
 		input.ClientProtocol == protocol.OpenAIEmbeddings) && input.ObserveUsage &&
 		result.HasResponse() && result.StatusCode >= http.StatusOK &&
 		result.StatusCode < http.StatusMultipleChoices &&
-		result.Usage.State == usage.StateMissing && forwarder.usageCapture != nil {
+		executionResult.Usage == nil && result.Usage.State == usage.StateMissing && forwarder.usageCapture != nil {
 		result.Usage = forwarder.usageCapture.extractNonStreamingPlain(
 			input.Dialect,
 			result.ClassificationBody,

--- a/internal/gateway/execution_forward.go
+++ b/internal/gateway/execution_forward.go
@@ -755,7 +755,7 @@ func newExecutionAttemptSpec(input ForwardInput) (execution.AttemptSpec, error) 
 			return execution.AttemptSpec{}, err
 		}
 		spec.Body = body
-		platformheader.StripRequestRepresentationMetadata(spec.Header)
+		platformheader.StripRepresentationMetadata(spec.Header)
 	}
 	if err := spec.Validate(); err != nil {
 		return execution.AttemptSpec{}, err

--- a/internal/gateway/handler.go
+++ b/internal/gateway/handler.go
@@ -547,7 +547,7 @@ func (handler *Handler) Handle(ginContext *gin.Context) {
 		return
 	}
 	requestHeaders := ginContext.Request.Header.Clone()
-	platformheader.StripRequestRepresentationMetadata(requestHeaders)
+	platformheader.StripRepresentationMetadata(requestHeaders)
 	parsed := &dialect.ParsedRequest{
 		Method:   ginContext.Request.Method,
 		Path:     ginContext.Request.URL.Path,

--- a/internal/gateway/images_conversion_test.go
+++ b/internal/gateway/images_conversion_test.go
@@ -1,0 +1,97 @@
+package gateway
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/dialect"
+	"gpt-load/internal/platform/config"
+	"gpt-load/internal/protocol"
+	"gpt-load/internal/state"
+)
+
+func TestGatewayImagesConversionFailureUsesExistingFallback(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		count := 2
+		if stream {
+			count = 1
+		}
+		for _, native := range []bool{false, true} {
+			t.Run(fmt.Sprintf("stream=%t/native=%t", stream, native), func(t *testing.T) {
+				var convertedCalls, nativeCalls atomic.Int32
+				convertedUpstream := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+					convertedCalls.Add(1)
+					writer.WriteHeader(http.StatusInternalServerError)
+				}))
+				defer convertedUpstream.Close()
+				nativeUpstream := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+					nativeCalls.Add(1)
+					var received struct {
+						Count  int  `json:"n"`
+						Stream bool `json:"stream"`
+					}
+					if err := json.NewDecoder(request.Body).Decode(&received); err != nil || received.Count != count || received.Stream != stream {
+						t.Errorf("native parameters = %+v, decode error = %v", received, err)
+					}
+					body := `{"data":[{"b64_json":"aW1hZ2U="},{"b64_json":"aW1hZ2U="}]}`
+					writer.Header().Set("Content-Type", "application/json")
+					if stream {
+						writer.Header().Set("Content-Type", "text/event-stream")
+						body = "data: {\"type\":\"image_generation.completed\",\"b64_json\":\"aW1hZ2U=\"}\n\n"
+					}
+					if _, err := writer.Write([]byte(body)); err != nil {
+						t.Error(err)
+					}
+				}))
+				defer nativeUpstream.Close()
+				params, err := json.Marshal(map[string]string{"base_url": convertedUpstream.URL + "/v1beta"})
+				if err != nil {
+					t.Fatal(err)
+				}
+				groups := []dialectGatewayGroup{{
+					id: 1, name: "gemini", channelID: channel.Gemini, params: params, apiKeys: []string{"gemini-key-one", "gemini-key-two"},
+				}}
+				if native {
+					nativeParams, err := json.Marshal(map[string]string{"base_url": nativeUpstream.URL + "/v1"})
+					if err != nil {
+						t.Fatal(err)
+					}
+					groups = append(groups, dialectGatewayGroup{id: 2, name: "native", channelID: channel.OpenAI, params: nativeParams, apiKeys: []string{"native-key"}})
+				}
+				engine, registry := newDialectGatewayEngineWithSystemSettings(t, protocol.OpenAIImages, "public-image",
+					dialect.NewSet(dialect.NewOpenAIImages()), newTestExecutionForwarder(t),
+					config.Settings{state.SettingRouteStrategy: string(state.RouteStrategyWeightedMix)}, groups...)
+				before := registry.Snapshot()
+				body := fmt.Sprintf(`{"model":"public-image","prompt":"draw","n":%d,"stream":%t}`, count, stream)
+				request := httptest.NewRequest(http.MethodPost, "/v1/images/generations", strings.NewReader(body))
+				request.Header.Set("Authorization", "Bearer gl-client")
+				response := httptest.NewRecorder()
+				engine.ServeHTTP(response, request)
+				wantStatus, wantAttempts := http.StatusUnprocessableEntity, "1"
+				if native {
+					wantStatus, wantAttempts = http.StatusOK, "2"
+				}
+				if response.Code != wantStatus || response.Header().Get(debugHeaderAttempts) != wantAttempts || convertedCalls.Load() != 0 {
+					t.Fatalf("response = %d %s, attempts = %s, conversion dispatches = %d", response.Code, response.Body.String(), response.Header().Get(debugHeaderAttempts), convertedCalls.Load())
+				}
+				if native {
+					if nativeCalls.Load() != 1 {
+						t.Fatalf("native dispatches = %d", nativeCalls.Load())
+					}
+					if !strings.Contains(response.Body.String(), `"b64_json":"aW1hZ2U="`) {
+						t.Fatalf("native result was lost: %s", response.Body.String())
+					}
+				} else if !strings.Contains(response.Body.String(), `"code":"protocol_conversion_unsupported"`) || !reflect.DeepEqual(before, registry.Snapshot()) {
+					t.Fatalf("conversion failure changed response or credential health: %s", response.Body.String())
+				}
+			})
+		}
+	}
+}

--- a/internal/gateway/models_test.go
+++ b/internal/gateway/models_test.go
@@ -127,7 +127,7 @@ func TestVisibleOpenAIModelIDsUnionsChatAndResponses(t *testing.T) {
 					protocol.OpenAIImages: {},
 				},
 			}},
-			want: []string{"chat-only", "shared"},
+			want: []string{"both", "chat-only", "shared"},
 		},
 	}
 

--- a/internal/platform/httpheader/request_representation.go
+++ b/internal/platform/httpheader/request_representation.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-var requestRepresentationMetadataNames = [...]string{
+var representationMetadataNames = [...]string{
 	"Content-Encoding",
 	"Content-Length",
 	"ETag",
@@ -27,19 +27,18 @@ func NormalizeUpstreamRequestRepresentation(request *http.Request, finalBodyLeng
 	} else {
 		request.Header = request.Header.Clone()
 	}
-	StripRequestRepresentationMetadata(request.Header)
+	StripRepresentationMetadata(request.Header)
 	deleteField(request.Header, "Accept-Encoding")
 	request.Header.Set("Accept-Encoding", "identity")
 	request.ContentLength = finalBodyLength
 }
 
-// StripRequestRepresentationMetadata removes headers bound to the original
-// HTTP request representation, regardless of their field-name casing.
-func StripRequestRepresentationMetadata(headers http.Header) {
+// StripRepresentationMetadata 清理绑定原始 HTTP 正文的元数据，适用于请求与响应。
+func StripRepresentationMetadata(headers http.Header) {
 	if headers == nil {
 		return
 	}
-	for _, name := range requestRepresentationMetadataNames {
+	for _, name := range representationMetadataNames {
 		deleteField(headers, name)
 	}
 }

--- a/internal/platform/httpheader/request_representation_test.go
+++ b/internal/platform/httpheader/request_representation_test.go
@@ -81,7 +81,7 @@ func TestNormalizeUpstreamRequestRepresentationInitializesNilHeader(t *testing.T
 	}
 }
 
-func TestStripRequestRepresentationMetadataRemovesCaseCollidingFields(t *testing.T) {
+func TestStripRepresentationMetadataRemovesCaseCollidingFields(t *testing.T) {
 	headers := http.Header{
 		"Content-Encoding": {"gzip"},
 		"content-length":   {"123"},
@@ -96,7 +96,7 @@ func TestStripRequestRepresentationMetadataRemovesCaseCollidingFields(t *testing
 		"Content-Type":     {"application/json"},
 	}
 
-	StripRequestRepresentationMetadata(headers)
+	StripRepresentationMetadata(headers)
 
 	for _, name := range []string{
 		"Content-Encoding",

--- a/internal/scheduler/channel_scheduler_test.go
+++ b/internal/scheduler/channel_scheduler_test.go
@@ -85,7 +85,7 @@ func TestIteratorDoesNotLetConvertedPreferenceBypassNativeTier(t *testing.T) {
 	}
 }
 
-func TestImagesGenerationPrefersNativeBeforeAntigravityConversion(t *testing.T) {
+func TestImagesGenerationPrefersNativeBeforeGeminiConversions(t *testing.T) {
 	snapshot, err := state.Compile(state.CompileInput{
 		ChannelRegistry: channel.NewRegistry(),
 		Groups: []state.GroupConfig{
@@ -93,13 +93,15 @@ func TestImagesGenerationPrefersNativeBeforeAntigravityConversion(t *testing.T) 
 				Models: []state.ModelConfig{{ID: "gemini-3.1-flash-image", Alias: "public"}}, Enabled: true},
 			{ID: 2, ChannelID: channel.OpenAI, ConnectionType: "api_key", Params: json.RawMessage(`{}`),
 				Models: []state.ModelConfig{{ID: "gpt-image-2", Alias: "public"}}, Enabled: true},
+			{ID: 3, ChannelID: channel.Gemini, ConnectionType: "api_key", Params: json.RawMessage(`{}`),
+				Models: []state.ModelConfig{{ID: "gemini-3.1-flash-image", Alias: "public"}}, Enabled: true},
 		},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	iterator := New(snapshot, fakeCredentialSource{keys: []state.CredentialMeta{
-		{ID: 11, GroupID: 1}, {ID: 21, GroupID: 2},
+		{ID: 11, GroupID: 1}, {ID: 21, GroupID: 2}, {ID: 31, GroupID: 3},
 	}}, Query{
 		ClientProtocol: protocol.OpenAIImages, Operation: execution.OperationImagesGenerate,
 		RouteRequirement: execution.RouteRequirementAny, ExternalModel: modelPointer("public"),
@@ -113,6 +115,11 @@ func TestImagesGenerationPrefersNativeBeforeAntigravityConversion(t *testing.T) 
 	if err != nil || second.GroupID != 1 || second.RouteMode != channel.RouteConverted ||
 		second.UpstreamModelID == nil || *second.UpstreamModelID != "gemini-3.1-flash-image" {
 		t.Fatalf("second selection = %+v, error = %v", second, err)
+	}
+	third, err := iterator.Next()
+	if err != nil || third.GroupID != 3 || third.RouteMode != channel.RouteConverted ||
+		third.UpstreamModelID == nil || *third.UpstreamModelID != "gemini-3.1-flash-image" {
+		t.Fatalf("third selection = %+v, error = %v", third, err)
 	}
 	if got := snapshot.ExecutionCandidates[protocol.OpenAIImages][execution.OperationImagesEdit]["public"]; len(got) != 1 || got[0].GroupID != 2 {
 		t.Fatalf("image edits targets = %+v", got)

--- a/internal/scheduler/channel_scheduler_test.go
+++ b/internal/scheduler/channel_scheduler_test.go
@@ -85,6 +85,40 @@ func TestIteratorDoesNotLetConvertedPreferenceBypassNativeTier(t *testing.T) {
 	}
 }
 
+func TestImagesGenerationPrefersNativeBeforeAntigravityConversion(t *testing.T) {
+	snapshot, err := state.Compile(state.CompileInput{
+		ChannelRegistry: channel.NewRegistry(),
+		Groups: []state.GroupConfig{
+			{ID: 1, ChannelID: channel.Antigravity, ConnectionType: "subscription", Params: json.RawMessage(`{}`),
+				Models: []state.ModelConfig{{ID: "gemini-3.1-flash-image", Alias: "public"}}, Enabled: true},
+			{ID: 2, ChannelID: channel.OpenAI, ConnectionType: "api_key", Params: json.RawMessage(`{}`),
+				Models: []state.ModelConfig{{ID: "gpt-image-2", Alias: "public"}}, Enabled: true},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	iterator := New(snapshot, fakeCredentialSource{keys: []state.CredentialMeta{
+		{ID: 11, GroupID: 1}, {ID: 21, GroupID: 2},
+	}}, Query{
+		ClientProtocol: protocol.OpenAIImages, Operation: execution.OperationImagesGenerate,
+		RouteRequirement: execution.RouteRequirementAny, ExternalModel: modelPointer("public"),
+		PreferredCredentialID: 11,
+	})
+	first, err := iterator.Next()
+	if err != nil || first.GroupID != 2 || first.RouteMode != channel.RouteNative {
+		t.Fatalf("first selection = %+v, error = %v", first, err)
+	}
+	second, err := iterator.Next()
+	if err != nil || second.GroupID != 1 || second.RouteMode != channel.RouteConverted ||
+		second.UpstreamModelID == nil || *second.UpstreamModelID != "gemini-3.1-flash-image" {
+		t.Fatalf("second selection = %+v, error = %v", second, err)
+	}
+	if got := snapshot.ExecutionCandidates[protocol.OpenAIImages][execution.OperationImagesEdit]["public"]; len(got) != 1 || got[0].GroupID != 2 {
+		t.Fatalf("image edits targets = %+v", got)
+	}
+}
+
 func TestIteratorSkipGroupAndAllowedCredentialIDsApplyAcrossRouteTiers(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### 关联 Issue / Related Issue
<!-- 请填写此 PR 关联的 issue 编号，例如：Closes #123 / Please link the issue number, e.g., Closes #123 -->
Closes #538

### 变更内容 / Change Content
<!-- 请简要描述本次变更的核心内容 / Please briefly describe the core changes of this PR -->
- [ ] Bug 修复 / Bug fix
- [x] 新功能 / New feature
- [ ] 其他改动 / Other changes

<!-- 请在下方详细描述你的变更 / Please describe your changes in detail below -->
为 Antigravity 订阅渠道和 Google Gemini API Key 渠道增加 `POST /v1/images/generations` 单向协议转换。此前这两个渠道没有 OpenAI Images 候选路由；现在客户端可通过该端点调用配置的 Gemini 图像模型，并收到 `data[].b64_json` 图片结果。

- 两个渠道共用 `geminiimage` 的请求校验、请求/响应转换和用量处理，分别复用既有 CPA、Bifrost 执行链路。
- 沿用现有路由策略；保留缓存输入与思考输出的用量语义，复用现有调度、凭据、健康和价格机制，无数据库迁移或新增依赖。
- 本次支持单张、非流式、Base64 返回：`n` 省略或 `1`，`stream` 省略或 `false`，`response_format` 省略或 `b64_json`，`size` / `quality` 省略或 `auto`。超出转换能力的参数在发送上游前归类为 `conversion_unsupported`，复用现有候选回退；全部候选均不支持时返回 HTTP 422，非法请求仍为 HTTP 400。不包含图片编辑、流式转换或 Imagen `predict` 接口。
- 无有效图片时返回安全错误；已发送请求的失败保持保守重放规则，缺失/非法用量不会被转换成正常计价数据。

验证：提交前重新运行 `make check`，包括后端全量测试、Go vet/build、前端 lint/format/类型检查/构建。新增测试覆盖两条执行链路到本地模拟上游的转换、认证与模型别名、用量及价格、原生优先、混合调度下的原生回退、400/422 错误分类、凭据健康及响应边界。尚未使用真实订阅账号或 Gemini API Key 生图验收。

公开文档未改动，支持边界已在本说明列明；本地 `docs/` 实施文档不随 PR 提交。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [ ] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.
