### PR TITLE
refactor(cooldown): 精简模型冷却展示与管理接口

### DIFF
--- a/internal/control/credential_collection_helpers.go
+++ b/internal/control/credential_collection_helpers.go
@@ -48,19 +48,13 @@ func parseCredentialCollectionQuery(rawQuery string) (CredentialCollectionQuery,
 	}
 	for key, entries := range values {
 		switch key {
-		case "q", "status", "page", "page_size", "model_cooldown":
+		case "q", "status", "page", "page_size":
 		default:
 			return CredentialCollectionQuery{}, app_errors.ErrBadRequest
 		}
 		if len(entries) != 1 {
 			return CredentialCollectionQuery{}, app_errors.ErrBadRequest
 		}
-	}
-	if entries, exists := values["model_cooldown"]; exists {
-		if entries[0] != "true" {
-			return CredentialCollectionQuery{}, app_errors.ErrBadRequest
-		}
-		query.ModelCooldown = true
 	}
 	if entries, exists := values["q"]; exists {
 		query.Query = strings.TrimSpace(entries[0])

--- a/internal/control/credential_mutations.go
+++ b/internal/control/credential_mutations.go
@@ -785,9 +785,6 @@ func summarizeGroupRuntimeCredentials(
 			continue
 		}
 		summary.Total++
-		if hasModelCooldown(view.ModelCooldowns, observedAt) {
-			summary.ModelCooldown++
-		}
 		switch classifyHealthKey(groupView, view, observedAt) {
 		case healthBucketAvailable:
 			summary.Available++

--- a/internal/control/credentials.go
+++ b/internal/control/credentials.go
@@ -43,11 +43,10 @@ type CredentialRevealResult struct {
 }
 
 type CredentialCollectionQuery struct {
-	Query         string
-	Status        *string
-	ModelCooldown bool
-	Page          int
-	PageSize      int
+	Query    string
+	Status   *string
+	Page     int
+	PageSize int
 }
 
 type CredentialCollectionResponse struct {
@@ -59,12 +58,11 @@ type CredentialCollectionResponse struct {
 }
 
 type CredentialSummaryResponse struct {
-	Total         int `json:"total"`
-	Available     int `json:"available"`
-	Cooldown      int `json:"cooldown"`
-	Blacklisted   int `json:"blacklisted"`
-	Disabled      int `json:"disabled"`
-	ModelCooldown int `json:"model_cooldown"`
+	Total       int `json:"total"`
+	Available   int `json:"available"`
+	Cooldown    int `json:"cooldown"`
+	Blacklisted int `json:"blacklisted"`
+	Disabled    int `json:"disabled"`
 }
 
 type CredentialAccountResponse struct {
@@ -468,9 +466,6 @@ func (s *Service) mapCredentialCollection(
 func summarizeCredentialCollection(records []credentialCollectionRecord) CredentialSummaryResponse {
 	summary := CredentialSummaryResponse{Total: len(records)}
 	for _, record := range records {
-		if len(record.item.ModelCooldowns) > 0 {
-			summary.ModelCooldown++
-		}
 		switch record.bucket {
 		case healthBucketAvailable:
 			summary.Available++
@@ -487,9 +482,6 @@ func summarizeCredentialCollection(records []credentialCollectionRecord) Credent
 
 func credentialCollectionMatches(record credentialCollectionRecord, query CredentialCollectionQuery) bool {
 	if query.Status != nil && record.item.EffectiveStatus != *query.Status {
-		return false
-	}
-	if query.ModelCooldown && len(record.item.ModelCooldowns) == 0 {
 		return false
 	}
 	if query.Query == "" {

--- a/internal/control/health.go
+++ b/internal/control/health.go
@@ -21,18 +21,22 @@ type RequestLogStatsReader interface {
 }
 
 type healthCountsResponse struct {
+	Credentials int `json:"credentials"`
+	Available   int `json:"available"`
+	Cooldown    int `json:"cooldown"`
+	Blacklisted int `json:"blacklisted"`
+}
+
+type healthGroupCountsResponse struct {
+	healthCountsResponse
 	ModelCooldown int `json:"model_cooldown"`
-	Credentials   int `json:"credentials"`
-	Available     int `json:"available"`
-	Cooldown      int `json:"cooldown"`
-	Blacklisted   int `json:"blacklisted"`
 }
 
 type healthGroupResponse struct {
-	ID      uint                 `json:"id"`
-	Name    string               `json:"name"`
-	Enabled bool                 `json:"enabled"`
-	Counts  healthCountsResponse `json:"counts"`
+	ID      uint                      `json:"id"`
+	Name    string                    `json:"name"`
+	Enabled bool                      `json:"enabled"`
+	Counts  healthGroupCountsResponse `json:"counts"`
 }
 
 type healthRecoveryResponse struct {
@@ -98,20 +102,19 @@ type requestLogHealthResponse struct {
 }
 
 type runtimeHealthResponse struct {
-	ModelCooldownCredentials []healthModelCooldownCredentialResponse `json:"model_cooldown_credentials"`
-	ObservedAtMS             int64                                   `json:"observed_at_ms"`
-	Version                  string                                  `json:"version"`
-	UptimeSeconds            int64                                   `json:"uptime_seconds"`
-	SnapshotRevision         uint64                                  `json:"snapshot_revision"`
-	StatsWindowSeconds       int64                                   `json:"stats_window_seconds"`
-	Counts                   healthCountsResponse                    `json:"counts"`
-	Groups                   []healthGroupResponse                   `json:"groups"`
-	CooldownCredentials      []healthProblemCredentialResponse       `json:"cooldown_credentials"`
-	BlacklistedCredentials   []healthProblemCredentialResponse       `json:"blacklisted_credentials"`
-	LowQuotaCredentials      []healthQuotaCredentialResponse         `json:"low_quota_credentials"`
-	ExpiringResetCredits     []healthExpiringResetCreditResponse     `json:"expiring_reset_credits"`
-	BlockedAccessKeys        []healthAccessKeyCostLimitResponse      `json:"blocked_access_keys"`
-	RequestLog               requestLogHealthResponse                `json:"request_log"`
+	ObservedAtMS           int64                               `json:"observed_at_ms"`
+	Version                string                              `json:"version"`
+	UptimeSeconds          int64                               `json:"uptime_seconds"`
+	SnapshotRevision       uint64                              `json:"snapshot_revision"`
+	StatsWindowSeconds     int64                               `json:"stats_window_seconds"`
+	Counts                 healthCountsResponse                `json:"counts"`
+	Groups                 []healthGroupResponse               `json:"groups"`
+	CooldownCredentials    []healthProblemCredentialResponse   `json:"cooldown_credentials"`
+	BlacklistedCredentials []healthProblemCredentialResponse   `json:"blacklisted_credentials"`
+	LowQuotaCredentials    []healthQuotaCredentialResponse     `json:"low_quota_credentials"`
+	ExpiringResetCredits   []healthExpiringResetCreditResponse `json:"expiring_reset_credits"`
+	BlockedAccessKeys      []healthAccessKeyCostLimitResponse  `json:"blocked_access_keys"`
+	RequestLog             requestLogHealthResponse            `json:"request_log"`
 }
 
 type healthAccessKeyCostLimitResponse struct {
@@ -270,16 +273,15 @@ func (service *Service) RuntimeHealth() (runtimeHealthResponse, error) {
 		return runtimeHealthResponse{}, fmt.Errorf("map runtime health observed_at_ms: %w", err)
 	}
 	result := runtimeHealthResponse{
-		ModelCooldownCredentials: []healthModelCooldownCredentialResponse{},
-		ObservedAtMS:             observedAtMS,
-		SnapshotRevision:         observation.snapshot.Revision,
-		StatsWindowSeconds:       int64(health.StatsWindow / time.Second),
-		Groups:                   []healthGroupResponse{},
-		CooldownCredentials:      []healthProblemCredentialResponse{},
-		BlacklistedCredentials:   []healthProblemCredentialResponse{},
-		LowQuotaCredentials:      []healthQuotaCredentialResponse{},
-		ExpiringResetCredits:     []healthExpiringResetCreditResponse{},
-		BlockedAccessKeys:        []healthAccessKeyCostLimitResponse{},
+		ObservedAtMS:           observedAtMS,
+		SnapshotRevision:       observation.snapshot.Revision,
+		StatsWindowSeconds:     int64(health.StatsWindow / time.Second),
+		Groups:                 []healthGroupResponse{},
+		CooldownCredentials:    []healthProblemCredentialResponse{},
+		BlacklistedCredentials: []healthProblemCredentialResponse{},
+		LowQuotaCredentials:    []healthQuotaCredentialResponse{},
+		ExpiringResetCredits:   []healthExpiringResetCreditResponse{},
+		BlockedAccessKeys:      []healthAccessKeyCostLimitResponse{},
 	}
 	groupIDs := make([]uint, 0, len(observation.snapshot.GroupCatalog))
 	for groupID := range observation.snapshot.GroupCatalog {
@@ -305,23 +307,10 @@ func (service *Service) RuntimeHealth() (runtimeHealthResponse, error) {
 			}
 		}
 		if hasModelCooldown(key.ModelCooldowns, observation.observedAt) {
-			result.Counts.ModelCooldown++
 			result.Groups[index].Counts.ModelCooldown++
-			if len(result.ModelCooldownCredentials) < healthProblemCredentialDetailLimit {
-				// 停用分组仍保留模型冷却，身份展示使用完整分组目录。
-				identity, err := service.healthProblemCredentialIdentity(observation.problemCiphertexts, key.ID, group.ChannelID, group.ConnectionType)
-				if err != nil {
-					return runtimeHealthResponse{}, err
-				}
-				limits, err := modelCooldownResponses(key.ModelCooldowns, observation.observedAt)
-				if err != nil {
-					return runtimeHealthResponse{}, err
-				}
-				result.ModelCooldownCredentials = append(result.ModelCooldownCredentials, healthModelCooldownCredentialResponse{CredentialID: key.ID, GroupID: key.GroupID, GroupName: group.Name, Identity: identity, ModelCooldowns: limits})
-			}
 		}
 		addHealthCount(&result.Counts, bucket)
-		addHealthCount(&result.Groups[index].Counts, bucket)
+		addHealthCount(&result.Groups[index].Counts.healthCountsResponse, bucket)
 		// 额度只用于管理面展示，不参与健康分桶或调度；低额度凭据在这里单列提示。
 		if bucket == healthBucketAvailable || bucket == healthBucketCooldown {
 			if remaining := key.ObservedQuotaRemaining(); remaining != nil &&

--- a/internal/control/health_test.go
+++ b/internal/control/health_test.go
@@ -137,7 +137,7 @@ func TestRuntimeHealthReturnsMutuallyExclusiveCurrentState(t *testing.T) {
 		got.Groups[1].ID != 2 || got.Groups[2].ID != 3 || got.Groups[3].ID != 4 {
 		t.Fatalf("group order = %#v", got.Groups)
 	}
-	if got.Groups[0].Counts != (healthCountsResponse{
+	if got.Groups[0].Counts.healthCountsResponse != (healthCountsResponse{
 		Credentials: 3, Available: 1, Cooldown: 1, Blacklisted: 1,
 	}) {
 		t.Fatalf("active group counts = %#v", got.Groups[0].Counts)

--- a/internal/control/model_cooldown.go
+++ b/internal/control/model_cooldown.go
@@ -10,14 +10,6 @@ type ModelCooldownResponse struct {
 	CooldownUntilMS int64  `json:"cooldown_until_ms"`
 }
 
-type healthModelCooldownCredentialResponse struct {
-	CredentialID   uint                    `json:"credential_id"`
-	GroupID        uint                    `json:"group_id"`
-	GroupName      string                  `json:"group_name"`
-	Identity       string                  `json:"identity"`
-	ModelCooldowns []ModelCooldownResponse `json:"model_cooldowns"`
-}
-
 func hasModelCooldown(limits map[string]time.Time, now time.Time) bool {
 	for _, until := range limits {
 		if until.After(now) {

--- a/internal/control/model_cooldown_test.go
+++ b/internal/control/model_cooldown_test.go
@@ -1,6 +1,7 @@
 package control
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -71,7 +72,7 @@ func TestModelCooldownCollectionAndHealthKeepIndependentAccountStatus(t *testing
 	for _, model := range []string{"b", "a"} {
 		fixture.registry.SetModelCooldown(ref, model, now.Add(time.Hour), now)
 	}
-	query, parseErr := parseCredentialCollectionQuery("model_cooldown=true")
+	query, parseErr := parseCredentialCollectionQuery("")
 	if parseErr != nil {
 		t.Fatal(parseErr)
 	}
@@ -87,7 +88,7 @@ func TestModelCooldownCollectionAndHealthKeepIndependentAccountStatus(t *testing
 	if err != nil {
 		t.Fatal(err)
 	}
-	if collection.Summary.ModelCooldown != 1 || collection.Summary.Available != 2 || collection.Pagination.TotalItems != 1 || len(collection.Items) != 1 {
+	if collection.Summary.Available != 2 || collection.Pagination.TotalItems != 2 || len(collection.Items) != 2 {
 		t.Fatalf("collection = %#v", collection)
 	}
 	item := collection.Items[0]
@@ -98,12 +99,38 @@ func TestModelCooldownCollectionAndHealthKeepIndependentAccountStatus(t *testing
 	if err != nil {
 		t.Fatal(err)
 	}
-	if health.Counts.ModelCooldown != 1 || len(health.ModelCooldownCredentials) != 1 || len(health.CooldownCredentials) != 0 {
+	if health.Counts.Available != 2 || health.Groups[0].Counts.ModelCooldown != 1 || len(health.CooldownCredentials) != 0 {
 		t.Fatalf("health = %#v", health)
+	}
+	// 删除的展示不再保留对应汇总字段和明细响应。
+	for name, value := range map[string]any{
+		"credential_summary": collection.Summary,
+		"health_counts":      health.Counts,
+		"health":             health,
+	} {
+		payload, err := json.Marshal(value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(payload, &fields); err != nil {
+			t.Fatal(err)
+		}
+		for _, removed := range []string{"model_cooldown", "model_cooldown_credentials"} {
+			if _, exists := fields[removed]; exists {
+				t.Errorf("%s still exposes %s", name, removed)
+			}
+		}
 	}
 }
 
-func TestRuntimeHealthKeepsModelCooldownIdentityWhenGroupIsDisabled(t *testing.T) {
+func TestCredentialCollectionRejectsRemovedModelCooldownFilter(t *testing.T) {
+	if _, err := parseCredentialCollectionQuery("model_cooldown=true"); err == nil {
+		t.Fatal("removed model cooldown filter is still accepted")
+	}
+}
+
+func TestRuntimeHealthCountsModelCooldownWhenGroupIsDisabled(t *testing.T) {
 	for _, connectionType := range []string{"api_key", "subscription"} {
 		t.Run(connectionType, func(t *testing.T) {
 			var fixture serviceFixture
@@ -122,7 +149,7 @@ func TestRuntimeHealthKeepsModelCooldownIdentityWhenGroupIsDisabled(t *testing.T
 				t.Fatal("model cooldown was rejected")
 			}
 			before, err := fixture.service.RuntimeHealth()
-			if err != nil || len(before.ModelCooldownCredentials) != 1 {
+			if err != nil || len(before.Groups) != 1 || before.Groups[0].Counts.ModelCooldown != 1 {
 				t.Fatalf("initial health = %#v, %v", before, err)
 			}
 			for _, enabled := range []bool{false, true} {
@@ -135,13 +162,8 @@ func TestRuntimeHealthKeepsModelCooldownIdentityWhenGroupIsDisabled(t *testing.T
 				if err != nil {
 					t.Fatalf("health with group enabled=%t: %v", enabled, err)
 				}
-				if got.Counts.ModelCooldown != 1 || len(got.ModelCooldownCredentials) != 1 {
+				if len(got.Groups) != 1 || got.Groups[0].Counts.ModelCooldown != 1 {
 					t.Fatalf("model cooldown disappeared after group enabled=%t: %#v", enabled, got)
-				}
-				detail := got.ModelCooldownCredentials[0]
-				if detail.CredentialID != credentialID || detail.GroupID != groupID ||
-					detail.Identity != before.ModelCooldownCredentials[0].Identity || len(detail.ModelCooldowns) != 1 {
-					t.Fatalf("model cooldown identity changed: %#v", detail)
 				}
 				if len(got.Groups) != 1 || got.Groups[0].Enabled != enabled || (got.Counts.Credentials > 0) != enabled {
 					t.Fatalf("group health changed: %#v", got)

--- a/internal/control/runtime_observation.go
+++ b/internal/control/runtime_observation.go
@@ -93,7 +93,6 @@ func (service *Service) captureRuntimeHealthObservation() (
 	problemCiphertexts := make(map[uint]string)
 	cooldownDetails := 0
 	blacklistedDetails := 0
-	modelCooldownDetails := 0
 	for _, key := range keys {
 		group, exists := snapshot.GroupCatalog[key.GroupID]
 		if !exists {
@@ -112,10 +111,6 @@ func (service *Service) captureRuntimeHealthObservation() (
 		}
 		if bucket == healthBucketBlacklisted && blacklistedDetails < healthProblemCredentialDetailLimit {
 			blacklistedDetails++
-			needsIdentity = true
-		}
-		if hasModelCooldown(key.ModelCooldowns, observedAt) && modelCooldownDetails < healthProblemCredentialDetailLimit {
-			modelCooldownDetails++
 			needsIdentity = true
 		}
 		if !needsIdentity {

--- a/internal/control/wire_v3_contract_test.go
+++ b/internal/control/wire_v3_contract_test.go
@@ -91,7 +91,7 @@ func TestHealthAndRouteInspectionUseCredentialWireNames(t *testing.T) {
 		t.Fatalf("json.Marshal(health) error = %v", err)
 	}
 	for _, token := range []string{
-		`"counts":{"model_cooldown":0,"credentials":1,"available":1,"cooldown":0,"blacklisted":0}`,
+		`"counts":{"credentials":1,"available":1,"cooldown":0,"blacklisted":0}`,
 		`"cooldown_credentials":[{"credential_id":7`,
 		`"blacklisted_credentials":[]`,
 	} {

--- a/web/src/api/control/types.ts
+++ b/web/src/api/control/types.ts
@@ -346,7 +346,6 @@ export interface CredentialTestResultDto {
 }
 
 export interface CredentialSummaryDto {
-  model_cooldown: number
   total: number
   available: number
   cooldown: number
@@ -370,7 +369,6 @@ export interface CredentialCollectionDto {
 }
 
 export interface CredentialCollectionFilters {
-  model_cooldown?: true
   q?: string
   status?: CredentialStatus
   page: number
@@ -402,7 +400,6 @@ export interface CredentialCounts {
 }
 
 export interface HealthCredentialCountsDto {
-  model_cooldown: number
   credentials: number
   available: number
   cooldown: number
@@ -413,7 +410,7 @@ export interface HealthGroupDto {
   id: number
   name: string
   enabled: boolean
-  counts: HealthCredentialCountsDto
+  counts: HealthCredentialCountsDto & { model_cooldown: number }
 }
 
 export interface HealthRecoveryDto {
@@ -459,16 +456,7 @@ export interface RequestLogHealthDto {
   last_retention_failure_at_ms: number | null
 }
 
-export interface HealthModelCooldownCredentialDto {
-  credential_id: number
-  group_id: number
-  group_name: string
-  identity: string
-  model_cooldowns: ModelCooldownDto[]
-}
-
 export interface RuntimeHealthDto {
-  model_cooldown_credentials: HealthModelCooldownCredentialDto[]
   observed_at_ms: number
   version: string
   uptime_seconds: number

--- a/web/src/app/query-keys.ts
+++ b/web/src/app/query-keys.ts
@@ -35,7 +35,6 @@ export function normalizeCredentialCollectionFilters(
   const query = filters.q?.trim()
   if (query) normalized.q = query
   if (filters.status !== undefined) normalized.status = filters.status
-  if (filters.model_cooldown) normalized.model_cooldown = true
   return normalized
 }
 

--- a/web/src/app/resources/credentials.ts
+++ b/web/src/app/resources/credentials.ts
@@ -87,7 +87,6 @@ const credentialCollectionFields = [
   'pagination',
 ] as const
 const credentialSummaryFields = [
-  'model_cooldown',
   'total',
   'available',
   'cooldown',
@@ -502,7 +501,7 @@ function projectObservation(value: unknown): CredentialObservationDto {
   }
 }
 
-export function projectModelCooldown(value: unknown) {
+function projectModelCooldown(value: unknown) {
   const record = projectRecord(value)
   assertNoSecretLikeFields(record, ['model', 'cooldown_until_ms'])
   return {
@@ -516,16 +515,12 @@ export function projectCredentialSummary(value: unknown): CredentialSummaryDto {
   assertNoSecretLikeFields(record, credentialSummaryFields)
   const result = {
     total: projectSafeInteger(record.total, { minimum: 0 }),
-    model_cooldown: projectSafeInteger(record.model_cooldown, { minimum: 0 }),
     available: projectSafeInteger(record.available, { minimum: 0 }),
     cooldown: projectSafeInteger(record.cooldown, { minimum: 0 }),
     blacklisted: projectSafeInteger(record.blacklisted, { minimum: 0 }),
     disabled: projectSafeInteger(record.disabled, { minimum: 0 }),
   }
-  if (
-    result.total !== result.available + result.cooldown + result.blacklisted + result.disabled ||
-    result.model_cooldown > result.total
-  ) {
+  if (result.total !== result.available + result.cooldown + result.blacklisted + result.disabled) {
     invalidResponse()
   }
   return result
@@ -711,7 +706,6 @@ function credentialCollectionURL(
     page: String(normalized.page),
     page_size: String(normalized.page_size),
   })
-  if (normalized.model_cooldown) params.set('model_cooldown', 'true')
   if (normalized.q !== undefined) params.set('q', normalized.q)
   if (normalized.status !== undefined) params.set('status', normalized.status)
   return `/api/groups/${groupId}/credentials?${params.toString()}`
@@ -1077,14 +1071,12 @@ function queryFilters(queryKey: QueryKey): CredentialCollectionFilters | undefin
   if (
     !Number.isSafeInteger(record.page) ||
     (record.page_size !== 20 && record.page_size !== 50 && record.page_size !== 100) ||
-    (record.model_cooldown !== undefined && record.model_cooldown !== true) ||
     (record.q !== undefined && typeof record.q !== 'string') ||
     (record.status !== undefined && !effectiveStatuses.includes(record.status as CredentialStatus))
   ) {
     return undefined
   }
   return {
-    ...(record.model_cooldown === true ? { model_cooldown: true as const } : {}),
     page: record.page as number,
     page_size: record.page_size as 20 | 50 | 100,
     ...(record.q === undefined ? {} : { q: record.q }),
@@ -1094,7 +1086,6 @@ function queryFilters(queryKey: QueryKey): CredentialCollectionFilters | undefin
 
 function matchesFilters(item: CredentialItemDto, filters: CredentialCollectionFilters): boolean {
   if (filters.status !== undefined && item.effective_status !== filters.status) return false
-  if (filters.model_cooldown && item.model_cooldowns.length === 0) return false
   if (filters.q === undefined) return true
   const query = filters.q.toLowerCase()
   return (
@@ -1109,8 +1100,6 @@ function withSummaryDelta(
   next: CredentialItemDto | undefined,
 ): CredentialSummaryDto {
   const result = { ...summary }
-  result.model_cooldown +=
-    Number((next?.model_cooldowns.length ?? 0) > 0) - Number(previous.model_cooldowns.length > 0)
   result[previous.effective_status]--
   if (next !== undefined) result[next.effective_status]++
   return result
@@ -1152,7 +1141,6 @@ function credentialFilterSetID(filters: CredentialCollectionFilters): string {
   return JSON.stringify({
     q: filters.q ?? null,
     status: filters.status ?? null,
-    model_cooldown: filters.model_cooldown ?? false,
     page_size: filters.page_size,
   })
 }
@@ -1162,10 +1150,8 @@ function totalItemsAfterBatchDelete(
   knownDeletedIDs: Set<number>,
   summary: CredentialSummaryDto,
 ): number {
-  const { q, status, model_cooldown } = pages[0].filters
-  if (q === undefined && !model_cooldown)
-    return status === undefined ? summary.total : summary[status]
-  if (q === undefined && status === undefined && model_cooldown) return summary.model_cooldown
+  const { q, status } = pages[0].filters
+  if (q === undefined) return status === undefined ? summary.total : summary[status]
   return Math.max(
     0,
     Math.max(...pages.map(({ collection }) => collection.pagination.total_items)) -

--- a/web/src/app/resources/health.ts
+++ b/web/src/app/resources/health.ts
@@ -16,7 +16,6 @@ import type {
 import { InvalidResponseError } from '@/api/errors'
 import { controlQueryKeys } from '@/app/query-keys'
 import { projectAccessKeyCostLimitRuleStatus } from './access-keys'
-import { projectModelCooldown } from './credentials'
 
 import {
   assertNoSecretLikeFields,
@@ -41,15 +40,8 @@ export type {
   RuntimeHealthDto,
 } from '@/api/control/types'
 
-const countFields = [
-  'model_cooldown',
-  'credentials',
-  'available',
-  'cooldown',
-  'blacklisted',
-] as const
+const countFields = ['credentials', 'available', 'cooldown', 'blacklisted'] as const
 const healthFields = [
-  'model_cooldown_credentials',
   'observed_at_ms',
   'version',
   'uptime_seconds',
@@ -163,7 +155,6 @@ export function projectHealthCounts(value: unknown): HealthCredentialCountsDto {
     credentials: projectSafeInteger(record.credentials, { minimum: 0 }),
     available: projectSafeInteger(record.available, { minimum: 0 }),
     cooldown: projectSafeInteger(record.cooldown, { minimum: 0 }),
-    model_cooldown: projectSafeInteger(record.model_cooldown, { minimum: 0 }),
     blacklisted: projectSafeInteger(record.blacklisted, { minimum: 0 }),
   }
   if (result.credentials !== result.available + result.cooldown + result.blacklisted) {
@@ -175,11 +166,15 @@ export function projectHealthCounts(value: unknown): HealthCredentialCountsDto {
 function projectHealthGroup(value: unknown): HealthGroupDto {
   const record = projectRecord(value)
   assertNoSecretLikeFields(record, ['id', 'name', 'enabled', 'counts'])
+  const { model_cooldown, ...counts } = projectRecord(record.counts)
   return {
     id: projectSafeInteger(record.id, { minimum: 1 }),
     name: projectNonBlankString(record.name),
     enabled: projectBoolean(record.enabled),
-    counts: projectHealthCounts(record.counts),
+    counts: {
+      ...projectHealthCounts(counts),
+      model_cooldown: projectSafeInteger(model_cooldown, { minimum: 0 }),
+    },
   }
 }
 
@@ -332,23 +327,6 @@ export function projectRuntimeHealth(value: unknown): RuntimeHealthDto {
     stats_window_seconds: projectSafeInteger(record.stats_window_seconds, { minimum: 1 }),
     counts: projectHealthCounts(record.counts),
     groups: projectArray(record.groups, projectHealthGroup),
-    model_cooldown_credentials: projectArray(record.model_cooldown_credentials, (value) => {
-      const item = projectRecord(value)
-      assertNoSecretLikeFields(item, [
-        'credential_id',
-        'group_id',
-        'group_name',
-        'identity',
-        'model_cooldowns',
-      ])
-      return {
-        credential_id: projectSafeInteger(item.credential_id, { minimum: 1 }),
-        group_id: projectSafeInteger(item.group_id, { minimum: 1 }),
-        group_name: projectNonBlankString(item.group_name),
-        identity: projectNonBlankString(item.identity),
-        model_cooldowns: projectArray(item.model_cooldowns, projectModelCooldown),
-      }
-    }),
     cooldown_credentials: projectArray(record.cooldown_credentials, projectProblemCredential),
     blacklisted_credentials: projectArray(record.blacklisted_credentials, projectProblemCredential),
     low_quota_credentials: projectArray(record.low_quota_credentials, projectQuotaCredential),

--- a/web/src/app/router.ts
+++ b/web/src/app/router.ts
@@ -81,7 +81,7 @@ const routes: RouteRecordRaw[] = [
       titleKey: 'shell.monitor',
       requiresAuth: true,
       primaryNav: 'monitor',
-      messageNamespaces: ['monitor'],
+      messageNamespaces: ['monitor', 'group', 'settings'],
     },
   }),
   pageRoute(pageRouteNames.models, {

--- a/web/src/components/ui/CredentialHealthBar.vue
+++ b/web/src/components/ui/CredentialHealthBar.vue
@@ -13,11 +13,10 @@ const props = defineProps<{
 }>()
 
 const { n } = useI18n()
-const normalizedCounts = computed<CredentialCounts>(() =>
+const normalizedCounts = computed(() =>
   'total' in props.counts
     ? props.counts
     : {
-        model_cooldown: props.counts.model_cooldown,
         total: props.counts.credentials,
         available: props.counts.available,
         cooldown: props.counts.cooldown,

--- a/web/src/components/ui/ModelCooldownDetails.vue
+++ b/web/src/components/ui/ModelCooldownDetails.vue
@@ -14,12 +14,9 @@ const { locale, t } = useI18n()
     class="model-cooldowns"
     :aria-label="t('group.credentials.modelCooldown.label')"
   >
-    <header class="model-cooldowns__header">
-      <h3>{{ t('group.credentials.modelCooldown.label') }}</h3>
-      <span>{{ t('group.credentials.modelCooldown.until') }}</span>
-    </header>
+    <h3>{{ t('group.credentials.modelCooldown.label') }}</h3>
     <dl class="model-cooldowns__list">
-      <div v-for="cooldown in cooldowns" :key="cooldown.model" class="model-cooldowns__row">
+      <div v-for="cooldown in cooldowns" :key="cooldown.model" class="model-cooldowns__tag">
         <dt>{{ cooldown.model }}</dt>
         <dd>
           <AppRelativeTime
@@ -41,40 +38,29 @@ const { locale, t } = useI18n()
   min-width: 0;
   font-size: var(--text-label-xs);
 }
-.model-cooldowns__header {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: var(--space-3);
-  color: var(--color-text-muted);
-}
-.model-cooldowns__header h3 {
+.model-cooldowns h3 {
   margin: 0;
+  color: var(--color-text-muted);
   font: inherit;
   font-weight: 680;
   letter-spacing: 0.06em;
 }
-.model-cooldowns__header > span {
-  flex: none;
-  padding-right: 12px;
-  font-weight: 400;
-}
 .model-cooldowns__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 8px;
   min-width: 0;
   margin: 0;
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-control);
-  background: var(--color-surface);
 }
-.model-cooldowns__row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) max-content;
+.model-cooldowns__tag {
+  display: inline-flex;
+  max-width: 100%;
   align-items: baseline;
-  gap: var(--space-4);
-  padding: 9px 12px;
-}
-.model-cooldowns__row + .model-cooldowns__row {
-  border-top: 1px solid var(--color-border-subtle);
+  gap: 6px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-tag);
+  background: var(--color-surface);
+  padding: 5px 9px;
 }
 .model-cooldowns dt {
   min-width: 0;
@@ -82,10 +68,13 @@ const { locale, t } = useI18n()
   font-family: var(--font-mono);
   overflow-wrap: anywhere;
 }
+.model-cooldowns dt::after {
+  content: ':';
+}
 .model-cooldowns dd {
+  flex: none;
   margin: 0;
   color: var(--color-text-muted);
-  text-align: right;
   white-space: nowrap;
 }
 </style>

--- a/web/src/components/ui/ModelCooldownDetails.vue
+++ b/web/src/components/ui/ModelCooldownDetails.vue
@@ -9,50 +9,83 @@ const { locale, t } = useI18n()
 </script>
 
 <template>
-  <dl
+  <section
     v-if="cooldowns.length > 0"
     class="model-cooldowns"
     :aria-label="t('group.credentials.modelCooldown.label')"
   >
-    <div v-for="cooldown in cooldowns" :key="cooldown.model">
-      <dt>{{ cooldown.model }}</dt>
-      <dd>
-        <span>{{ t('group.credentials.modelCooldown.until') }}</span>
-        <AppRelativeTime
-          :instant="cooldown.cooldown_until_ms"
-          :locale="locale"
-          :empty-label="t('group.credentials.none')"
-          hint
-        />
-      </dd>
-    </div>
-  </dl>
+    <header class="model-cooldowns__header">
+      <h3>{{ t('group.credentials.modelCooldown.label') }}</h3>
+      <span>{{ t('group.credentials.modelCooldown.until') }}</span>
+    </header>
+    <dl class="model-cooldowns__list">
+      <div v-for="cooldown in cooldowns" :key="cooldown.model" class="model-cooldowns__row">
+        <dt>{{ cooldown.model }}</dt>
+        <dd>
+          <AppRelativeTime
+            :instant="cooldown.cooldown_until_ms"
+            :locale="locale"
+            :empty-label="t('group.credentials.none')"
+            hint
+          />
+        </dd>
+      </div>
+    </dl>
+  </section>
 </template>
 
 <style scoped>
 .model-cooldowns {
   display: grid;
-  gap: var(--space-2);
-  margin: 0;
+  gap: 6px;
   min-width: 0;
   font-size: var(--text-label-xs);
 }
-.model-cooldowns > div,
-.model-cooldowns dd {
+.model-cooldowns__header {
   display: flex;
-  flex-wrap: wrap;
   align-items: baseline;
-  gap: var(--space-2);
-}
-.model-cooldowns > div {
   justify-content: space-between;
+  gap: var(--space-3);
+  color: var(--color-text-muted);
+}
+.model-cooldowns__header h3 {
+  margin: 0;
+  font: inherit;
+  font-weight: 680;
+  letter-spacing: 0.06em;
+}
+.model-cooldowns__header > span {
+  flex: none;
+  padding-right: 12px;
+  font-weight: 400;
+}
+.model-cooldowns__list {
+  min-width: 0;
+  margin: 0;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-control);
+  background: var(--color-surface);
+}
+.model-cooldowns__row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content;
+  align-items: baseline;
+  gap: var(--space-4);
+  padding: 9px 12px;
+}
+.model-cooldowns__row + .model-cooldowns__row {
+  border-top: 1px solid var(--color-border-subtle);
 }
 .model-cooldowns dt {
+  min-width: 0;
+  color: var(--color-text);
   font-family: var(--font-mono);
   overflow-wrap: anywhere;
 }
 .model-cooldowns dd {
   margin: 0;
   color: var(--color-text-muted);
+  text-align: right;
+  white-space: nowrap;
 }
 </style>

--- a/web/src/features/groups/GroupsView.vue
+++ b/web/src/features/groups/GroupsView.vue
@@ -569,6 +569,7 @@ function connectionTypeBadgeClass(type: ConnectionType): string {
                 />
                 <StatusBadge
                   v-if="group.credential_counts.model_cooldown > 0"
+                  class="credential-health__model-cooldown"
                   tone="warning"
                   size="compact"
                 >
@@ -760,6 +761,10 @@ function connectionTypeBadgeClass(type: ConnectionType): string {
   min-width: 0;
   align-items: center;
   gap: var(--space-2);
+}
+
+.credential-health__model-cooldown {
+  justify-self: start;
 }
 
 .record-actions {

--- a/web/src/features/groups/credentials/GroupCredentialRecord.vue
+++ b/web/src/features/groups/credentials/GroupCredentialRecord.vue
@@ -163,12 +163,14 @@ function runMenuAction(action: 'test' | 'toggle' | 'restore' | 'remove'): void {
         <span class="group-credential-record__mobile-label">{{
           t('group.credentials.columns.status')
         }}</span>
-        <StatusBadge :status="item.effective_status" size="compact">
-          {{ t(`group.credentials.effective.${item.effective_status}`) }}
-        </StatusBadge>
-        <StatusBadge v-if="item.model_cooldowns.length > 0" tone="warning" size="compact">{{
-          t('group.credentials.modelCooldown.count', { count: n(item.model_cooldowns.length) })
-        }}</StatusBadge>
+        <div class="group-credential-record__status-badges">
+          <StatusBadge :status="item.effective_status" size="compact">
+            {{ t(`group.credentials.effective.${item.effective_status}`) }}
+          </StatusBadge>
+          <StatusBadge v-if="item.model_cooldowns.length > 0" tone="warning" size="compact">{{
+            t('group.credentials.modelCooldown.count', { count: n(item.model_cooldowns.length) })
+          }}</StatusBadge>
+        </div>
       </div>
 
       <div class="ledger-record-list__cell group-credential-record__weight" role="cell">
@@ -337,11 +339,12 @@ function runMenuAction(action: 'test' | 'toggle' | 'restore' | 'remove'): void {
             />
           </div>
 
+          <ModelCooldownDetails :cooldowns="item.model_cooldowns" />
+
           <div class="setting-panel">
             <span class="setting-panel__title">
               {{ t('group.credentials.diagnostics') }}
             </span>
-            <ModelCooldownDetails :cooldowns="item.model_cooldowns" />
             <dl class="setting-panel__body group-credential-record__runtime-details">
               <div>
                 <dt>{{ t('group.credentials.detailsFailure') }}</dt>
@@ -411,6 +414,13 @@ function runMenuAction(action: 'test' | 'toggle' | 'restore' | 'remove'): void {
   gap: 6px;
 }
 
+.group-credential-record__status-badges {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px 8px;
+}
+
 .group-credential-record__weight-none {
   color: var(--color-text-faint);
   text-decoration: underline dotted;
@@ -473,16 +483,16 @@ function runMenuAction(action: 'test' | 'toggle' | 'restore' | 'remove'): void {
   margin: 0;
 }
 
-.group-credential-record__details dl div {
+.group-credential-record__runtime-details > div {
   min-width: 0;
 }
 
-.group-credential-record__details dt {
+.group-credential-record__runtime-details dt {
   color: var(--color-text-faint);
   font-size: var(--text-label-xs);
 }
 
-.group-credential-record__details dd {
+.group-credential-record__runtime-details dd {
   margin: 3px 0 0;
   overflow-wrap: anywhere;
   font-family: var(--font-mono);
@@ -643,7 +653,7 @@ function runMenuAction(action: 'test' | 'toggle' | 'restore' | 'remove'): void {
   }
 
   .group-credential-record__mask,
-  .group-credential-record__recent,
+  .group-credential-record__status,
   .group-credential-record__actions {
     grid-column: 1 / -1;
   }
@@ -657,7 +667,6 @@ function runMenuAction(action: 'test' | 'toggle' | 'restore' | 'remove'): void {
     gap: 5px;
   }
 
-  .group-credential-record__recent,
   .group-credential-record__actions {
     border-top: 1px solid var(--color-border-subtle);
     padding-top: 11px;

--- a/web/src/features/groups/credentials/GroupCredentialsTab.vue
+++ b/web/src/features/groups/credentials/GroupCredentialsTab.vue
@@ -9,7 +9,6 @@ import {
   Plus,
   RotateCcw,
   Search,
-  Timer,
 } from '@lucide/vue'
 import { useQuery, useQueryClient } from '@tanstack/vue-query'
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
@@ -265,10 +264,7 @@ const credentialTestDialogResult = computed(() => {
   }
 })
 const hasChangedConditions = computed(
-  () =>
-    filters.value.q !== undefined ||
-    filters.value.status !== undefined ||
-    filters.value.model_cooldown === true,
+  () => filters.value.q !== undefined || filters.value.status !== undefined,
 )
 const statusSummaryItems = computed(() => {
   const summary = collection.value?.summary
@@ -325,13 +321,7 @@ watch(
 )
 
 watch(
-  () => [
-    filters.value.status,
-    filters.value.q,
-    filters.value.page,
-    filters.value.page_size,
-    filters.value.model_cooldown,
-  ],
+  () => [filters.value.status, filters.value.q, filters.value.page, filters.value.page_size],
   () => {
     selectedIds.value = new Set()
   },
@@ -380,9 +370,7 @@ function updateRoute(
 }
 
 function setFilter(
-  patch: Partial<
-    Pick<CredentialCollectionFilters, 'q' | 'status' | 'page_size' | 'model_cooldown'>
-  >,
+  patch: Partial<Pick<CredentialCollectionFilters, 'q' | 'status' | 'page_size'>>,
 ): void {
   updateRoute({ ...filters.value, ...patch, page: 1 })
 }
@@ -467,7 +455,6 @@ function currentSelectionContext(): string {
   return JSON.stringify({
     groupId: props.groupId,
     status: filters.value.status ?? null,
-    modelCooldown: filters.value.model_cooldown ?? false,
     query: filters.value.q ?? null,
     page: filters.value.page,
     pageSize: filters.value.page_size,
@@ -1680,20 +1667,6 @@ async function runBatch(
             </AppButton>
           </span>
         </label>
-        <AppButton
-          class="group-credentials__model-filter"
-          variant="secondary"
-          size="compact"
-          :tone="filters.model_cooldown ? 'warning' : 'neutral'"
-          :aria-pressed="filters.model_cooldown === true"
-          @click="setFilter({ model_cooldown: filters.model_cooldown ? undefined : true })"
-        >
-          <Timer :size="15" aria-hidden="true" />
-          {{ t('group.credentials.modelCooldown.label') }}
-          <span class="group-credentials__filter-count">{{
-            n(collection.summary.model_cooldown)
-          }}</span>
-        </AppButton>
         <CredentialBatchBar
           class="group-credentials__batch-bar"
           :selected-count="selectedCount"
@@ -1926,15 +1899,6 @@ async function runBatch(
 </template>
 
 <style scoped>
-.group-credentials__filter-count {
-  min-width: 20px;
-  border-radius: var(--radius-tag);
-  background: color-mix(in srgb, currentColor 9%, transparent);
-  padding: 1px 5px;
-  font-family: var(--font-mono);
-  font-size: var(--text-label-xs);
-  text-align: center;
-}
 .group-credentials__batch-bar {
   margin-left: auto;
 }
@@ -2064,9 +2028,6 @@ async function runBatch(
   }
 }
 @media (max-width: 860px) {
-  .group-credentials__model-filter {
-    min-height: var(--touch-target);
-  }
   .group-credential-record-grid {
     --ledger-record-list-card-grid: minmax(0, 0.8fr) minmax(0, 1.2fr);
   }

--- a/web/src/features/groups/credentials/GroupCredentialsTab.vue
+++ b/web/src/features/groups/credentials/GroupCredentialsTab.vue
@@ -9,6 +9,7 @@ import {
   Plus,
   RotateCcw,
   Search,
+  Timer,
 } from '@lucide/vue'
 import { useQuery, useQueryClient } from '@tanstack/vue-query'
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
@@ -1679,23 +1680,22 @@ async function runBatch(
             </AppButton>
           </span>
         </label>
-        <label class="group-credentials__model-filter">
-          <input
-            type="checkbox"
-            :checked="filters.model_cooldown === true"
-            @change="
-              setFilter({
-                model_cooldown: ($event.target as HTMLInputElement).checked ? true : undefined,
-              })
-            "
-          />
-          {{
-            t('group.credentials.modelCooldown.credentialCount', {
-              count: n(collection.summary.model_cooldown),
-            })
-          }}
-        </label>
+        <AppButton
+          class="group-credentials__model-filter"
+          variant="secondary"
+          size="compact"
+          :tone="filters.model_cooldown ? 'warning' : 'neutral'"
+          :aria-pressed="filters.model_cooldown === true"
+          @click="setFilter({ model_cooldown: filters.model_cooldown ? undefined : true })"
+        >
+          <Timer :size="15" aria-hidden="true" />
+          {{ t('group.credentials.modelCooldown.label') }}
+          <span class="group-credentials__filter-count">{{
+            n(collection.summary.model_cooldown)
+          }}</span>
+        </AppButton>
         <CredentialBatchBar
+          class="group-credentials__batch-bar"
           :selected-count="selectedCount"
           :all-visible-selected="allVisibleSelected"
           :pending="batchBusy || singleBusy"
@@ -1926,12 +1926,17 @@ async function runBatch(
 </template>
 
 <style scoped>
-.group-credentials__model-filter {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
+.group-credentials__filter-count {
+  min-width: 20px;
+  border-radius: var(--radius-tag);
+  background: color-mix(in srgb, currentColor 9%, transparent);
+  padding: 1px 5px;
+  font-family: var(--font-mono);
   font-size: var(--text-label-xs);
-  white-space: nowrap;
+  text-align: center;
+}
+.group-credentials__batch-bar {
+  margin-left: auto;
 }
 .group-credentials {
   display: grid;
@@ -1950,10 +1955,10 @@ async function runBatch(
   overflow-wrap: anywhere;
 }
 .group-credentials__tools {
-  display: grid;
-  grid-template-columns: minmax(260px, 1fr) auto minmax(0, max-content);
-  align-items: start;
-  gap: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px 12px;
   border-bottom: 1px solid var(--color-border-subtle);
   margin-bottom: var(--space-4);
   padding: 13px 0 var(--space-3);
@@ -1962,14 +1967,15 @@ async function runBatch(
   display: flex;
   min-width: 0;
   align-items: center;
-  width: 420px;
-  max-width: 100%;
+  flex: 1 1 260px;
+  max-width: 420px;
 }
 .group-credentials__search-controls {
   display: flex;
   min-width: 0;
   align-items: center;
   gap: 10px;
+  width: 100%;
 }
 .group-credentials__search-input {
   width: 420px;
@@ -2024,7 +2030,7 @@ async function runBatch(
 }
 .group-credentials__accounts {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(420px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(420px, 100%), 1fr));
   align-items: start;
   gap: var(--space-3);
 }
@@ -2033,24 +2039,24 @@ async function runBatch(
   gap: var(--space-3);
   padding: var(--space-4) 0;
 }
-/* 操作列收成「更多操作 + 展开」两个图标后只需固定 80px，省下的宽度还给信息列。 */
+/* 状态列容纳凭据状态与模型冷却两个标记，避免挤占相邻信息列。 */
 .group-credential-record-grid {
   --ledger-record-list-record-min-height: 52px;
   --ledger-record-list-record-padding: 8px 0;
-  --ledger-record-list-grid: 48px minmax(200px, 1.5fr) 116px minmax(130px, 0.85fr)
-    minmax(170px, 1.1fr) 80px;
+  --ledger-record-list-grid: 48px minmax(140px, 1fr) minmax(256px, max-content) 80px
+    minmax(112px, 0.55fr) 80px;
   --ledger-record-list-column-gap: 12px;
 }
 @media (max-width: 1120px) {
   .group-credential-record-grid {
-    --ledger-record-list-grid: 44px minmax(160px, 1.3fr) 108px minmax(112px, 0.8fr)
-      minmax(140px, 1fr) 76px;
+    --ledger-record-list-grid: 44px minmax(120px, 1fr) minmax(256px, max-content) 70px
+      minmax(90px, 0.65fr) 76px;
     --ledger-record-list-column-gap: 9px;
   }
 }
 @media (max-width: 1023px) and (min-width: 861px) {
   .group-credential-record-grid {
-    --ledger-record-list-grid: 44px minmax(150px, 1.3fr) 108px minmax(110px, 0.8fr) 76px;
+    --ledger-record-list-grid: 44px minmax(120px, 1fr) minmax(256px, max-content) 70px 76px;
   }
   .group-credential-record-grid :deep(.ledger-record-list__header > :nth-child(5)),
   .group-credential-record-grid :deep(.group-credential-record__recent) {
@@ -2058,8 +2064,8 @@ async function runBatch(
   }
 }
 @media (max-width: 860px) {
-  .group-credentials__tools {
-    grid-template-columns: 1fr;
+  .group-credentials__model-filter {
+    min-height: var(--touch-target);
   }
   .group-credential-record-grid {
     --ledger-record-list-card-grid: minmax(0, 0.8fr) minmax(0, 1.2fr);
@@ -2069,8 +2075,16 @@ async function runBatch(
   .group-credentials {
     padding-top: var(--detail-panel-padding-top-compact);
   }
+  .group-credentials__batch-bar {
+    flex-basis: 100%;
+    margin-left: 0;
+  }
 }
 @media (max-width: 560px) {
+  .group-credentials__search-field {
+    flex-basis: 100%;
+    max-width: none;
+  }
   .group-credentials__search-field,
   .group-credentials__search-input {
     width: 100%;

--- a/web/src/features/groups/credentials/SubscriptionAccountCard.vue
+++ b/web/src/features/groups/credentials/SubscriptionAccountCard.vue
@@ -1205,9 +1205,10 @@ function runMenuAction(
           </div>
         </section>
 
+        <ModelCooldownDetails :cooldowns="item.model_cooldowns" />
+
         <section class="subscription-account__detail-section">
           <h3>{{ t('group.credentials.subscription.overview') }}</h3>
-          <ModelCooldownDetails :cooldowns="item.model_cooldowns" />
           <div class="subscription-account__diagnostics">
             <dl>
               <dt>{{ t('group.credentials.subscription.lastUsed') }}</dt>
@@ -1513,6 +1514,8 @@ function runMenuAction(
   width: 20px;
   height: 20px;
   flex: none;
+  align-self: flex-start;
+  margin-top: 2px;
   align-items: center;
   justify-items: start;
   border: 0;
@@ -1552,8 +1555,14 @@ function runMenuAction(
 .subscription-account__badges {
   display: flex;
   min-width: 0;
+  flex: 1;
+  flex-wrap: wrap;
   align-items: center;
   gap: var(--space-2);
+}
+.subscription-account__badges > * {
+  flex-shrink: 0;
+  max-width: 100%;
 }
 .subscription-account__mail {
   min-width: 0;

--- a/web/src/features/groups/group-route.ts
+++ b/web/src/features/groups/group-route.ts
@@ -77,7 +77,6 @@ export function parseCredentialRouteQuery(query: LocationQuery): CredentialColle
   }
   const q = normalizeCredentialSearch(scalarRouteQuery(query.q))
   if (q !== undefined) filters.q = q
-  if (scalarRouteQuery(query.model_cooldown) === 'true') filters.model_cooldown = true
   if (status !== undefined && credentialStatuses.has(status as CredentialStatus)) {
     filters.status = status as CredentialStatus
   }
@@ -99,7 +98,6 @@ export function serializeCredentialRouteQuery(
   const q = normalizeCredentialSearch(filters.q)
   if (q !== undefined) query.q = q
   if (filters.status !== undefined) query.credential_status = filters.status
-  if (filters.model_cooldown) query.model_cooldown = 'true'
   if (filters.page !== 1) query.page = String(filters.page)
   if (filters.page_size !== 20) query.page_size = String(filters.page_size)
   const expanded = serializePositiveRouteIntegerList(state.expandedCredentialIDs)

--- a/web/src/features/monitor/HealthProblemCollection.vue
+++ b/web/src/features/monitor/HealthProblemCollection.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ArrowRight, ScrollText } from '@lucide/vue'
+import { ArrowRight, ChevronDown, ScrollText } from '@lucide/vue'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { RouterLink } from 'vue-router'
@@ -306,24 +306,34 @@ function credentialMeta(credential: HealthProblemCredentialDto): string {
       </template>
     </LedgerRecordList>
     <div v-if="modelCooldownCredentials.length > 0" class="problem-health__models">
-      <details v-for="credential in modelCooldownCredentials" :key="credential.credential_id">
+      <details
+        v-for="credential in modelCooldownCredentials"
+        :key="credential.credential_id"
+        class="problem-health__model-record"
+      >
         <summary>
           <RouterLink
+            class="problem-health__model-identity"
             :to="
               groupDetailLocation(credential.group_id, {
                 tab: 'credentials',
                 model_cooldown: 'true',
               })
             "
-            >{{ credential.group_name }} · {{ credential.identity }}</RouterLink
           >
-          <StatusBadge tone="warning" size="compact">{{
+            <strong>{{ credential.identity }}</strong>
+            <small>{{ credential.group_name }}</small>
+          </RouterLink>
+          <StatusBadge class="problem-health__model-count" tone="warning" size="compact">{{
             t('group.credentials.modelCooldown.count', {
               count: n(credential.model_cooldowns.length),
             })
           }}</StatusBadge>
+          <ChevronDown class="problem-health__model-chevron" :size="16" aria-hidden="true" />
         </summary>
-        <ModelCooldownDetails :cooldowns="credential.model_cooldowns" />
+        <div class="problem-health__model-details">
+          <ModelCooldownDetails :cooldowns="credential.model_cooldowns" />
+        </div>
       </details>
     </div>
   </section>
@@ -331,21 +341,81 @@ function credentialMeta(credential: HealthProblemCredentialDto): string {
 
 <style scoped>
 .problem-health__models {
-  display: grid;
-  gap: var(--space-3);
-  padding: var(--space-4);
+  min-width: 0;
   max-height: 320px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-control);
+  background: var(--color-surface);
   overflow: auto;
 }
-.problem-health__models summary {
+.problem-health__model-record + .problem-health__model-record {
+  border-top: 1px solid var(--color-border-subtle);
+}
+.problem-health__model-record summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto 16px;
+  align-items: center;
+  gap: 10px 16px;
+  padding: 12px 14px;
   cursor: pointer;
-  margin-bottom: var(--space-2);
-  overflow-wrap: anywhere;
+  list-style: none;
   font-size: var(--text-label-xs);
 }
-.problem-health__models summary a {
+.problem-health__model-record summary::-webkit-details-marker {
+  display: none;
+}
+.problem-health__model-record summary:hover,
+.problem-health__model-record[open] summary {
+  background: var(--color-surface-sunken);
+}
+.problem-health__model-record summary:focus-visible,
+.problem-health__model-identity:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: -2px;
+}
+.problem-health__model-identity {
+  display: grid;
+  justify-self: start;
+  min-width: 0;
+  gap: 3px;
+  border-radius: var(--radius-tag);
   color: var(--color-text);
-  margin-right: var(--space-2);
+  overflow-wrap: anywhere;
+}
+.problem-health__model-identity strong {
+  font-weight: 560;
+}
+.problem-health__model-identity small {
+  color: var(--color-text-faint);
+  font-size: inherit;
+}
+.problem-health__model-identity:hover strong {
+  color: var(--color-action);
+}
+.problem-health__model-chevron {
+  color: var(--color-text-faint);
+}
+.problem-health__model-record[open] .problem-health__model-chevron {
+  transform: rotate(180deg);
+}
+.problem-health__model-details {
+  padding: 12px 14px 14px;
+  border-top: 1px solid var(--color-border-subtle);
+  background: var(--color-surface-sunken);
+}
+@media (max-width: 560px) {
+  .problem-health__model-record summary {
+    grid-template-columns: minmax(0, 1fr) 16px;
+    gap: 8px 12px;
+  }
+  .problem-health__model-count {
+    grid-column: 1;
+    justify-self: start;
+  }
+  .problem-health__model-chevron {
+    grid-column: 2;
+    grid-row: 1 / 3;
+  }
 }
 .problem-health {
   display: grid;

--- a/web/src/features/monitor/HealthProblemCollection.vue
+++ b/web/src/features/monitor/HealthProblemCollection.vue
@@ -1,18 +1,16 @@
 <script setup lang="ts">
-import { ArrowRight, ChevronDown, ScrollText } from '@lucide/vue'
+import { ArrowRight, ScrollText } from '@lucide/vue'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { RouterLink } from 'vue-router'
 
 import type { HealthProblemCredentialDto } from '@/app/resources/health'
-import type { HealthModelCooldownCredentialDto } from '@/api/control/types'
 import { groupDetailLocation, monitorLocation } from '@/app/route-locations'
 import LedgerRecordList from '@/components/collection/LedgerRecordList.vue'
 import AppTooltip from '@/components/ui/AppTooltip.vue'
 import IconButton from '@/components/ui/IconButton.vue'
 import OverflowTooltip from '@/components/ui/OverflowTooltip.vue'
 import StatusBadge from '@/components/ui/StatusBadge.vue'
-import ModelCooldownDetails from '@/components/ui/ModelCooldownDetails.vue'
 
 import MonitorSectionHeading from './MonitorSectionHeading.vue'
 
@@ -29,7 +27,6 @@ interface RecoveryDisplay {
 
 const props = defineProps<{
   items: HealthProblemItem[]
-  modelCooldownCredentials: HealthModelCooldownCredentialDto[]
   recoveryByCredential: Record<number, RecoveryDisplay | undefined>
   statsWindowSeconds: number
   availableCount: number
@@ -60,21 +57,14 @@ function credentialMeta(credential: HealthProblemCredentialDto): string {
         })
       "
       :meta="
-        items.length + modelCooldownCredentials.length > 0
-          ? t('monitor.health.problems.count', {
-              count: n(
-                new Set([
-                  ...items.map((item) => item.credential.credential_id),
-                  ...modelCooldownCredentials.map((item) => item.credential_id),
-                ]).size,
-              ),
-            })
+        items.length > 0
+          ? t('monitor.health.problems.count', { count: n(items.length) })
           : undefined
       "
     />
 
     <div
-      v-if="items.length === 0 && modelCooldownCredentials.length === 0"
+      v-if="items.length === 0"
       class="problem-health__clear-panel"
       :class="{ 'problem-health__clear-panel--inactive': availableCount === 0 }"
       role="status"
@@ -305,118 +295,10 @@ function credentialMeta(credential: HealthProblemCredentialDto): string {
         </article>
       </template>
     </LedgerRecordList>
-    <div v-if="modelCooldownCredentials.length > 0" class="problem-health__models">
-      <details
-        v-for="credential in modelCooldownCredentials"
-        :key="credential.credential_id"
-        class="problem-health__model-record"
-      >
-        <summary>
-          <RouterLink
-            class="problem-health__model-identity"
-            :to="
-              groupDetailLocation(credential.group_id, {
-                tab: 'credentials',
-                model_cooldown: 'true',
-              })
-            "
-          >
-            <strong>{{ credential.identity }}</strong>
-            <small>{{ credential.group_name }}</small>
-          </RouterLink>
-          <StatusBadge class="problem-health__model-count" tone="warning" size="compact">{{
-            t('group.credentials.modelCooldown.count', {
-              count: n(credential.model_cooldowns.length),
-            })
-          }}</StatusBadge>
-          <ChevronDown class="problem-health__model-chevron" :size="16" aria-hidden="true" />
-        </summary>
-        <div class="problem-health__model-details">
-          <ModelCooldownDetails :cooldowns="credential.model_cooldowns" />
-        </div>
-      </details>
-    </div>
   </section>
 </template>
 
 <style scoped>
-.problem-health__models {
-  min-width: 0;
-  max-height: 320px;
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-control);
-  background: var(--color-surface);
-  overflow: auto;
-}
-.problem-health__model-record + .problem-health__model-record {
-  border-top: 1px solid var(--color-border-subtle);
-}
-.problem-health__model-record summary {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto 16px;
-  align-items: center;
-  gap: 10px 16px;
-  padding: 12px 14px;
-  cursor: pointer;
-  list-style: none;
-  font-size: var(--text-label-xs);
-}
-.problem-health__model-record summary::-webkit-details-marker {
-  display: none;
-}
-.problem-health__model-record summary:hover,
-.problem-health__model-record[open] summary {
-  background: var(--color-surface-sunken);
-}
-.problem-health__model-record summary:focus-visible,
-.problem-health__model-identity:focus-visible {
-  outline: 2px solid var(--color-focus);
-  outline-offset: -2px;
-}
-.problem-health__model-identity {
-  display: grid;
-  justify-self: start;
-  min-width: 0;
-  gap: 3px;
-  border-radius: var(--radius-tag);
-  color: var(--color-text);
-  overflow-wrap: anywhere;
-}
-.problem-health__model-identity strong {
-  font-weight: 560;
-}
-.problem-health__model-identity small {
-  color: var(--color-text-faint);
-  font-size: inherit;
-}
-.problem-health__model-identity:hover strong {
-  color: var(--color-action);
-}
-.problem-health__model-chevron {
-  color: var(--color-text-faint);
-}
-.problem-health__model-record[open] .problem-health__model-chevron {
-  transform: rotate(180deg);
-}
-.problem-health__model-details {
-  padding: 12px 14px 14px;
-  border-top: 1px solid var(--color-border-subtle);
-  background: var(--color-surface-sunken);
-}
-@media (max-width: 560px) {
-  .problem-health__model-record summary {
-    grid-template-columns: minmax(0, 1fr) 16px;
-    gap: 8px 12px;
-  }
-  .problem-health__model-count {
-    grid-column: 1;
-    justify-self: start;
-  }
-  .problem-health__model-chevron {
-    grid-column: 2;
-    grid-row: 1 / 3;
-  }
-}
 .problem-health {
   display: grid;
   min-width: 0;

--- a/web/src/features/monitor/HealthSummaryStrip.vue
+++ b/web/src/features/monitor/HealthSummaryStrip.vue
@@ -4,7 +4,6 @@ import { useI18n } from 'vue-i18n'
 
 import type { HealthCredentialCountsDto } from '@/app/resources/health'
 import AppTooltip from '@/components/ui/AppTooltip.vue'
-import StatusBadge from '@/components/ui/StatusBadge.vue'
 import type { StatusTone } from '@/components/ui/status-presenter'
 
 interface CooldownRecovery {
@@ -93,27 +92,10 @@ const items = computed<HealthOverviewItem[]>(() => [
       </AppTooltip>
       <span v-else class="health-overview__detail">{{ item.detail }}</span>
     </article>
-    <div v-if="counts.model_cooldown > 0" class="health-overview__model-cooldown">
-      <StatusBadge tone="warning" size="compact">{{
-        t('group.credentials.modelCooldown.credentialCount', { count: n(counts.model_cooldown) })
-      }}</StatusBadge>
-      <span>{{ t('group.credentials.modelCooldown.hint') }}</span>
-    </div>
   </section>
 </template>
 
 <style scoped>
-.health-overview__model-cooldown {
-  display: flex;
-  grid-column: 1 / -1;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 8px 12px;
-  padding: 12px 18px;
-  background: var(--color-surface);
-  color: var(--color-text-muted);
-  font-size: var(--text-label-xs);
-}
 .health-overview {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));

--- a/web/src/features/monitor/HealthSummaryStrip.vue
+++ b/web/src/features/monitor/HealthSummaryStrip.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 
 import type { HealthCredentialCountsDto } from '@/app/resources/health'
 import AppTooltip from '@/components/ui/AppTooltip.vue'
+import StatusBadge from '@/components/ui/StatusBadge.vue'
 import type { StatusTone } from '@/components/ui/status-presenter'
 
 interface CooldownRecovery {
@@ -92,21 +93,25 @@ const items = computed<HealthOverviewItem[]>(() => [
       </AppTooltip>
       <span v-else class="health-overview__detail">{{ item.detail }}</span>
     </article>
-    <span v-if="counts.model_cooldown > 0" class="health-overview__model-cooldown"
-      >{{
+    <div v-if="counts.model_cooldown > 0" class="health-overview__model-cooldown">
+      <StatusBadge tone="warning" size="compact">{{
         t('group.credentials.modelCooldown.credentialCount', { count: n(counts.model_cooldown) })
-      }}
-      · {{ t('group.credentials.modelCooldown.hint') }}</span
-    >
+      }}</StatusBadge>
+      <span>{{ t('group.credentials.modelCooldown.hint') }}</span>
+    </div>
   </section>
 </template>
 
 <style scoped>
 .health-overview__model-cooldown {
+  display: flex;
   grid-column: 1 / -1;
-  padding: var(--space-3) var(--space-4);
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 12px;
+  padding: 12px 18px;
   background: var(--color-surface);
-  color: var(--color-warning);
+  color: var(--color-text-muted);
   font-size: var(--text-label-xs);
 }
 .health-overview {

--- a/web/src/features/monitor/HealthTab.vue
+++ b/web/src/features/monitor/HealthTab.vue
@@ -232,7 +232,6 @@ defineExpose({ refresh })
       >
         <HealthProblemCollection
           :items="problemItems"
-          :model-cooldown-credentials="healthQuery.data.value.model_cooldown_credentials"
           :recovery-by-credential="recoveryByCredential"
           :stats-window-seconds="healthQuery.data.value.stats_window_seconds"
           :available-count="healthQuery.data.value.counts.available"

--- a/web/src/i18n/locales/en-US/group.ts
+++ b/web/src/i18n/locales/en-US/group.ts
@@ -381,7 +381,6 @@ export default {
         count: 'Model cooldown · {count}',
         credentialCount: 'Model cooldown · {count} credentials',
         until: 'Available after',
-        hint: 'Only the affected models are limited; credential status is shown separately.',
       },
       title: 'Keys',
       description: 'Review status, scheduling weight, and recent results',

--- a/web/src/i18n/locales/en-US/monitor.ts
+++ b/web/src/i18n/locales/en-US/monitor.ts
@@ -566,7 +566,7 @@ export default {
         group_weight_zero: 'Group effective weight is zero',
         credential_disabled: 'Credential is disabled',
         credential_blacklisted: 'Credential is blacklisted',
-        model_cooldown: 'The current model is cooling down on this credential',
+        model_cooldown: 'Model cooldown',
         credential_cooldown: 'Credential is cooling down',
         credential_auth_unavailable: 'Subscription authentication is currently unavailable',
         credential_weight_zero: 'Credential effective weight is zero',

--- a/web/src/i18n/locales/ja-JP/group.ts
+++ b/web/src/i18n/locales/ja-JP/group.ts
@@ -382,7 +382,6 @@ export default {
         count: 'モデルクールダウン · {count}',
         credentialCount: 'モデルクールダウン · {count} 件の認証情報',
         until: '復帰時刻',
-        hint: '対象モデルのみが制限され、認証情報の基本状態は別に表示されます。',
       },
       title: 'キー',
       description: '状態、スケジュールウェイト、最近の結果を確認します',

--- a/web/src/i18n/locales/ja-JP/monitor.ts
+++ b/web/src/i18n/locales/ja-JP/monitor.ts
@@ -564,7 +564,7 @@ export default {
         group_weight_zero: 'グループの有効ウェイトがゼロです',
         credential_disabled: '認証情報は無効です',
         credential_blacklisted: '認証情報はブラックリストに登録されています',
-        model_cooldown: 'この認証情報の対象モデルはクールダウン中です',
+        model_cooldown: 'モデル冷却中',
         credential_cooldown: '認証情報はクールダウン中です',
         credential_auth_unavailable: 'サブスクリプション認証を現在利用できません',
         credential_weight_zero: '認証情報の有効ウェイトがゼロです',

--- a/web/src/i18n/locales/zh-CN/group.ts
+++ b/web/src/i18n/locales/zh-CN/group.ts
@@ -369,7 +369,6 @@ export default {
         count: '模型冷却 · {count}',
         credentialCount: '模型冷却 · {count} 个凭据',
         until: '恢复时间',
-        hint: '仅影响对应模型，凭据基础状态独立显示',
       },
       title: '密钥',
       description: '查看状态、调度权重和最近结果',

--- a/web/src/i18n/locales/zh-CN/monitor.ts
+++ b/web/src/i18n/locales/zh-CN/monitor.ts
@@ -544,7 +544,7 @@ export default {
         group_weight_zero: '分组有效权重为零',
         credential_disabled: '凭据已停用',
         credential_blacklisted: '凭据已拉黑',
-        model_cooldown: '该凭据的当前模型正在冷却',
+        model_cooldown: '当前模型冷却中',
         credential_cooldown: '凭据正在冷却',
         credential_auth_unavailable: '订阅账号当前无法完成鉴权',
         credential_weight_zero: '凭据有效权重为零',


### PR DESCRIPTION
### 关联 Issue / Related Issue
<!-- 请填写此 PR 关联的 issue 编号，例如：Closes #123 / Please link the issue number, e.g., Closes #123 -->
无关联 Issue；精简 #599 引入的模型冷却展示。

### 变更内容 / Change Content
<!-- 请简要描述本次变更的核心内容 / Please briefly describe the core changes of this PR -->
- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [x] 其他改动 / Other changes

<!-- 请在下方详细描述你的变更 / Please describe your changes in detail below -->

凭据详情原本为每个冷却模型单独占一行，列表标记容易挤压，健康页还重复展示模型冷却提示和独立明细。本次将模型名与恢复时间合为可换行的紧凑标签，并移除多余展示及对应管理接口资源。

- 调整 API Key 状态列宽和标记间距，订阅卡按完整标记换行，适配长名称、窄屏和明暗主题。
- 删除分组模型冷却筛选、健康页顶部提示和“需要关注的凭据”下方的模型冷却列表；保留分组冷却计数。
- 清理筛选参数、路由和缓存分支、无用汇总字段、健康模型明细及身份读取逻辑、对应文案和样式。
- 补齐监控页面翻译依赖，精简中英日文的路由冷却状态文案。

验证：重新运行 `make check` 通过；相关移除行为完成 RED/GREEN 验证，9 个实际管理接口通过前端资源投影校验。已实际检查桌面、手机、长模型名、明暗主题、订阅详情、健康页和旧筛选链接规范化。

管理 API 同步移除 `model_cooldown` 筛选参数、凭据汇总与健康总计的 `model_cooldown` 字段，以及健康响应的 `model_cooldown_credentials`；分组计数仍保留。网关调度、模型冷却、恢复及保存机制不变，无数据迁移或依赖更新。Mock 数据与验收截图仅保留在本地，未提交；无需更新公开操作文档。


### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.
