### PR TITLE
feat(gateway): 接入原生文本重排序协议

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,12 +133,15 @@ When working over SSH or from a remote browser, the browser's `localhost` may no
 | OpenAI Responses        | `/v1/responses` and its resource paths |
 | OpenAI Images           | `POST /v1/images/...`                  |
 | OpenAI Embeddings       | `POST /v1/embeddings`                  |
+| Rerank                  | `POST /v1/rerank`                      |
 | Anthropic Messages      | `POST /v1/messages`                    |
 | Gemini                  | `/v1beta/models/...`                   |
 
 Each channel declares exactly which protocols and capabilities it can execute. GPT-Load converts between supported capabilities, but it is not a general-purpose any-protocol, any-JSON translator.
 
 Embeddings initially uses the native OpenAI-compatible wire only on the OpenAI, OpenRouter, and OpenAI Compatible API-key channels; subscription channels and protocol conversion are not supported. An AccessKey without a protocol filter keeps its existing “all enabled protocols” behavior and therefore gains Embeddings access after upgrade. Least-privilege deployments should configure an explicit protocol filter.
+
+Rerank uses the independent `rerank` protocol through `POST /v1/rerank` on the OpenAI Compatible, New API, and GPT-Load API-key channels. Requests contain `model`, `query`, and a text-only `documents` array, with optional upstream parameters such as `top_n` and `return_documents`. Streaming, subscription channels, and protocol conversion are not supported. OpenAI Compatible takes a complete API prefix (for example, `https://host/v1`); New API / GPT-Load take the gateway root. The upstream must implement a compatible Rerank endpoint. AccessKeys without a protocol filter also gain Rerank access. Responses containing only non-token units such as `search_units` remain unpriced; these units are not treated as tokens or free requests.
 
 ### Built-in channels
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -133,12 +133,15 @@ Codex、Claude、Antigravity 的 OAuth 客户端使用固定回调端口。Compo
 | OpenAI Responses        | `/v1/responses` 及其资源路径 |
 | OpenAI Images           | `POST /v1/images/...`        |
 | OpenAI Embeddings       | `POST /v1/embeddings`        |
+| Rerank                  | `POST /v1/rerank`            |
 | Anthropic Messages      | `POST /v1/messages`          |
 | Gemini                  | `/v1beta/models/...`         |
 
 每个渠道会明确声明自己可执行的协议与能力。GPT-Load 在受支持的能力之间做转换，但不是任意协议、任意 JSON 的通用转换器。
 
 Embeddings 首期只在 OpenAI、OpenRouter 和 OpenAI Compatible API Key 渠道提供原生 OpenAI-compatible Wire，不支持订阅渠道或协议互转。未设置协议过滤器的 AccessKey 会按既有语义允许全部已启用协议，升级后也会获得 Embeddings 访问能力；最小权限部署请显式配置协议过滤器。
+
+Rerank 使用独立的 `rerank` 协议，在 OpenAI Compatible、New API、GPT-Load API Key 渠道支持 `POST /v1/rerank`。请求使用 `model`、`query` 和纯文本 `documents` 数组，可传 `top_n`、`return_documents` 等上游参数；不支持流式、订阅渠道或协议互转。OpenAI Compatible 的 Base URL 是完整 API 前缀（如 `https://host/v1`），New API / GPT-Load 使用网关根地址；上游必须提供兼容 Rerank 接口。未设置协议过滤器的 AccessKey 也会获得 Rerank 访问能力。仅有 `search_units` 等非 Token 计量时保持未计价，不将其视为 Token 或免费请求。
 
 ### 内置渠道
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -133,12 +133,15 @@ SSH やリモートブラウザ経由で操作する場合、ブラウザの `lo
 | OpenAI Responses        | `/v1/responses` およびそのリソースパス |
 | OpenAI Images           | `POST /v1/images/...`                  |
 | OpenAI Embeddings       | `POST /v1/embeddings`                  |
+| Rerank                  | `POST /v1/rerank`                      |
 | Anthropic Messages      | `POST /v1/messages`                    |
 | Gemini                  | `/v1beta/models/...`                   |
 
 各チャネルは実行可能なプロトコルと機能を明示的に宣言します。GPT-Load はサポート対象の機能間で変換を行いますが、任意のプロトコル・任意の JSON を扱う汎用コンバーターではありません。
 
 Embeddings は初期段階では OpenAI、OpenRouter、OpenAI Compatible の API Key チャネルでのみネイティブな OpenAI 互換ワイヤーを提供し、サブスクリプションチャネルとプロトコル変換には対応していません。プロトコルフィルターを設定していない AccessKey は既存の「有効なプロトコルをすべて許可する」動作を維持するため、アップグレード後に Embeddings へのアクセス権も得ます。最小権限で運用する場合は、プロトコルフィルターを明示的に設定してください。
+
+Rerank は独立した `rerank` プロトコルを使用し、OpenAI Compatible、New API、GPT-Load の API Key チャネルで `POST /v1/rerank` に対応します。リクエストには `model`、`query`、テキストのみの `documents` 配列を指定し、`top_n` や `return_documents` などの上流パラメーターも利用できます。ストリーミング、サブスクリプション、プロトコル変換には対応しません。OpenAI Compatible には完全な API プレフィックス（例：`https://host/v1`）、New API / GPT-Load にはゲートウェイのルートを設定します。上流は互換 Rerank API を提供する必要があります。プロトコルフィルターのない AccessKey は Rerank へのアクセス権も得ます。`search_units` など Token 以外の単位のみが返る場合は未計価とし、Token 数や無料リクエストとして扱いません。
 
 ### 組み込みチャネル
 

--- a/internal/channel/compiler.go
+++ b/internal/channel/compiler.go
@@ -440,7 +440,7 @@ func validProtocolOperation(clientProtocol protocol.Protocol, operation executio
 	switch operation {
 	case execution.OperationChatCompletion:
 		return clientProtocol != protocol.OpenAIResponses && clientProtocol != protocol.OpenAIImages &&
-			clientProtocol != protocol.OpenAIEmbeddings
+			clientProtocol != protocol.OpenAIEmbeddings && clientProtocol != protocol.Rerank
 	case execution.OperationCountTokens:
 		return clientProtocol == protocol.Anthropic || clientProtocol == protocol.Gemini
 	case execution.OperationResponsesCreate,
@@ -455,11 +455,13 @@ func validProtocolOperation(clientProtocol protocol.Protocol, operation executio
 	case execution.OperationImagesGenerate,
 		execution.OperationImagesEdit:
 		return clientProtocol == protocol.OpenAIImages
+	case execution.OperationRerank:
+		return clientProtocol == protocol.Rerank
 	case execution.OperationEmbeddingsCreate:
 		return clientProtocol == protocol.OpenAIEmbeddings
 	case execution.OperationListModels:
 		return clientProtocol != protocol.OpenAIResponses && clientProtocol != protocol.OpenAIImages &&
-			clientProtocol != protocol.OpenAIEmbeddings
+			clientProtocol != protocol.OpenAIEmbeddings && clientProtocol != protocol.Rerank
 	case execution.OperationProbe:
 		return clientProtocol != protocol.OpenAIImages
 	default:

--- a/internal/channel/gpt_load_module_test.go
+++ b/internal/channel/gpt_load_module_test.go
@@ -79,6 +79,7 @@ func TestGPTLoadChannelContract(t *testing.T) {
 			execution.OperationImagesGenerate: RouteNative,
 			execution.OperationImagesEdit:     RouteNative,
 		},
+		protocol.Rerank: {execution.OperationRerank: RouteNative, execution.OperationProbe: RouteNative},
 		protocol.OpenAIEmbeddings: {
 			execution.OperationEmbeddingsCreate: RouteNative,
 			execution.OperationProbe:            RouteNative,

--- a/internal/channel/modules/gpt_load.go
+++ b/internal/channel/modules/gpt_load.go
@@ -32,6 +32,8 @@ func GPTLoad() spec.Module {
 				EndpointPolicy: spec.EndpointRequiredBaseURL,
 			},
 			Routes: []spec.Route{
+				spec.NewRoute(protocol.Rerank, execution.OperationRerank, execution.RouteNative),
+				spec.NewRoute(protocol.Rerank, execution.OperationProbe, execution.RouteNative),
 				spec.NewRoute(protocol.OpenAICompletions, execution.OperationChatCompletion, execution.RouteNative),
 				spec.NewRoute(protocol.OpenAICompletions, execution.OperationListModels, execution.RouteNative),
 				spec.NewRoute(protocol.OpenAICompletions, execution.OperationProbe, execution.RouteNative),

--- a/internal/channel/modules/newapi.go
+++ b/internal/channel/modules/newapi.go
@@ -31,6 +31,8 @@ func NewAPI() spec.Module {
 				EndpointPolicy: spec.EndpointRequiredBaseURL,
 			},
 			Routes: []spec.Route{
+				spec.NewRoute(protocol.Rerank, execution.OperationRerank, execution.RouteNative),
+				spec.NewRoute(protocol.Rerank, execution.OperationProbe, execution.RouteNative),
 				spec.NewRoute(protocol.OpenAICompletions, execution.OperationChatCompletion, execution.RouteNative),
 				spec.NewRoute(protocol.OpenAICompletions, execution.OperationListModels, execution.RouteNative),
 				spec.NewRoute(protocol.OpenAICompletions, execution.OperationProbe, execution.RouteNative),

--- a/internal/channel/modules/openai_compatible.go
+++ b/internal/channel/modules/openai_compatible.go
@@ -32,6 +32,8 @@ func OpenAICompatible() spec.Module {
 				EndpointPolicy: spec.EndpointRequiredBaseURL,
 			},
 			Routes: []spec.Route{
+				spec.NewRoute(protocol.Rerank, execution.OperationRerank, execution.RouteNative),
+				spec.NewRoute(protocol.Rerank, execution.OperationProbe, execution.RouteNative),
 				spec.NewRoute(protocol.OpenAICompletions, execution.OperationChatCompletion, execution.RouteNative),
 				spec.NewRoute(protocol.OpenAIEmbeddings, execution.OperationEmbeddingsCreate, execution.RouteNative),
 				spec.NewRoute(protocol.OpenAIEmbeddings, execution.OperationProbe, execution.RouteNative),

--- a/internal/channel/newapi_module_test.go
+++ b/internal/channel/newapi_module_test.go
@@ -68,6 +68,7 @@ func TestNewAPIChannelContract(t *testing.T) {
 			execution.OperationImagesGenerate: RouteNative,
 			execution.OperationImagesEdit:     RouteNative,
 		},
+		protocol.Rerank: {execution.OperationRerank: RouteNative, execution.OperationProbe: RouteNative},
 		protocol.OpenAIEmbeddings: {
 			execution.OperationEmbeddingsCreate: RouteNative,
 			execution.OperationProbe:            RouteNative,

--- a/internal/channel/rerank_module_test.go
+++ b/internal/channel/rerank_module_test.go
@@ -1,0 +1,30 @@
+package channel
+
+import (
+	"testing"
+
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+)
+
+func TestRerankNativeCapabilitiesAreExplicit(t *testing.T) {
+	registry := NewRegistry()
+	for _, descriptor := range registry.List() {
+		definition, ok := registry.lookup(descriptor.ID)
+		if !ok {
+			t.Fatal("missing definition")
+		}
+		want := descriptor.ID == OpenAICompatible || descriptor.ID == NewAPI || descriptor.ID == GPTLoad
+		for _, operation := range []execution.Operation{execution.OperationRerank, execution.OperationProbe} {
+			mode, present := definition.modes[protocol.Rerank][operation]
+			if present != want || present && mode != RouteNative {
+				t.Errorf("%s/%s: mode=%s present=%t want=%t", descriptor.ID, operation, mode, present, want)
+			}
+		}
+	}
+	for _, operation := range []execution.Operation{execution.OperationChatCompletion, execution.OperationEmbeddingsCreate, execution.OperationListModels} {
+		if validProtocolOperation(protocol.Rerank, operation) {
+			t.Errorf("invalid rerank operation %s", operation)
+		}
+	}
+}

--- a/internal/channel/route_golden_test.go
+++ b/internal/channel/route_golden_test.go
@@ -41,7 +41,7 @@ func TestBuiltInRouteGolden(t *testing.T) {
 	}
 
 	digest := fmt.Sprintf("%x", sha256.Sum256([]byte(strings.Join(got, "\n"))))
-	const wantDigest = "4ae1835a06b87aa3b6cff9958ca9aaf81f287c84883af6b241dd910bacf9bdaf"
+	const wantDigest = "70566b49763604e52ef7abc92670564289e9413b272cc7fb4d28aa0183c2ccd0"
 	if digest != wantDigest {
 		t.Fatalf("built-in routes changed: digest = %s, want %s\n%s", digest, wantDigest, strings.Join(got, "\n"))
 	}
@@ -62,6 +62,7 @@ func allGoldenOperations() []execution.Operation {
 		execution.OperationImagesGenerate,
 		execution.OperationImagesEdit,
 		execution.OperationEmbeddingsCreate,
+		execution.OperationRerank,
 		execution.OperationListModels,
 		execution.OperationProbe,
 	}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -153,6 +153,7 @@ func BuildContainer() (*dig.Container, error) {
 		dialect.NewOpenAIResponses,
 		dialect.NewOpenAIImages,
 		dialect.NewOpenAIEmbeddings,
+		dialect.NewRerank,
 		dialect.NewAnthropic,
 		dialect.NewGemini,
 		func(
@@ -160,10 +161,11 @@ func BuildContainer() (*dig.Container, error) {
 			openAIResponses *dialect.OpenAIResponses,
 			openAIImages *dialect.OpenAIImages,
 			openAIEmbeddings *dialect.OpenAIEmbeddings,
+			rerank *dialect.Rerank,
 			anthropic *dialect.Anthropic,
 			gemini *dialect.Gemini,
 		) dialect.Set {
-			return dialect.NewSet(openAI, openAIResponses, openAIImages, openAIEmbeddings, anthropic, gemini)
+			return dialect.NewSet(openAI, openAIResponses, openAIImages, openAIEmbeddings, rerank, anthropic, gemini)
 		},
 		func(registry *channel.Registry) (*bifrostexecutor.RuntimeManager, error) {
 			return bifrostexecutor.NewManagedRuntime(registry)

--- a/internal/container/container_test.go
+++ b/internal/container/container_test.go
@@ -519,6 +519,7 @@ func TestBuildContainerResolvesAllDialects(t *testing.T) {
 		openAIResponses *dialect.OpenAIResponses,
 		openAIImages *dialect.OpenAIImages,
 		openAIEmbeddings *dialect.OpenAIEmbeddings,
+		rerank *dialect.Rerank,
 		anthropic *dialect.Anthropic,
 		gemini *dialect.Gemini,
 		values dialect.Set,
@@ -534,8 +535,9 @@ func TestBuildContainerResolvesAllDialects(t *testing.T) {
 			values[protocol.OpenAIResponses] != openAIResponses ||
 			values[protocol.OpenAIImages] != openAIImages ||
 			values[protocol.OpenAIEmbeddings] != openAIEmbeddings ||
+			values[protocol.Rerank] != rerank ||
 			values[protocol.Anthropic] != anthropic ||
-			values[protocol.Gemini] != gemini || len(values) != 6 {
+			values[protocol.Gemini] != gemini || len(values) != 7 {
 			t.Fatalf("dialect Set = %#v", values)
 		}
 	})

--- a/internal/control/access_keys_test.go
+++ b/internal/control/access_keys_test.go
@@ -155,6 +155,7 @@ func TestAccessKeyCreateAcceptsAllEnabledProtocolsInCanonicalOrder(t *testing.T)
 				protocol.Gemini,
 				protocol.OpenAIImages,
 				protocol.OpenAIEmbeddings,
+				protocol.Rerank,
 				protocol.OpenAIResponses,
 				protocol.Anthropic,
 				protocol.OpenAICompletions,

--- a/internal/control/credential_probe.go
+++ b/internal/control/credential_probe.go
@@ -181,9 +181,7 @@ func (probe *credentialProbeExecutor) Probe(
 		generation = 1
 	}
 	probeProtocols := []protocol.Protocol{target.protocol}
-	if target.fallbackProtocol != "" {
-		probeProtocols = append(probeProtocols, target.fallbackProtocol)
-	}
+	probeProtocols = append(probeProtocols, target.fallbackProtocols...)
 	startedAt := probe.now()
 	for index, probeProtocol := range probeProtocols {
 		routeMode, supported := group.ResolvedTarget.ModeForModel(
@@ -235,7 +233,7 @@ func (probe *credentialProbeExecutor) Probe(
 			result: result, latency: latency, protocol: probeProtocol,
 		}
 		if credentialProbePassed(result) || index+1 == len(probeProtocols) ||
-			!validationProbeNeedsEmbeddingsFallback(result) {
+			!validationProbeNeedsProtocolFallback(result) {
 			return executed, nil
 		}
 	}

--- a/internal/control/rerank_validation_test.go
+++ b/internal/control/rerank_validation_test.go
@@ -1,0 +1,46 @@
+package control
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+	"gpt-load/internal/state"
+)
+
+func TestRerankValidationFallbackRecoversOnlyAfterSuccessfulProbe(t *testing.T) {
+	for _, status := range []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusTooManyRequests, http.StatusInternalServerError} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			group := state.GroupView{ValidationModel: "reranker"}
+			setValidationChannel(&group, channel.OpenAICompatible, json.RawMessage(`{"base_url":"https://example.com/v1"}`))
+			worker := newValidationWorkerForTest(validationSnapshot(map[uint]state.GroupView{1: group}), []state.CredentialRef{{ID: 7, GroupID: 1, EncryptedValue: "key-7"}}, &validationProbeRecorder{})
+			var protocols []protocol.Protocol
+			worker.executor = scriptedDiscoveryExecutor{execute: func(_ context.Context, spec execution.AttemptSpec) execution.AttemptResult {
+				protocols = append(protocols, spec.ClientProtocol)
+				if spec.ClientProtocol == protocol.Rerank {
+					return execution.AttemptResult{DispatchState: execution.DispatchMaybeSent, ResponseStarted: true, StatusCode: 200, Header: http.Header{}}
+				}
+				return validationStartedProbeFailure(status, execution.FailureHintModelUnavailable, execution.ErrorScopeModel, "model_not_found", "unsupported model")
+			}}
+			worker.Validate(context.Background())
+			want := []protocol.Protocol{protocol.OpenAICompletions}
+			if status == http.StatusBadRequest {
+				want = append(want, protocol.OpenAIEmbeddings, protocol.Rerank)
+			}
+			if !reflect.DeepEqual(protocols, want) {
+				t.Fatalf("probes=%v want=%v", protocols, want)
+			}
+			if status == http.StatusBadRequest && !reflect.DeepEqual(worker.recorder.events(), []string{"registry.recover:7", "stats.reset:7"}) {
+				t.Fatalf("events=%v", worker.recorder.events())
+			}
+			if status != http.StatusBadRequest && len(worker.recorder.events()) != 0 {
+				t.Fatalf("unexpected recovery: %v", worker.recorder.events())
+			}
+		})
+	}
+}

--- a/internal/control/validation.go
+++ b/internal/control/validation.go
@@ -63,10 +63,10 @@ type validationWorker struct {
 type groupValidationSignature [sha256.Size]byte
 
 type groupValidationTarget struct {
-	protocol         protocol.Protocol
-	fallbackProtocol protocol.Protocol
-	model            string
-	signature        groupValidationSignature
+	protocol          protocol.Protocol
+	fallbackProtocols []protocol.Protocol
+	model             string
+	signature         groupValidationSignature
 }
 
 var _ validationSweep = (*validationWorker)(nil)
@@ -306,18 +306,18 @@ func buildGroupValidationTarget(group state.GroupView) (groupValidationTarget, b
 	if !ok {
 		return groupValidationTarget{}, false
 	}
-	fallbackProtocol := protocol.Protocol("")
-	if selectedProtocol != protocol.OpenAIEmbeddings {
-		if mode, supported := group.ResolvedTarget.ModeForModel(
-			protocol.OpenAIEmbeddings,
-			execution.OperationProbe,
-			probeModel,
-		); supported && mode == channel.RouteNative {
-			fallbackProtocol = protocol.OpenAIEmbeddings
+	var fallbackProtocols []protocol.Protocol
+	for _, candidate := range []protocol.Protocol{protocol.OpenAIEmbeddings, protocol.Rerank} {
+		if candidate == selectedProtocol {
+			continue
+		}
+		if mode, supported := group.ResolvedTarget.ModeForModel(candidate, execution.OperationProbe, probeModel); supported && mode == channel.RouteNative {
+			fallbackProtocols = append(fallbackProtocols, candidate)
 		}
 	}
+
 	return groupValidationTarget{
-		protocol: selectedProtocol, fallbackProtocol: fallbackProtocol,
+		protocol: selectedProtocol, fallbackProtocols: fallbackProtocols,
 		model:     probeModel,
 		signature: computeGroupValidationSignature(group, selectedProtocol, probeModel),
 	}, true
@@ -327,7 +327,7 @@ func validationProtocol(target channel.ResolvedTarget, model string) (protocol.P
 	return target.PreferredProtocol(execution.OperationProbe, model)
 }
 
-func validationProbeNeedsEmbeddingsFallback(result execution.AttemptResult) bool {
+func validationProbeNeedsProtocolFallback(result execution.AttemptResult) bool {
 	if result.Validate() != nil || result.Error == nil ||
 		result.DispatchState != execution.DispatchMaybeSent || !result.ResponseStarted {
 		return false

--- a/internal/control/validation_test.go
+++ b/internal/control/validation_test.go
@@ -232,8 +232,8 @@ func TestValidationProbeEmbeddingsFallbackEvidenceIsNarrow(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			if got := validationProbeNeedsEmbeddingsFallback(test.result); got != test.want {
-				t.Fatalf("validationProbeNeedsEmbeddingsFallback() = %t, want %t; result=%#v", got, test.want, test.result)
+			if got := validationProbeNeedsProtocolFallback(test.result); got != test.want {
+				t.Fatalf("validationProbeNeedsProtocolFallback() = %t, want %t; result=%#v", got, test.want, test.result)
 			}
 		})
 	}

--- a/internal/dialect/rerank.go
+++ b/internal/dialect/rerank.go
@@ -1,0 +1,157 @@
+package dialect
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"mime"
+	"net/http"
+	"strings"
+
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+)
+
+const rerankPath = "/v1/rerank"
+
+// Rerank 实现 query/documents 纯文本原生接口。
+type Rerank struct{}
+
+func NewRerank() *Rerank { return &Rerank{} }
+
+func (*Rerank) Protocol() protocol.Protocol { return protocol.Rerank }
+
+func (d *Rerank) InspectRequest(request *ParsedRequest) (RequestMetadata, error) {
+	if request == nil || request.Method != http.MethodPost || request.Path != rerankPath {
+		return RequestMetadata{}, fmt.Errorf("rerank requires POST %s", rerankPath)
+	}
+	if value := request.Header.Get("Content-Type"); strings.TrimSpace(value) != "" {
+		mediaType, _, err := mime.ParseMediaType(value)
+		if err != nil || !strings.EqualFold(mediaType, "application/json") {
+			return RequestMetadata{}, fmt.Errorf("rerank requires application/json")
+		}
+	}
+	metadata, err := inspectJSONRequestFields(request.Body, true)
+	if err != nil {
+		return RequestMetadata{}, err
+	}
+	if metadata.Stream {
+		return RequestMetadata{}, fmt.Errorf("rerank does not support streaming")
+	}
+	if err := validateRerankInput(request.Body); err != nil {
+		return RequestMetadata{}, err
+	}
+	metadata.Operation = execution.OperationRerank
+	metadata.RouteRequirement = execution.RouteRequirementNative
+	metadata.ObserveUsage = true
+	return metadata, nil
+}
+
+func validateRerankInput(body []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	if _, err := decoder.Token(); err != nil {
+		return fmt.Errorf("decode rerank request")
+	}
+	seen := make(map[string]bool, 4)
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return fmt.Errorf("decode rerank field")
+		}
+		field, ok := token.(string)
+		if !ok {
+			return fmt.Errorf("invalid rerank field")
+		}
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return fmt.Errorf("decode rerank value")
+		}
+		name := strings.ToLower(field)
+		switch name {
+		case "query", "documents", "top_n", "return_documents":
+			if field != name || seen[name] {
+				return fmt.Errorf("rerank %s must be unique and lowercase", name)
+			}
+			seen[name] = true
+		default:
+			continue
+		}
+		switch name {
+		case "query":
+			var query string
+			if json.Unmarshal(raw, &query) != nil || strings.TrimSpace(query) == "" {
+				return fmt.Errorf("rerank query must be a non-empty string")
+			}
+		case "documents":
+			var documents []json.RawMessage
+			if json.Unmarshal(raw, &documents) != nil || len(documents) == 0 {
+				return fmt.Errorf("rerank documents must be a non-empty string array")
+			}
+			for _, document := range documents {
+				if !jsonEmbeddingString(document) {
+					return fmt.Errorf("rerank documents must contain only strings")
+				}
+			}
+		case "top_n":
+			value := strings.TrimSpace(string(raw))
+			if !jsonInteger(raw) || value[0] == '-' || value == "0" {
+				return fmt.Errorf("rerank top_n must be a positive integer")
+			}
+		case "return_documents":
+			value := string(bytes.TrimSpace(raw))
+			if value != "true" && value != "false" {
+				return fmt.Errorf("rerank return_documents must be a boolean")
+			}
+		}
+	}
+	if !seen["query"] || !seen["documents"] {
+		return fmt.Errorf("rerank query and documents are required")
+	}
+	return nil
+}
+
+func (d *Rerank) RewriteRequestModel(request *ParsedRequest, model string) (*ParsedRequest, error) {
+	if err := validateModelRewriteTarget(model, false); err != nil {
+		return nil, err
+	}
+	if _, err := d.InspectRequest(request); err != nil {
+		return nil, err
+	}
+	object, err := decodeJSONObject(request.Body)
+	if err != nil {
+		return nil, err
+	}
+	for field := range object {
+		if openAIEmbeddingsControlField(field) || field == "stream" {
+			delete(object, field)
+		}
+	}
+	encodedModel, err := json.Marshal(model)
+	if err != nil {
+		return nil, fmt.Errorf("encode rerank model: %w", err)
+	}
+	object["model"] = encodedModel
+	body, err := json.Marshal(object)
+	if err != nil {
+		return nil, fmt.Errorf("encode rerank request: %w", err)
+	}
+	clone, err := cloneParsedRequest(request)
+	if err != nil {
+		return nil, err
+	}
+	clone.Body = body
+	if clone.Header == nil {
+		clone.Header = make(http.Header)
+	}
+	if clone.Header.Get("Content-Type") == "" {
+		clone.Header.Set("Content-Type", "application/json")
+	}
+	return clone, nil
+}
+
+func (*Rerank) RewriteResponseModel(body []byte, model string) ([]byte, error) {
+	if err := validateModelRewriteTarget(model, false); err != nil {
+		return nil, err
+	}
+	return rewriteOptionalJSONField(body, "model", model)
+}

--- a/internal/dialect/rerank_test.go
+++ b/internal/dialect/rerank_test.go
@@ -1,0 +1,133 @@
+package dialect
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+	"gpt-load/internal/usage"
+)
+
+func rerankDialect(t *testing.T) Dialect {
+	t.Helper()
+	selected, _, err := standardRequest(protocol.Protocol("rerank"), "public")
+	if err != nil {
+		t.Fatalf("Rerank standard request unavailable: %v", err)
+	}
+	return selected
+}
+
+func TestRerankRequestContract(t *testing.T) {
+	d := rerankDialect(t)
+	for _, test := range []struct {
+		name, body string
+		valid      bool
+	}{
+		{"text", `{"model":"public","query":"hello","documents":["a",""]}`, true},
+		{"options", `{"model":"public","query":"hello","documents":["a"],"top_n":1,"return_documents":false,"stream":false,"future":1.2300}`, true},
+		{"missing model", `{"query":"q","documents":["a"]}`, false},
+		{"missing query", `{"model":"m","documents":["a"]}`, false},
+		{"empty query", `{"model":"m","query":" ","documents":["a"]}`, false},
+		{"missing documents", `{"model":"m","query":"q"}`, false},
+		{"empty documents", `{"model":"m","query":"q","documents":[]}`, false},
+		{"null document", `{"model":"m","query":"q","documents":[null]}`, false},
+		{"object documents", `{"model":"m","query":"q","documents":[{"text":"a"}]}`, false},
+		{"query duplicate", `{"model":"m","query":"q","query":"r","documents":["a"]}`, false},
+		{"case alias", `{"model":"m","Query":"q","documents":["a"]}`, false},
+		{"documents duplicate", `{"model":"m","query":"q","documents":["a"],"documents":["b"]}`, false},
+		{"top_n zero", `{"model":"m","query":"q","documents":["a"],"top_n":0}`, false},
+		{"top_n fractional", `{"model":"m","query":"q","documents":["a"],"top_n":1.5}`, false},
+		{"return_documents null", `{"model":"m","query":"q","documents":["a"],"return_documents":null}`, false},
+		{"stream", `{"model":"m","query":"q","documents":["a"],"stream":true}`, false},
+		{"trailing data", `{"model":"m","query":"q","documents":["a"]}{}`, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			metadata, err := d.InspectRequest(&ParsedRequest{Method: http.MethodPost, Path: "/v1/rerank", Body: []byte(test.body)})
+			if (err == nil) != test.valid {
+				t.Fatalf("valid=%t, err=%v", test.valid, err)
+			}
+			if err == nil && (metadata.Operation != execution.Operation("rerank") || metadata.Stream || !metadata.ObserveUsage || metadata.RouteRequirement != execution.RouteRequirementNative || len(metadata.AffinityPrefix) != 0) {
+				t.Fatalf("metadata = %#v", metadata)
+			}
+		})
+	}
+	for _, request := range []*ParsedRequest{
+		nil,
+		{Method: http.MethodGet, Path: "/v1/rerank"},
+		{Method: http.MethodPost, Path: "/v1/embeddings"},
+		{Method: http.MethodPost, Path: "/v1/rerank", Header: http.Header{"Content-Type": {"text/plain"}}},
+		{Method: http.MethodPost, Path: "/v1/rerank", Body: []byte{'{', 0xff, '}'}},
+	} {
+		if _, err := d.InspectRequest(request); err == nil {
+			t.Fatal("invalid request accepted")
+		}
+	}
+}
+
+func TestRerankModelRewritePreservesWireValues(t *testing.T) {
+	d := rerankDialect(t).(ModelRewriter)
+	body := []byte(`{"model":"public","query":"q","documents":["a"],"stream":false,"api_key":"injected","fallbacks":["other"],"future":1.2300}`)
+	request := &ParsedRequest{Method: http.MethodPost, Path: "/v1/rerank", Body: body}
+	got, err := d.RewriteRequestModel(request, "upstream")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, value := range []string{`"model":"upstream"`, `"future":1.2300`, `"documents":["a"]`} {
+		if !bytes.Contains(got.Body, []byte(value)) {
+			t.Fatalf("missing %s in %s", value, got.Body)
+		}
+	}
+	for _, value := range []string{"api_key", "fallbacks", "stream"} {
+		if bytes.Contains(got.Body, []byte(`"`+value+`":`)) {
+			t.Fatalf("control field retained: %s", got.Body)
+		}
+	}
+	if !bytes.Equal(request.Body, body) {
+		t.Fatal("request mutated")
+	}
+	response := []byte(`{"model":"upstream","results":[{"index":1,"relevance_score":0.1234567890123456789,"document":{"text":"upstream"}}],"future":1.2300}`)
+	rewritten, err := d.RewriteResponseModel(response, "public")
+	var before, after map[string]json.RawMessage
+	if json.Unmarshal(response, &before) != nil || json.Unmarshal(rewritten, &after) != nil {
+		t.Fatal("invalid response JSON")
+	}
+	if err != nil || string(after["model"]) != `"public"` || !bytes.Equal(before["results"], after["results"]) || !bytes.Equal(before["future"], after["future"]) {
+		t.Fatalf("response=%s err=%v", rewritten, err)
+	}
+	withoutModel := []byte(`{"results":[]}`)
+	gotBody, err := d.RewriteResponseModel(withoutModel, "public")
+	if err != nil || !bytes.Equal(gotBody, withoutModel) {
+		t.Fatalf("absent model: %s %v", gotBody, err)
+	}
+}
+
+func TestRerankUsageRequiresConsistentTokenEvidence(t *testing.T) {
+	d := rerankDialect(t).(UsageExtractor)
+	for _, test := range []struct {
+		body  string
+		input int64
+		state usage.State
+	}{
+		{`{"usage":{"total_tokens":20}}`, 20, usage.StateComplete},
+		{`{"usage":{"prompt_tokens":20,"total_tokens":20}}`, 20, usage.StateComplete},
+		{`{"usage":{"input_tokens":20}}`, 20, usage.StateComplete},
+		{`{"meta":{"tokens":{"input_tokens":20}}}`, 20, usage.StateComplete},
+		{`{"meta":{"billed_units":{"input_tokens":20}}}`, 20, usage.StateComplete},
+		{`{"usage":{"total_tokens":0}}`, 0, usage.StateComplete},
+		{`{"meta":{"billed_units":{"search_units":1}}}`, 0, usage.StateMissing},
+		{`{"results":[]}`, 0, usage.StateMissing},
+		{`{"usage":{"total_tokens":-1}}`, 0, usage.StateMissing},
+		{`{"usage":{"total_tokens":1.5}}`, 0, usage.StateMissing},
+		{`{"usage":{"total_tokens":9223372036854775808}}`, 0, usage.StateMissing},
+		{`{"usage":{"prompt_tokens":10,"total_tokens":20}}`, 0, usage.StateMissing},
+		{`{"usage":{"input_tokens":10,"total_tokens":10,"output_tokens":2}}`, 0, usage.StateMissing},
+	} {
+		got, err := d.ExtractUsage([]byte(test.body))
+		if err != nil || got.State != test.state || got.Tokens != (usage.Tokens{UncachedInput: test.input}) {
+			t.Fatalf("%s: %#v %v", test.body, got, err)
+		}
+	}
+}

--- a/internal/dialect/rerank_usage.go
+++ b/internal/dialect/rerank_usage.go
@@ -1,0 +1,101 @@
+package dialect
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"gpt-load/internal/usage"
+)
+
+func (*Rerank) ExtractUsage(body []byte) (usage.Result, error) {
+	root, err := decodeJSONObject(body)
+	if err != nil {
+		return usage.Result{}, fmt.Errorf("decode rerank usage response")
+	}
+	object, diagnostics := usageOptionalObject(root, "usage")
+	meta, metaDiagnostics := usageOptionalObject(root, "meta")
+	diagnostics.Merge(metaDiagnostics)
+	tokens, tokenDiagnostics := usageOptionalObject(meta, "tokens")
+	diagnostics.Merge(tokenDiagnostics)
+	billed, billedDiagnostics := usageOptionalObject(meta, "billed_units")
+	diagnostics.Merge(billedDiagnostics)
+	var input *int64
+	invalid := !usageIntegerUsable(diagnostics)
+	// 只采用明确且一致的 Token 证据；search_units 不属于 Token。
+	for _, source := range []struct {
+		value *int64
+		diag  usage.Diagnostics
+	}{
+		rerankUsageInteger(object, "prompt_tokens"),
+		rerankUsageInteger(object, "input_tokens"),
+		rerankUsageInteger(object, "total_tokens"),
+		rerankUsageInteger(tokens, "input_tokens"),
+		rerankUsageInteger(billed, "input_tokens"),
+	} {
+		diagnostics.Merge(source.diag)
+		if !usageIntegerUsable(source.diag) {
+			invalid = true
+		}
+		if source.value == nil {
+			continue
+		}
+		if input != nil && *input != *source.value {
+			diagnostics.Add(usage.DiagnosticInconsistentTotal)
+			invalid = true
+		}
+		input = source.value
+	}
+	for _, source := range []struct {
+		value *int64
+		diag  usage.Diagnostics
+	}{
+		rerankUsageInteger(object, "output_tokens"),
+		rerankUsageInteger(object, "completion_tokens"),
+		rerankUsageInteger(tokens, "output_tokens"),
+		rerankUsageInteger(billed, "output_tokens"),
+	} {
+		diagnostics.Merge(source.diag)
+		if !usageIntegerUsable(source.diag) || source.value != nil && *source.value != 0 {
+			diagnostics.Add(usage.DiagnosticUnsupportedBillableDetail)
+			invalid = true
+		}
+	}
+	if invalid {
+		input = nil
+	}
+	var accumulator usage.Accumulator
+	if err := accumulator.ReplaceSnapshot(usage.Patch{UncachedInput: input, Final: true, Diagnostics: diagnostics}); err != nil {
+		return usage.Result{}, fmt.Errorf("normalize rerank usage response")
+	}
+	result, _ := accumulator.Finalize(true)
+	return result, nil
+}
+
+func (*Rerank) NewUsageStreamExtractor() UsageStreamExtractor {
+	return &rerankUnsupportedStreamUsage{}
+}
+
+type rerankUnsupportedStreamUsage struct{ finalized bool }
+
+func (*rerankUnsupportedStreamUsage) Observe([]byte) error {
+	return fmt.Errorf("rerank does not support streaming usage")
+}
+
+func (e *rerankUnsupportedStreamUsage) Finalize() (usage.Result, bool) {
+	if e.finalized {
+		return usage.Result{}, false
+	}
+	e.finalized = true
+	return usage.Result{State: usage.StateNotApplicable}, true
+}
+
+func rerankUsageInteger(object map[string]json.RawMessage, field string) struct {
+	value *int64
+	diag  usage.Diagnostics
+} {
+	value, diag := usageInteger(object, field, false)
+	return struct {
+		value *int64
+		diag  usage.Diagnostics
+	}{value, diag}
+}

--- a/internal/dialect/standard_request.go
+++ b/internal/dialect/standard_request.go
@@ -44,6 +44,10 @@ func standardRequest(
 		selected = NewOpenAIEmbeddings()
 		request.Path = openAIEmbeddingsPath
 		body = map[string]any{"model": model, "input": ""}
+	case protocol.Rerank:
+		selected = NewRerank()
+		request.Path = rerankPath
+		body = map[string]any{"model": model, "query": "ping", "documents": []string{"ping"}, "top_n": 1}
 	case protocol.Anthropic:
 		selected = NewAnthropic()
 		request.Path = "/v1/messages"

--- a/internal/execution/bifrost/capabilities.go
+++ b/internal/execution/bifrost/capabilities.go
@@ -39,9 +39,9 @@ func convertedRouteImplemented(providerKind channel.ProviderKind, clientProtocol
 	case execution.OperationImagesGenerate:
 		return providerKind == channel.ProviderGemini && clientProtocol == protocol.OpenAIImages
 	case execution.OperationListModels:
-		return clientProtocol != protocol.OpenAIResponses && clientProtocol.Valid()
+		return clientProtocol != protocol.OpenAIResponses && clientProtocol != protocol.Rerank && clientProtocol.Valid()
 	case execution.OperationProbe:
-		return clientProtocol.Valid()
+		return clientProtocol != protocol.Rerank && clientProtocol.Valid()
 	case execution.OperationChatCompletion:
 		return clientProtocol == protocol.OpenAICompletions ||
 			clientProtocol == protocol.Anthropic ||
@@ -62,6 +62,9 @@ func nativeRouteImplemented(
 	clientProtocol protocol.Protocol,
 	operation execution.Operation,
 ) bool {
+	if clientProtocol == protocol.Rerank {
+		return (providerKind == channel.ProviderOpenAICompatible || providerKind == channel.ProviderMultiProtocolGateway) && (operation == execution.OperationRerank || operation == execution.OperationProbe)
+	}
 	switch providerKind {
 	case channel.ProviderOpenAI:
 		if clientProtocol == protocol.OpenAIEmbeddings {

--- a/internal/execution/bifrost/executor.go
+++ b/internal/execution/bifrost/executor.go
@@ -68,6 +68,7 @@ func (r *Runtime) Execute(parent context.Context, spec execution.AttemptSpec) (r
 	defer func() {
 		normalizeImagesAttemptResult(spec, &result)
 		normalizeEmbeddingsAttemptResult(spec, &result)
+		normalizeRerankAttemptResult(spec, &result)
 	}()
 	prepared, preflightError := r.prepare(spec, false)
 	if preflightError != nil {
@@ -491,6 +492,9 @@ func (r *Runtime) prepare(spec execution.AttemptSpec, stream bool) (preparedAtte
 	if providerKind == channel.ProviderDeepSeek && spec.ClientProtocol == protocol.Anthropic {
 		directKey.UseAnthropicEndpoints = schemas.Ptr(true)
 	}
+	if spec.ClientProtocol == protocol.Rerank {
+		return prepareRerank(spec, resolved, provider, directKey, secrets)
+	}
 	if spec.Operation == execution.OperationProbe {
 		if spec.ClientProtocol == protocol.OpenAIEmbeddings {
 			typedURL, targetErr := embeddingTypedTarget(providerKind, resolved.TargetConfig, "")
@@ -905,7 +909,7 @@ func supportedRequestShape(spec execution.AttemptSpec, stream bool) bool {
 			return false
 		}
 		switch spec.ClientProtocol {
-		case protocol.OpenAICompletions, protocol.OpenAIResponses, protocol.OpenAIEmbeddings,
+		case protocol.OpenAICompletions, protocol.OpenAIResponses, protocol.OpenAIEmbeddings, protocol.Rerank,
 			protocol.Anthropic, protocol.Gemini:
 			return true
 		default:
@@ -948,6 +952,8 @@ func supportedRequestShape(spec execution.AttemptSpec, stream bool) bool {
 		default:
 			return false
 		}
+	case protocol.Rerank:
+		return !stream && spec.RouteMode == execution.RouteNative && spec.Operation == execution.OperationRerank && spec.Method == http.MethodPost && spec.Path == "/v1/rerank"
 	case protocol.OpenAIEmbeddings:
 		return !stream && spec.RouteMode == execution.RouteNative &&
 			spec.Operation == execution.OperationEmbeddingsCreate &&

--- a/internal/execution/bifrost/passthrough.go
+++ b/internal/execution/bifrost/passthrough.go
@@ -691,7 +691,7 @@ func usageEvidenceFromPassthroughForSpec(
 	spec execution.AttemptSpec,
 	source *schemas.BifrostPassthroughUsage,
 ) (*execution.UsageEvidence, error) {
-	if spec.ClientProtocol == protocol.OpenAIImages {
+	if spec.ClientProtocol == protocol.OpenAIImages || spec.ClientProtocol == protocol.Rerank {
 		return nil, nil
 	}
 	return usageEvidenceFromPassthrough(source)

--- a/internal/execution/bifrost/rerank.go
+++ b/internal/execution/bifrost/rerank.go
@@ -1,0 +1,90 @@
+package bifrost
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/maximhq/bifrost/core/schemas"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/dialect"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/platform/contentcoding"
+	"gpt-load/internal/protocol"
+)
+
+func prepareRerank(
+	spec execution.AttemptSpec,
+	resolved channel.ResolvedTarget,
+	provider schemas.ModelProvider,
+	directKey schemas.Key,
+	secrets []string,
+) (preparedAttempt, *execution.AttemptResult) {
+	request := &dialect.ParsedRequest{Method: http.MethodPost, Path: "/v1/rerank", Header: spec.Header.Clone(), Body: spec.Body}
+	if spec.Operation == execution.OperationProbe {
+		body, err := json.Marshal(map[string]any{
+			"model": spec.UpstreamModel, "query": "ping", "documents": []string{"ping"}, "top_n": 1,
+		})
+		if err != nil {
+			failure := notSentUnaryFailure(execution.ErrorKindInternal, "encode rerank probe")
+			return preparedAttempt{}, &failure
+		}
+		request.Body = body
+	}
+	request, err := dialect.NewRerank().RewriteRequestModel(request, spec.UpstreamModel)
+	if err != nil {
+		failure := notSentUnaryFailure(execution.ErrorKindInvalidRequest, "invalid rerank request body")
+		failure.Error.OriginHint = execution.ErrorOriginClient
+		failure.Error.ScopeHint = execution.ErrorScopeRequest
+		return preparedAttempt{}, &failure
+	}
+	baseURL, configured, err := targetBaseURL(resolved.TargetConfig)
+	if err != nil || !configured {
+		failure := notSentUnaryFailure(execution.ErrorKindInvalidRequest, "invalid rerank target")
+		return preparedAttempt{}, &failure
+	}
+	path := "/rerank"
+	if resolved.ProviderKind == channel.ProviderMultiProtocolGateway {
+		path = "/v1/rerank"
+	}
+	return preparedAttempt{
+		provider: provider, mode: channel.RouteNative, upstreamProtocol: protocol.Rerank,
+		clientProtocol: protocol.Rerank, directKey: directKey, secrets: secrets,
+		passthrough: &schemas.BifrostPassthroughRequest{
+			Provider: provider, Model: spec.UpstreamModel, Method: http.MethodPost,
+			Path: path, UpstreamURL: baseURL, RawQuery: safeAttemptQuery(spec),
+			Body: request.Body, SafeHeaders: safePassthroughHeaders(request.Header),
+		},
+	}, nil
+}
+
+func normalizeRerankAttemptResult(spec execution.AttemptSpec, result *execution.AttemptResult) {
+	if result == nil || spec.ClientProtocol != protocol.Rerank {
+		return
+	}
+	if result.Error != nil {
+		if result.Error.ReplaySafety == "" {
+			result.Error.ReplaySafety = execution.ReplaySafetyUnknown
+		}
+		return
+	}
+	if spec.Operation != execution.OperationProbe || result.StatusCode < 200 || result.StatusCode >= 300 {
+		return
+	}
+	encoding, err := contentcoding.ParseContentEncoding(result.Header.Values("Content-Encoding"))
+	var body []byte
+	if err == nil {
+		body, err = contentcoding.DecodeLimited(encoding, result.Body, execution.UnaryResponseBodyLimit(protocol.Rerank))
+	}
+	var response struct {
+		Results []struct {
+			Index *int     `json:"index"`
+			Score *float64 `json:"relevance_score"`
+		} `json:"results"`
+	}
+	if err != nil || json.Unmarshal(body, &response) != nil || len(response.Results) != 1 ||
+		response.Results[0].Index == nil || *response.Results[0].Index != 0 || response.Results[0].Score == nil {
+		*result = startedUnaryFailure(result.StatusCode, result.Header, execution.ErrorKindInternal, "upstream returned an invalid rerank probe response")
+		result.UpstreamProtocol = protocol.Rerank
+	}
+}

--- a/internal/execution/bifrost/rerank_test.go
+++ b/internal/execution/bifrost/rerank_test.go
@@ -1,0 +1,147 @@
+package bifrost
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+)
+
+func rerankSpec(id channel.ID, baseURL string) execution.AttemptSpec {
+	spec := openAIEmbeddingsSpec(id, baseURL, []byte(`{"model":"public","query":"q","documents":["a","b"],"stream":false,"api_key":"injected","future":1.2300}`))
+	spec.ClientProtocol = protocol.Rerank
+	spec.Operation = execution.OperationRerank
+	spec.Path = "/v1/rerank"
+	spec.ClientModel = "public"
+	spec.RawQuery = "tenant=a%2Bb&api_key=injected"
+	return freezeTestAttempt(spec)
+}
+
+func TestRerankRuntimePreservesNativeWireAcrossSupportedChannels(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		id           channel.ID
+		prefix, path string
+	}{
+		{channel.OpenAICompatible, "/tenant/api/v4", "/tenant/api/v4/rerank"},
+		{channel.OpenAICompatible, "/v2", "/v2/rerank"},
+		{channel.NewAPI, "/team", "/team/v1/rerank"},
+		{channel.GPTLoad, "/team", "/team/v1/rerank"},
+	} {
+		t.Run(string(test.id)+test.prefix, func(t *testing.T) {
+			var calls atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				if r.Method != http.MethodPost || r.URL.Path != test.path || r.URL.RawQuery != "tenant=a%2Bb" {
+					t.Errorf("target: %s %s", r.Method, r.URL)
+				}
+				if r.Header.Get("Authorization") != "Bearer "+testAPIKey || r.Header.Get("X-Api-Key") != "" {
+					t.Error("credential headers were not replaced")
+				}
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				var object map[string]json.RawMessage
+				if json.Unmarshal(body, &object) != nil || string(object["model"]) != `"provider-model"` || string(object["query"]) != `"q"` || string(object["future"]) != "1.2300" {
+					t.Errorf("body=%s", body)
+				}
+				for _, field := range []string{"stream", "api_key", "fallbacks"} {
+					if _, exists := object[field]; exists {
+						t.Errorf("control field %s retained", field)
+					}
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("X-Request-Id", "rerank-request")
+				_, _ = io.WriteString(w, `{"model":"provider-model","results":[{"index":1,"relevance_score":0.1234567890123456789,"document":{"text":"a"}}],"future":1.2300,"usage":{"total_tokens":8}}`)
+			}))
+			defer server.Close()
+			runtime := newProtocolTestRuntime(t, testRuntimeOptions{allowPrivateNetwork: true})
+			result := runtime.Execute(context.Background(), rerankSpec(test.id, server.URL+test.prefix))
+			if err := result.Validate(); err != nil || result.Error != nil || result.StatusCode != 200 || calls.Load() != 1 || result.UpstreamProtocol != protocol.Rerank || result.UpstreamRequestID != "rerank-request" {
+				t.Fatalf("calls=%d result=%+v error=%+v contract=%v", calls.Load(), result, result.Error, err)
+			}
+			for _, value := range []string{`"model":"public"`, `"relevance_score":0.1234567890123456789`, `"future":1.2300`} {
+				if !bytes.Contains(result.Body, []byte(value)) {
+					t.Fatalf("missing %s: %s", value, result.Body)
+				}
+			}
+			if runtime.keyPoolCalls() != 0 {
+				t.Fatal("SDK key pool was used")
+			}
+		})
+	}
+}
+
+func TestRerankProbeUsesMinimalBodyAndRejectsInvalidSuccess(t *testing.T) {
+	for _, response := range []string{`{"results":[{"index":0,"relevance_score":0.8}]}`, `{"results":[]}`, `{"choices":[]}`} {
+		t.Run(response, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				var object map[string]json.RawMessage
+				if json.Unmarshal(body, &object) != nil || len(object) != 4 || string(object["query"]) != `"ping"` || string(object["documents"]) != `["ping"]` || string(object["top_n"]) != "1" {
+					t.Errorf("probe=%s", body)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, response)
+			}))
+			defer server.Close()
+			spec := rerankSpec(channel.OpenAICompatible, server.URL+"/v1")
+			spec.Operation = execution.OperationProbe
+			spec.Method, spec.Path, spec.RawQuery = "", "", ""
+			spec.Body = nil
+			runtime := newProtocolTestRuntime(t, testRuntimeOptions{allowPrivateNetwork: true})
+			result := runtime.Execute(context.Background(), freezeTestAttempt(spec))
+			wantSuccess := strings.Contains(response, "relevance_score")
+			if err := result.Validate(); err != nil || (result.Error == nil) != wantSuccess {
+				t.Fatalf("result=%+v error=%+v contract=%v", result, result.Error, err)
+			}
+		})
+	}
+}
+
+func TestRerankRuntimeEnforcesBodyLimitAndCancellation(t *testing.T) {
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("wait") == "true" {
+			select {
+			case <-r.Context().Done():
+			case <-release:
+			}
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"results":[],"extra":"`+strings.Repeat("x", 2048)+`"}`)
+	}))
+	defer server.Close()
+	defer close(release)
+	runtime := newProtocolTestRuntime(t, testRuntimeOptions{allowPrivateNetwork: true, maxUnaryResponseBodyBytes: 1024})
+	spec := rerankSpec(channel.OpenAICompatible, server.URL+"/v1")
+	result := runtime.Execute(context.Background(), spec)
+	if result.Error == nil {
+		t.Fatal("oversized response accepted")
+	}
+	spec.RawQuery = "wait=true"
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	result = runtime.Execute(ctx, freezeTestAttempt(spec))
+	if result.Error == nil || time.Since(started) > time.Second {
+		t.Fatalf("cancellation=%+v", result)
+	}
+}

--- a/internal/execution/bifrost/runtime_manager.go
+++ b/internal/execution/bifrost/runtime_manager.go
@@ -141,7 +141,7 @@ func buildEffectiveProviderConfigForAttempt(
 func multiProtocolGatewayProviderProfile(clientProtocol protocol.Protocol) (schemas.ModelProvider, error) {
 	switch clientProtocol {
 	case "", protocol.OpenAICompletions, protocol.OpenAIResponses,
-		protocol.OpenAIImages, protocol.OpenAIEmbeddings:
+		protocol.OpenAIImages, protocol.OpenAIEmbeddings, protocol.Rerank:
 		return schemas.OpenAI, nil
 	case protocol.Anthropic:
 		return schemas.Anthropic, nil

--- a/internal/execution/contracts.go
+++ b/internal/execution/contracts.go
@@ -43,6 +43,7 @@ const (
 	OperationImagesGenerate       Operation = "images_generate"
 	OperationImagesEdit           Operation = "images_edit"
 	OperationEmbeddingsCreate     Operation = "embeddings_create"
+	OperationRerank               Operation = "rerank"
 	OperationListModels           Operation = "list_models"
 	OperationProbe                Operation = "probe"
 )
@@ -63,6 +64,7 @@ func (o Operation) Valid() bool {
 		OperationImagesGenerate,
 		OperationImagesEdit,
 		OperationEmbeddingsCreate,
+		OperationRerank,
 		OperationListModels,
 		OperationProbe:
 		return true
@@ -88,7 +90,7 @@ const (
 // ReplayPolicy returns the operation-level replay contract.
 func (o Operation) ReplayPolicy() ReplayPolicy {
 	switch o {
-	case OperationImagesGenerate, OperationImagesEdit, OperationEmbeddingsCreate:
+	case OperationImagesGenerate, OperationImagesEdit, OperationEmbeddingsCreate, OperationRerank:
 		return ReplayPolicyRequireRejectedBeforeProcessing
 	default:
 		return ReplayPolicyLegacy

--- a/internal/execution/contracts_test.go
+++ b/internal/execution/contracts_test.go
@@ -30,6 +30,7 @@ func TestOperationAndDispatchEnums(t *testing.T) {
 		OperationImagesGenerate,
 		OperationImagesEdit,
 		OperationEmbeddingsCreate,
+		OperationRerank,
 		OperationListModels,
 		OperationProbe,
 	}
@@ -45,6 +46,7 @@ func TestOperationAndDispatchEnums(t *testing.T) {
 		OperationImagesGenerate,
 		OperationImagesEdit,
 		OperationEmbeddingsCreate,
+		OperationRerank,
 	} {
 		if !operationRequiresModel(operation) {
 			t.Fatalf("operation %q must require a model", operation)
@@ -477,6 +479,7 @@ func TestValidationAcceptsValidContractsAndRejectsInvalidFields(t *testing.T) {
 		OperationResponsesInputTokens,
 		OperationCountTokens,
 		OperationEmbeddingsCreate,
+		OperationRerank,
 		OperationProbe,
 	} {
 		modelRequired := spec.Clone()

--- a/internal/execution/model_cooldown.go
+++ b/internal/execution/model_cooldown.go
@@ -4,7 +4,7 @@ package execution
 func (o Operation) UsesModelCooldown() bool {
 	switch o {
 	case OperationChatCompletion, OperationResponsesCreate, OperationResponsesCompact,
-		OperationImagesGenerate, OperationImagesEdit, OperationEmbeddingsCreate:
+		OperationImagesGenerate, OperationImagesEdit, OperationEmbeddingsCreate, OperationRerank:
 		return true
 	default:
 		return false

--- a/internal/execution/responsealias/response_alias.go
+++ b/internal/execution/responsealias/response_alias.go
@@ -65,6 +65,8 @@ func modelRewriter(clientProtocol protocol.Protocol) (dialect.ModelRewriter, err
 		return dialect.NewOpenAIResponses(), nil
 	case protocol.OpenAIImages:
 		return dialect.NewOpenAIImages(), nil
+	case protocol.Rerank:
+		return dialect.NewRerank(), nil
 	case protocol.OpenAIEmbeddings:
 		return dialect.NewOpenAIEmbeddings(), nil
 	case protocol.Anthropic:

--- a/internal/execution/validation.go
+++ b/internal/execution/validation.go
@@ -316,6 +316,7 @@ func operationRequiresModel(operation Operation) bool {
 		operation == OperationImagesGenerate ||
 		operation == OperationImagesEdit ||
 		operation == OperationEmbeddingsCreate ||
+		operation == OperationRerank ||
 		operation == OperationProbe
 }
 

--- a/internal/gateway/execution_forward.go
+++ b/internal/gateway/execution_forward.go
@@ -49,7 +49,7 @@ func (forwarder *ExecutionForwarder) Forward(
 	result := upstreamFromExecutionResult(ctx, input, executionResult)
 	result = forwarder.prepareBufferedResult(input, result)
 	if (input.ClientProtocol == protocol.OpenAIImages ||
-		input.ClientProtocol == protocol.OpenAIEmbeddings) && input.ObserveUsage &&
+		input.ClientProtocol == protocol.OpenAIEmbeddings || input.ClientProtocol == protocol.Rerank) && input.ObserveUsage &&
 		result.HasResponse() && result.StatusCode >= http.StatusOK &&
 		result.StatusCode < http.StatusMultipleChoices &&
 		executionResult.Usage == nil && result.Usage.State == usage.StateMissing && forwarder.usageCapture != nil {

--- a/internal/gateway/models.go
+++ b/internal/gateway/models.go
@@ -137,6 +137,7 @@ func modelListProtocols(value protocol.Protocol) []protocol.Protocol {
 			protocol.OpenAIResponses,
 			protocol.OpenAIImages,
 			protocol.OpenAIEmbeddings,
+			protocol.Rerank,
 		}
 	}
 	return []protocol.Protocol{value}

--- a/internal/gateway/models_test.go
+++ b/internal/gateway/models_test.go
@@ -310,3 +310,72 @@ func assertJSONEqual(t *testing.T, got, want string) {
 		t.Fatalf("JSON mismatch\ngot:  %s\nwant: %s", got, want)
 	}
 }
+
+func TestVisibleOpenAIModelIDsIncludesRerankRoutes(t *testing.T) {
+	t.Parallel()
+
+	snapshot := &state.ConfigSnapshot{ExecutionCandidates: state.ExecutionCandidateIndex{
+		protocol.OpenAICompletions: {
+			execution.OperationChatCompletion: {
+				"chat-only": {{GroupID: 1}},
+				"shared":    {{GroupID: 1}},
+			},
+		},
+		protocol.Rerank: {
+			execution.OperationRerank: {
+				"rerank-only": {{GroupID: 2}},
+				"shared":      {{GroupID: 2}},
+			},
+		},
+	}}
+
+	tests := []struct {
+		name      string
+		accessKey state.AccessKeyView
+		want      []string
+	}{
+		{
+			name: "unrestricted union",
+			want: []string{"chat-only", "rerank-only", "shared"},
+		},
+		{
+			name: "rerank protocol filter",
+			accessKey: state.AccessKeyView{Filters: state.FilterSet{Protocols: map[protocol.Protocol]struct{}{
+				protocol.Rerank: {},
+			}}},
+			want: []string{"rerank-only", "shared"},
+		},
+		{
+			name: "rerank protocol and matching group filters",
+			accessKey: state.AccessKeyView{Filters: state.FilterSet{
+				Protocols: map[protocol.Protocol]struct{}{protocol.Rerank: {}},
+				Groups:    map[uint]struct{}{2: {}},
+			}},
+			want: []string{"rerank-only", "shared"},
+		},
+		{
+			name: "rerank protocol and nonmatching group filters",
+			accessKey: state.AccessKeyView{Filters: state.FilterSet{
+				Protocols: map[protocol.Protocol]struct{}{protocol.Rerank: {}},
+				Groups:    map[uint]struct{}{1: {}},
+			}},
+			want: []string{},
+		},
+		{
+			name: "chat protocol filter excludes rerank-only routes",
+			accessKey: state.AccessKeyView{Filters: state.FilterSet{Protocols: map[protocol.Protocol]struct{}{
+				protocol.OpenAICompletions: {},
+			}}},
+			want: []string{"chat-only", "shared"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := visibleModelIDs(snapshot, test.accessKey, protocol.OpenAICompletions)
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("visibleModelIDs() = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/gateway/request_log.go
+++ b/internal/gateway/request_log.go
@@ -157,7 +157,7 @@ func (recorder *requestRecorder) emit() {
 func (recorder *requestRecorder) freezeSensitiveInputErrorSummaries() {
 	if recorder == nil ||
 		(recorder.protocol != protocol.OpenAIImages &&
-			recorder.protocol != protocol.OpenAIEmbeddings) {
+			recorder.protocol != protocol.OpenAIEmbeddings && recorder.protocol != protocol.Rerank) {
 		return
 	}
 	if recorder.outcome.errorCode != "" {

--- a/internal/gateway/request_log_test.go
+++ b/internal/gateway/request_log_test.go
@@ -3822,3 +3822,52 @@ func TestRequestRecorderTerminalErrorsUseSanitizedAttemptSummary(t *testing.T) {
 		})
 	}
 }
+
+func TestRerankRequestLogFreezesProviderInputEcho(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingRequestLogSink{}
+	recorder := newRequestRecorder(
+		sink,
+		"req-embeddings-error",
+		time.Unix(100, 0),
+		9,
+		protocol.Rerank,
+		func() time.Time { return time.Unix(101, 0) },
+	)
+	recorder.setOperation(execution.OperationRerank)
+	providerSummary := "invalid input=input-sentinel vector=VkVDVE9SX1NFTlRJTkVM"
+	index := recorder.appendAttempt(
+		requestLogSelection(12, 22, "embeddings"),
+		UpstreamResult{StatusCode: http.StatusBadRequest},
+		telemetry.FailureCategoryClientError,
+		telemetry.ActionTerminate,
+		"upstream_client_error",
+		providerSummary,
+		time.Unix(100, 0),
+		time.Unix(100, 0),
+	)
+	recorder.completeResponse(
+		UpstreamResult{StatusCode: http.StatusBadRequest, ErrorSummary: providerSummary},
+		health.Decision{Category: health.FailureCategoryClientError},
+		"provider-embedding",
+		index,
+	)
+	recorder.emit()
+
+	if len(sink.events) != 1 {
+		t.Fatalf("events = %#v", sink.events)
+	}
+	event := sink.events[0]
+	want := fixedErrorSummary("upstream_client_error")
+	if event.ErrorSummary != want || len(event.Attempts) != 1 ||
+		event.Attempts[0].ErrorSummary != want {
+		t.Fatalf("Embeddings summaries = %q / %#v", event.ErrorSummary, event.Attempts)
+	}
+	encoded, _ := json.Marshal(event)
+	for _, forbidden := range []string{"input-sentinel", "VkVDVE9SX1NFTlRJTkVM"} {
+		if bytes.Contains(encoded, []byte(forbidden)) {
+			t.Fatalf("Embeddings request log retained %q: %s", forbidden, encoded)
+		}
+	}
+}

--- a/internal/gateway/rerank_response_test.go
+++ b/internal/gateway/rerank_response_test.go
@@ -1,0 +1,31 @@
+package gateway
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"gpt-load/internal/dialect"
+	"gpt-load/internal/platform/redact"
+	"gpt-load/internal/protocol"
+)
+
+func TestRerankResponsePreservesDocumentTextAndRejectsCredentials(t *testing.T) {
+	processor := &responseProcessor{redactor: redact.New()}
+	input := ForwardInput{Dialect: dialect.NewRerank(), ClientProtocol: protocol.Rerank, ExternalModel: "m", UpstreamModelID: "m"}
+	body := []byte(`{"results":[{"index":0,"relevance_score":0.1234567890123456789,"document":{"text":"sk-abcdefghijklmnopqrstuvwxyz012345678901234567890"}}],"future":1.2300}`)
+	got, err := processor.prepareSuccessRepresentation(input, 200, http.Header{}, body, []string{"actual-secret"})
+	if err != nil || !bytes.Equal(got.downstream, body) {
+		t.Fatalf("response=%s error=%v", got.downstream, err)
+	}
+	for _, body := range []string{
+		`{"results":[],"secret":"actual-secret"}`,
+		`{"results":[],"secret":"actual-secret","secret":"safe"}`,
+		`{"results":[{"document":{"text":"actual-secret"}}]}`,
+		`{"results":`,
+	} {
+		if _, err := processor.prepareSuccessRepresentation(input, 200, http.Header{}, []byte(body), []string{"actual-secret"}); err == nil {
+			t.Fatalf("unsafe response accepted: %s", body)
+		}
+	}
+}

--- a/internal/gateway/rerank_test.go
+++ b/internal/gateway/rerank_test.go
@@ -1,0 +1,114 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/dialect"
+	"gpt-load/internal/execution"
+	bifrostexecutor "gpt-load/internal/execution/bifrost"
+	"gpt-load/internal/platform/config"
+	"gpt-load/internal/pricing"
+	"gpt-load/internal/protocol"
+	"gpt-load/internal/state"
+	"gpt-load/internal/usage"
+)
+
+func TestRerankGatewayRoutesObservesAndProtectsAccess(t *testing.T) {
+	for _, test := range []struct {
+		name, response string
+		filters        state.FilterSet
+		status, calls  int
+		priced         bool
+	}{
+		{name: "tokens", response: `"usage":{"total_tokens":1000000}`, status: 200, calls: 1, priced: true},
+		{name: "units only", response: `"meta":{"billed_units":{"search_units":1}}`, status: 200, calls: 1},
+		{name: "protocol denied", response: `"usage":{"total_tokens":1}`, filters: state.FilterSet{Protocols: map[protocol.Protocol]struct{}{protocol.OpenAIEmbeddings: {}}}, status: 503},
+		{name: "model denied", response: `"usage":{"total_tokens":1}`, filters: state.FilterSet{Models: map[string]struct{}{"other": {}}}, status: 503},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var calls atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				if r.URL.Path != "/team/v1/rerank" || r.Header.Get("Authorization") != "Bearer sk-upstream" || !bytes.Contains(body, []byte(`"model":"provider-model"`)) || !bytes.Contains(body, []byte(`"top_n":1`)) {
+					t.Errorf("upstream request %s %s", r.URL, body)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"model":"provider-model","results":[{"index":1,"relevance_score":0.1234567890123456789,"document":{"text":"document-sentinel"}}],`+test.response+`}`)
+			}))
+			defer server.Close()
+			runtime, err := bifrostexecutor.NewRuntime(context.Background(), channel.NewRegistry())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer runtime.Shutdown()
+			sink := &recordingRequestLogSink{}
+			engine, handler, manager, _ := newRequestLogHandlerTestRuntime(t, NewExecutionForwarder(runtime), &recordingAccessKeyRPMLimiter{}, sink, "sk-upstream")
+			handler.dialects = dialect.NewSet(dialect.NewRerank())
+			params, _ := json.Marshal(map[string]string{"base_url": server.URL + "/team"})
+			_, err = manager.Publish(state.CompileInput{
+				ChannelRegistry: channel.NewRegistry(),
+				Groups: []state.GroupConfig{{ConnectionType: "api_key", ID: 1, Name: "rerank", ChannelID: channel.NewAPI, Params: params, Models: []state.ModelConfig{{ID: "provider-model", Alias: "public"}}, Enabled: true,
+					Settings: config.Settings{"parameter_overrides": []any{map[string]any{"match": map[string]any{"protocol": "rerank"}, "set": map[string]any{"top_n": 1}}}},
+				}},
+				Credentials: []state.CredentialConfig{testCredentialConfig(1, 1)},
+				AccessKeys:  []state.AccessKeyConfig{{ID: 1, Name: "client", KeyHash: handler.encryption.Hash("gl-client"), Status: state.AccessKeyStatusActive, Filters: test.filters}},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			table, err := pricing.NewTable([]pricing.Rule{{Identity: pricing.Identity{ChannelID: string(channel.NewAPI), ModelID: "provider-model"}, Prices: pricing.Prices{Input: pricing.Price{NanoUSDPerMillion: 2_000_000_000, Set: true}}}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			handler.priceTables = &mutableGatewayPriceTableProvider{table: table}
+			request := httptest.NewRequest(http.MethodPost, "/v1/rerank", strings.NewReader(`{"model":"public","query":"query-sentinel","documents":["first","document-sentinel"]}`))
+			request.Header.Set("Authorization", "Bearer gl-client")
+			response := httptest.NewRecorder()
+			engine.ServeHTTP(response, request)
+			if response.Code != test.status || calls.Load() != int64(test.calls) {
+				t.Fatalf("status=%d calls=%d body=%s", response.Code, calls.Load(), response.Body)
+			}
+			if test.calls == 0 {
+				return
+			}
+			if !strings.Contains(response.Body.String(), `"relevance_score":0.1234567890123456789`) || !strings.Contains(response.Body.String(), `"model":"public"`) {
+				t.Fatalf("response changed: %s", response.Body)
+			}
+			events := sink.snapshot()
+			if len(events) != 1 || events[0].Protocol != protocol.Rerank || events[0].Operation != execution.OperationRerank {
+				t.Fatalf("events=%#v", events)
+			}
+			observation := events[0].Usage
+			if test.priced {
+				if observation.Result.State != usage.StateComplete || observation.Result.Tokens.UncachedInput != 1_000_000 || observation.Pricing.EstimatedCostNanoUSD != 2_000_000_000 || observation.Pricing.CostState != "priced" {
+					t.Fatalf("usage=%#v", observation)
+				}
+			} else if observation.Result.State != usage.StateMissing || observation.Pricing.CostState != "unpriced" {
+				t.Fatalf("usage=%#v", observation)
+			}
+			encoded, err := json.Marshal(events)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, secret := range []string{"query-sentinel", "document-sentinel", "sk-upstream"} {
+				if bytes.Contains(encoded, []byte(secret)) {
+					t.Fatalf("input leaked into log: %s", secret)
+				}
+			}
+		})
+	}
+}

--- a/internal/gateway/response_representation.go
+++ b/internal/gateway/response_representation.go
@@ -56,7 +56,7 @@ func (forwarder *responseProcessor) prepareSuccessRepresentation(
 		return preparedSuccessRepresentation{}, successRepresentationProtocolError("unsupported or malformed Content-Encoding")
 	}
 	opaqueRepresentation := input.ClientProtocol == protocol.OpenAIImages ||
-		input.ClientProtocol == protocol.OpenAIEmbeddings
+		input.ClientProtocol == protocol.OpenAIEmbeddings || input.ClientProtocol == protocol.Rerank
 	var originalPlain []byte
 	if opaqueRepresentation && encoding == contentcoding.Identity {
 		// The buffered attempt result owns wire for the duration of this terminal
@@ -693,6 +693,9 @@ func opaqueCredentialLiteralsRemain(
 	body []byte,
 	secrets []string,
 ) bool {
+	if clientProtocol == protocol.Rerank {
+		return rerankCredentialLiteralsRemain(body, secrets)
+	}
 	if clientProtocol == protocol.OpenAIEmbeddings {
 		return embeddingsCredentialLiteralsRemain(body, secrets)
 	}
@@ -878,4 +881,30 @@ func (writer *boundedCredentialBuffer) Write(value []byte) (int, error) {
 		return 0, fmt.Errorf("credential replacement exceeds response limit")
 	}
 	return writer.buffer.Write(value)
+}
+
+// Rerank 文档保持原文，只检查已知凭据；逐 token 检查也覆盖重复字段的值。
+func rerankCredentialLiteralsRemain(body []byte, secrets []string) bool {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 || trimmed[0] != '{' || !json.Valid(trimmed) {
+		return true
+	}
+	replacers, exists := newCredentialLiteralReplacers(secrets)
+	if !exists {
+		return false
+	}
+	decoder := json.NewDecoder(bytes.NewReader(trimmed))
+	decoder.UseNumber()
+	for {
+		token, err := decoder.Token()
+		if err == io.EOF {
+			return false
+		}
+		if err != nil {
+			return true
+		}
+		if value, ok := token.(string); ok && credentialLiteralRemains(value, replacers.residual) {
+			return true
+		}
+	}
 }

--- a/internal/gateway/router.go
+++ b/internal/gateway/router.go
@@ -112,6 +112,7 @@ func dataPlaneEndpointCatalog() []dataPlaneEndpoint {
 			path:    openAIEmbeddingsPath,
 			resolve: staticRoute(protocol.OpenAIEmbeddings, endpointForward),
 		},
+		{name: "data.rerank", methods: []string{http.MethodPost}, path: "/v1/rerank", resolve: staticRoute(protocol.Rerank, endpointForward)},
 	}
 }
 

--- a/internal/gateway/router_test.go
+++ b/internal/gateway/router_test.go
@@ -81,6 +81,7 @@ func TestDataPlaneEndpointCatalogDeclaresCompleteHTTPRoutes(t *testing.T) {
 			methods: []string{http.MethodPost},
 			path:    "/v1/embeddings",
 		},
+		{name: "data.rerank", methods: []string{http.MethodPost}, path: "/v1/rerank"},
 	}
 
 	catalog := dataPlaneEndpointCatalog()

--- a/internal/health/execution_judge.go
+++ b/internal/health/execution_judge.go
@@ -372,6 +372,9 @@ func decisionForExecutionCategory(
 			if decisionContext.Operation == execution.OperationEmbeddingsCreate {
 				ruleID = "embeddings.model_unavailable"
 			}
+			if decisionContext.Operation == execution.OperationRerank {
+				ruleID = "rerank.model_unavailable"
+			}
 			return decision(
 				category,
 				origin,

--- a/internal/health/rerank_test.go
+++ b/internal/health/rerank_test.go
@@ -1,0 +1,29 @@
+package health
+
+import (
+	"net/http"
+	"testing"
+
+	"gpt-load/internal/execution"
+)
+
+func TestRerankRetryRequiresProofAndKeepsModelFailuresScoped(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		evidence execution.ErrorEvidence
+		retry    RetryDirective
+	}{
+		{"model rejected", execution.ErrorEvidence{Kind: execution.ErrorKindHTTP, Hint: execution.FailureHintModelUnavailable, OriginHint: execution.ErrorOriginUpstream, ScopeHint: execution.ErrorScopeModel, StatusCode: 404, Code: "model_not_found", ReplaySafety: execution.ReplaySafetyRejectedBeforeProcessing}, RetryNextCandidate},
+		{"unknown timeout", execution.ErrorEvidence{Kind: execution.ErrorKindTimeout, OriginHint: execution.ErrorOriginUpstream, ScopeHint: execution.ErrorScopeGroup, ReplaySafety: execution.ReplaySafetyUnknown}, RetryNone},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := JudgeExecution(ExecutionAttempt{DispatchState: execution.DispatchMaybeSent, StatusCode: test.evidence.StatusCode, Evidence: &test.evidence}, DecisionContext{Method: http.MethodPost, Operation: execution.OperationRerank})
+			if got.Retry != test.retry || got.Effect != EffectNone {
+				t.Fatalf("decision=%#v", got)
+			}
+			if test.name == "model rejected" && (got.Scope != execution.ErrorScopeModel || got.RuleID != "rerank.model_unavailable") {
+				t.Fatalf("model decision=%#v", got)
+			}
+		})
+	}
+}

--- a/internal/parameteroverride/rules.go
+++ b/internal/parameteroverride/rules.go
@@ -272,6 +272,8 @@ func supports(clientProtocol protocol.Protocol, operation execution.Operation) b
 		return operation == execution.OperationResponsesCreate
 	case protocol.OpenAIImages:
 		return operation == execution.OperationImagesGenerate
+	case protocol.Rerank:
+		return operation == execution.OperationRerank
 	case protocol.OpenAIEmbeddings:
 		return operation == execution.OperationEmbeddingsCreate
 	default:

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -8,13 +8,14 @@ const (
 	OpenAIResponses   Protocol = "openai-responses"
 	OpenAIImages      Protocol = "openai-images"
 	OpenAIEmbeddings  Protocol = "openai-embeddings"
+	Rerank            Protocol = "rerank"
 	Anthropic         Protocol = "anthropic"
 	Gemini            Protocol = "gemini"
 )
 
 func (p Protocol) Valid() bool {
 	switch p {
-	case OpenAICompletions, OpenAIResponses, OpenAIImages, OpenAIEmbeddings, Anthropic, Gemini:
+	case OpenAICompletions, OpenAIResponses, OpenAIImages, OpenAIEmbeddings, Rerank, Anthropic, Gemini:
 		return true
 	default:
 		return false
@@ -23,7 +24,7 @@ func (p Protocol) Valid() bool {
 
 func (p Protocol) DataPlaneEnabled() bool {
 	switch p {
-	case OpenAICompletions, OpenAIResponses, OpenAIImages, OpenAIEmbeddings, Anthropic, Gemini:
+	case OpenAICompletions, OpenAIResponses, OpenAIImages, OpenAIEmbeddings, Rerank, Anthropic, Gemini:
 		return true
 	default:
 		return false
@@ -40,6 +41,7 @@ func DataPlaneProtocols() []Protocol {
 		OpenAIResponses,
 		OpenAIImages,
 		OpenAIEmbeddings,
+		Rerank,
 		Anthropic,
 		Gemini,
 	}

--- a/internal/protocol/protocol_test.go
+++ b/internal/protocol/protocol_test.go
@@ -111,6 +111,7 @@ func TestDataPlaneProtocolsReturnsCanonicalOrderAndIndependentCopies(t *testing.
 		OpenAIResponses,
 		OpenAIImages,
 		OpenAIEmbeddings,
+		Rerank,
 		Anthropic,
 		Gemini,
 	}

--- a/internal/state/snapshot.go
+++ b/internal/state/snapshot.go
@@ -355,7 +355,7 @@ func appendExecutionTargets(
 				execution.OperationCountTokens,
 				execution.OperationImagesGenerate,
 				execution.OperationImagesEdit,
-				execution.OperationEmbeddingsCreate:
+				execution.OperationEmbeddingsCreate, execution.OperationRerank:
 				for _, model := range group.Models {
 					modelMode, supported := target.ModeForModel(clientProtocol, operation, model.ID)
 					if !supported {

--- a/web/src/api/control/protocols.ts
+++ b/web/src/api/control/protocols.ts
@@ -16,6 +16,10 @@ export const protocolCatalog = [
     supportsProtocolOnlyRouting: false,
   },
   {
+    value: 'rerank',
+    supportsProtocolOnlyRouting: false,
+  },
+  {
     value: 'anthropic',
     supportsProtocolOnlyRouting: false,
   },

--- a/web/src/app/resources/channels.ts
+++ b/web/src/app/resources/channels.ts
@@ -57,6 +57,7 @@ export type ChannelOperation =
   | 'images_generate'
   | 'images_edit'
   | 'embeddings_create'
+  | 'rerank'
   | 'list_models'
   | 'probe'
 
@@ -162,6 +163,7 @@ const operations = [
   'images_generate',
   'images_edit',
   'embeddings_create',
+  'rerank',
   'list_models',
   'probe',
 ] as const

--- a/web/src/app/resources/request-logs.ts
+++ b/web/src/app/resources/request-logs.ts
@@ -55,6 +55,7 @@ export type RequestLogOperation =
   | 'images_generate'
   | 'images_edit'
   | 'embeddings_create'
+  | 'rerank'
   | 'list_models'
   | 'probe'
 export type RequestLogRouteMode = 'native' | 'converted'
@@ -249,6 +250,7 @@ const operations = [
   'images_generate',
   'images_edit',
   'embeddings_create',
+  'rerank',
   'list_models',
   'probe',
 ] as const

--- a/web/src/app/resources/route-inspection.ts
+++ b/web/src/app/resources/route-inspection.ts
@@ -63,6 +63,7 @@ export type RouteInspectOperation =
   | 'images_generate'
   | 'images_edit'
   | 'embeddings_create'
+  | 'rerank'
 export type RouteInspectRequirement = 'any' | 'native'
 export type RouteInspectMode = 'native' | 'converted'
 
@@ -122,6 +123,7 @@ export const routeInspectOperations = [
   'images_generate',
   'images_edit',
   'embeddings_create',
+  'rerank',
 ] as const
 export const routeInspectRequirements = ['any', 'native'] as const
 const routeModes = ['native', 'converted'] as const

--- a/web/src/features/groups/settings/GroupSettingsTab.vue
+++ b/web/src/features/groups/settings/GroupSettingsTab.vue
@@ -121,6 +121,7 @@ const parameterOverrideOperations = new Set([
   'responses_create',
   'images_generate',
   'embeddings_create',
+  'rerank',
 ])
 const parameterOverrideProtocols = computed<AccessProtocol[]>(() => [
   ...new Set(

--- a/web/src/i18n/locales/en-US/monitor.ts
+++ b/web/src/i18n/locales/en-US/monitor.ts
@@ -389,7 +389,7 @@ export default {
       title: 'Route inspector',
       description: 'Inspect candidate Groups and credentials by protocol, model, and access key.',
       boundary:
-        'Simulates a standard stateless request without conversation content or an affinity hit; Responses uses store:false, Images checks generation only, and Embeddings checks creation only. Read-only, with no upstream request or token usage.',
+        'Simulates a standard stateless request without conversation content or an affinity hit; Responses uses store:false, Images checks generation only, Embeddings checks creation only, and Rerank checks text reranking. Read-only, with no upstream request or token usage.',
       routeModes: {
         native: 'Native',
         converted: 'Protocol conversion',
@@ -408,6 +408,7 @@ export default {
         images_generate: 'Generate image',
         images_edit: 'Edit image',
         embeddings_create: 'Create embeddings',
+        rerank: 'Rerank documents',
       },
       routeRequirements: {
         any: 'Allow protocol conversion (possibly lossy)',
@@ -800,6 +801,7 @@ export default {
         images_generate: 'Generate image',
         images_edit: 'Edit image',
         embeddings_create: 'Create embeddings',
+        rerank: 'Rerank documents',
         list_models: 'List models',
         probe: 'Health probe',
       },

--- a/web/src/i18n/locales/ja-JP/monitor.ts
+++ b/web/src/i18n/locales/ja-JP/monitor.ts
@@ -389,7 +389,7 @@ export default {
       title: 'ルート検査',
       description: 'プロトコル、モデル、アクセスキーから候補グループと認証情報を確認します。',
       boundary:
-        '会話内容やアフィニティヒットを含まない標準的なステートレスリクエストを模擬します。Responses は store:false を使用し、Images は画像生成のみ、Embeddings は埋め込み作成のみを確認します。読み取り専用で、上流送信や Token 消費はありません。',
+        '会話内容やアフィニティヒットを含まない標準的なステートレスリクエストを模擬します。Responses は store:false を使用し、Images は画像生成のみ、Embeddings は埋め込み作成のみ、Rerank はテキストの再ランキングを確認します。読み取り専用で、上流送信や Token 消費はありません。',
       routeModes: {
         native: 'ネイティブ',
         converted: 'プロトコル変換',
@@ -408,6 +408,7 @@ export default {
         images_generate: '画像を生成',
         images_edit: '画像を編集',
         embeddings_create: '埋め込みを作成',
+        rerank: 'ドキュメントを再ランキング',
       },
       routeRequirements: {
         any: 'プロトコル変換を許可（損失の可能性あり）',
@@ -799,6 +800,7 @@ export default {
         images_generate: '画像を生成',
         images_edit: '画像を編集',
         embeddings_create: '埋め込みを作成',
+        rerank: 'ドキュメントを再ランキング',
         list_models: 'モデル一覧',
         probe: 'ヘルスプローブ',
       },

--- a/web/src/i18n/locales/zh-CN/monitor.ts
+++ b/web/src/i18n/locales/zh-CN/monitor.ts
@@ -373,7 +373,7 @@ export default {
       title: '路由检查',
       description: '按协议、模型与访问密钥检查当前候选分组和凭据。',
       boundary:
-        '按所选协议模拟不含会话内容与亲和命中的标准无状态请求；Responses 使用 store:false，Images 只检查图片生成，Embeddings 只检查向量创建。只读检查，不会发送上游请求或消耗 Token。',
+        '按所选协议模拟不含会话内容与亲和命中的标准无状态请求；Responses 使用 store:false，Images 只检查图片生成，Embeddings 只检查向量创建，Rerank 检查文本重排序。只读检查，不会发送上游请求或消耗 Token。',
       routeModes: {
         native: '原生',
         converted: '协议转换',
@@ -392,6 +392,7 @@ export default {
         images_generate: '生成图片',
         images_edit: '编辑图片',
         embeddings_create: '创建向量',
+        rerank: '文档重排序',
       },
       routeRequirements: {
         any: '允许协议转换（可有损）',
@@ -781,6 +782,7 @@ export default {
         images_generate: '生成图片',
         images_edit: '编辑图片',
         embeddings_create: '创建向量',
+        rerank: '文档重排序',
         list_models: '列出模型',
         probe: '健康探测',
       },


### PR DESCRIPTION
### 关联 Issue / Related Issue
<!-- 请填写此 PR 关联的 issue 编号，例如：无关联 Issue。123 / Please link the issue number, e.g., 无关联 Issue。123 -->
无关联 Issue。

### 变更内容 / Change Content
<!-- 请简要描述本次变更的核心内容 / Please briefly describe the core changes of this PR -->
- [ ] Bug 修复 / Bug fix
- [x] 新功能 / New feature
- [ ] 其他改动 / Other changes

新增独立 `rerank` 协议和 `POST /v1/rerank`，在 OpenAI Compatible、New API、GPT-Load 三个 API Key 渠道支持纯文本原生重排序。请求沿用 AccessKey 权限、模型别名、凭据调度、参数覆盖和健康策略；响应保留上游文档、排序及评分精度。

- 补齐模型列表、路由检查、凭据探测回退、日志隐私及管理端协议/操作展示，同步中英日文案和 README。
- 根据明确且一致的 Token 证据记录用量并应用现有价格规则；仅有 `search_units` 或缺少 Token 时保持未计价。
- 不新增依赖或数据库迁移；不支持订阅渠道、流式、多模态文档或协议互转。没有协议筛选的 AccessKey 按既有语义获得 Rerank 访问能力，显式筛选保持原范围。

验证：基于最新 `main` 执行 `make check` 通过（前端 lint、格式、类型检查与构建，Go vet、构建及完整后端测试）。本地 HTTP 测试覆盖目标前缀、凭据替换、模型别名、原始响应、权限阻断、计价、日志隐私、探测、响应上限和取消；未使用真实付费上游凭据联调。

设计与实施记录按要求保存在本地 `docs/`，不包含在本 PR 中。


### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.
