### PR TITLE
fix(codex): 修正请求身份头覆盖与会话兼容

### DIFF
--- a/internal/control/credential_probe.go
+++ b/internal/control/credential_probe.go
@@ -207,9 +207,10 @@ func (probe *credentialProbeExecutor) Probe(
 			ChannelID: string(group.ChannelID),
 			RouteMode: execution.RouteMode(routeMode), ClientProtocol: probeProtocol,
 			Operation: execution.OperationProbe, ClientModel: target.model, UpstreamModel: target.model,
-			Header:       applyControlHeaderRules(group.HeaderRules, apiKey),
-			TargetConfig: group.ResolvedTarget.TargetConfig,
-			Timeouts:     executionTimeouts(group.Timeouts),
+			Header:            applyControlHeaderRules(group.HeaderRules, apiKey),
+			ConfiguredHeaders: group.HeaderRules.ConfiguredNames(),
+			TargetConfig:      group.ResolvedTarget.TargetConfig,
+			Timeouts:          executionTimeouts(group.Timeouts),
 			Credential: execution.NewCredentialSnapshot(
 				ref.ID,
 				version,

--- a/internal/control/discover_executor.go
+++ b/internal/control/discover_executor.go
@@ -92,11 +92,12 @@ func (s *Service) executeModelDiscovery(
 				Operation: execution.OperationListModels, Method: method, Path: path,
 				RawQuery: rawQuery,
 				Header:   applyControlHeaderRules(target.headerRules, credential.apiKey), Body: body,
-				TargetConfig:     target.resolvedTarget.TargetConfig,
-				Timeouts:         executionTimeouts(target.timeouts),
-				Credential:       credential.snapshot,
-				Proxy:            credential.proxy,
-				ProxyFingerprint: credential.proxyFingerprint,
+				ConfiguredHeaders: target.headerRules.ConfiguredNames(),
+				TargetConfig:      target.resolvedTarget.TargetConfig,
+				Timeouts:          executionTimeouts(target.timeouts),
+				Credential:        credential.snapshot,
+				Proxy:             credential.proxy,
+				ProxyFingerprint:  credential.proxyFingerprint,
 			})
 			if validationErr := spec.Validate(); validationErr != nil {
 				return ModelDiscoveryResult{}, fmt.Errorf("build discovery attempt: %w", app_errors.ErrInternalServer)

--- a/internal/execution/contracts.go
+++ b/internal/execution/contracts.go
@@ -219,7 +219,7 @@ type AttemptTimeouts struct {
 
 // AttemptSpec is a fully selected, provider-neutral upstream attempt.
 // NewAttemptSpec or Clone must be used at ownership boundaries because Query,
-// Header, Body, TargetConfig, and Credential contain reference-backed values.
+// Header, ConfiguredHeaders, Body, TargetConfig, and Credential contain reference-backed values.
 type AttemptSpec struct {
 	RequestID                string                   `json:"request_id"`
 	AttemptID                string                   `json:"attempt_id"`
@@ -241,6 +241,8 @@ type AttemptSpec struct {
 	RawQuery string      `json:"raw_query,omitempty"`
 	Header   http.Header `json:"header,omitempty"`
 	Body     []byte      `json:"body,omitempty"`
+	// ConfiguredHeaders 记录显式请求头规则的字段；最终值由 Header 提供，缺失表示移除。
+	ConfiguredHeaders []string `json:"-"`
 	// IncludeUsage asks the executor to request provider usage details when the
 	// selected operation supports an explicit wire option.
 	IncludeUsage bool `json:"include_usage,omitempty"`
@@ -269,6 +271,7 @@ func (s AttemptSpec) Clone() AttemptSpec {
 	clone := s
 	clone.Query = cloneValues(s.Query)
 	clone.Header = cloneHeader(s.Header)
+	clone.ConfiguredHeaders = append([]string(nil), s.ConfiguredHeaders...)
 	clone.Body = cloneBytes(s.Body)
 	clone.TargetConfig = cloneRawMessage(s.TargetConfig)
 	clone.Credential = s.Credential.Clone()

--- a/internal/execution/contracts_test.go
+++ b/internal/execution/contracts_test.go
@@ -185,15 +185,20 @@ func TestAttemptSpecOwnsReferenceBackedValues(t *testing.T) {
 	credentialData := []byte(`{"api_key":"sk-secret-value"}`)
 	raw := validAttemptSpec(credentialData)
 	raw.RouteRequirement = RouteRequirementNative
+	raw.ConfiguredHeaders = []string{"User-Agent"}
 	owned := NewAttemptSpec(raw)
 
 	raw.Header.Set("X-Test", "mutated")
+	raw.ConfiguredHeaders[0] = "Originator"
 	raw.Query.Set("api-version", "mutated")
 	raw.Body[0] = 'X'
 	raw.TargetConfig[0] = 'Y'
 	credentialData[0] = 'Y'
 	if got := owned.Header.Get("X-Test"); got != "original" {
 		t.Fatalf("owned header = %q, want original", got)
+	}
+	if owned.ConfiguredHeaders[0] != "User-Agent" {
+		t.Fatal("mutating source changed configured header names")
 	}
 	if got := owned.Query.Get("api-version"); got != "2026-01-01" {
 		t.Fatalf("owned query = %q, want original", got)
@@ -213,12 +218,16 @@ func TestAttemptSpecOwnsReferenceBackedValues(t *testing.T) {
 
 	clone := owned.Clone()
 	clone.Header.Set("X-Test", "clone")
+	clone.ConfiguredHeaders[0] = "Version"
 	clone.Query.Set("api-version", "clone")
 	clone.Body[0] = 'Z'
 	clone.TargetConfig[0] = 'Q'
 	clone.Credential.data[0] = 'Q'
 	if owned.Header.Get("X-Test") != "original" || owned.Query.Get("api-version") != "2026-01-01" {
 		t.Fatal("mutating clone changed original maps")
+	}
+	if owned.ConfiguredHeaders[0] != "User-Agent" {
+		t.Fatal("mutating clone changed configured header names")
 	}
 	if string(owned.Body) != `{"model":"client-model"}` || string(owned.Credential.Data()) != `{"api_key":"sk-secret-value"}` {
 		t.Fatal("mutating clone changed original byte slices")

--- a/internal/execution/cpa/adapter.go
+++ b/internal/execution/cpa/adapter.go
@@ -548,6 +548,7 @@ func bridgeRequest(
 	return providerRequest{
 		AttemptID: spec.AttemptID, Model: spec.UpstreamModel, Payload: payload,
 		Format: formatFor(spec.ClientProtocol), RequestPath: requestPath, Headers: headers,
+		ConfiguredHeaders:    append([]string(nil), spec.ConfiguredHeaders...),
 		OriginalRequest:      append([]byte(nil), payload...),
 		ContinuityKey:        spec.ContinuityKey,
 		BaseURL:              baseURL,

--- a/internal/execution/cpa/codex_headers_test.go
+++ b/internal/execution/cpa/codex_headers_test.go
@@ -1,0 +1,162 @@
+package cpa
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"gpt-load/internal/dialect"
+	"gpt-load/internal/gateway"
+	"gpt-load/internal/state"
+)
+
+func TestCodexGatewayRequestIdentity(t *testing.T) {
+	const defaultUA = "codex-tui/0.146.0 (Mac OS 26.5.0; arm64) iTerm.app/3.6.10 (codex-tui; 0.146.0)"
+	const lunaUA = "codex-tui/0.144.0 (Mac OS 26.5.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.144.0)"
+	const configuredUA = "codex-tui/0.200.0 (Mac OS 26.5.0; arm64)"
+	tests := []struct {
+		name           string
+		model          string
+		headers        http.Header
+		rules          state.HeaderRules
+		promptCacheKey string
+		wantUA         string
+		wantOriginator string
+		wantVersion    string
+		wantSession    string
+	}{
+		{
+			name:    "preserve provider default and align client version",
+			headers: http.Header{"User-Agent": {"browser/1.0"}, "Originator": {"browser"}, "Version": {"9.9.9"}},
+			wantUA:  defaultUA, wantOriginator: "codex-tui", wantVersion: "0.146.0",
+		},
+		{
+			name:    "configured identity wins",
+			headers: http.Header{"User-Agent": {"browser/1.0"}, "Version": {"9.9.9"}},
+			rules:   state.HeaderRules{Set: map[string]string{"user-agent": configuredUA, "originator": "configured-client"}},
+			wantUA:  configuredUA, wantOriginator: "configured-client", wantVersion: "0.200.0",
+		},
+		{
+			name: "preserve model default and align version", model: "gpt-5.6-luna",
+			headers: http.Header{"Version": {"9.9.9"}},
+			wantUA:  lunaUA, wantOriginator: "codex-tui", wantVersion: "0.144.0",
+		},
+		{
+			name: "configured identity wins over model default", model: "gpt-5.6-luna",
+			rules:  state.HeaderRules{Set: map[string]string{"User-Agent": configuredUA}},
+			wantUA: configuredUA, wantOriginator: "codex-tui", wantVersion: "0.200.0",
+		},
+		{
+			name:    "custom UA does not inherit unrelated version",
+			headers: http.Header{"Version": {"9.9.9"}},
+			rules:   state.HeaderRules{Set: map[string]string{"User-Agent": "custom-client/1.0"}},
+			wantUA:  "custom-client/1.0", wantOriginator: "codex-tui",
+		},
+		{
+			name:   "explicit version remains authoritative",
+			rules:  state.HeaderRules{Set: map[string]string{"User-Agent": "custom-client/1.0", "Version": "custom-version"}},
+			wantUA: "custom-client/1.0", wantOriginator: "codex-tui", wantVersion: "custom-version",
+		},
+		{
+			name:    "explicit removal survives SDK defaults",
+			headers: http.Header{"User-Agent": {"browser/1.0"}, "Originator": {"browser"}, "Version": {"9.9.9"}},
+			rules:   state.HeaderRules{Remove: []string{"User-Agent", "Originator", "Version"}},
+		},
+		{
+			name: "underscore session is preserved", model: "gpt-5.6-luna",
+			headers: http.Header{"Session_id": {"client-session"}},
+			wantUA:  lunaUA, wantOriginator: "codex-tui", wantVersion: "0.144.0", wantSession: "client-session",
+		},
+		{
+			name:    "hyphen session wins over alias",
+			headers: http.Header{"Session_id": {"alias-session"}, "Session-Id": {"canonical-session"}},
+			wantUA:  defaultUA, wantOriginator: "codex-tui", wantVersion: "0.146.0", wantSession: "canonical-session",
+		},
+		{
+			name:    "blank canonical session falls back to alias",
+			headers: http.Header{"Session-Id": {"  "}, "Session_id": {" alias-session "}},
+			wantUA:  defaultUA, wantOriginator: "codex-tui", wantVersion: "0.146.0", wantSession: "alias-session",
+		},
+		{
+			name: "prompt cache remains the session fallback", promptCacheKey: "cache-session",
+			wantUA: defaultUA, wantOriginator: "codex-tui", wantVersion: "0.146.0", wantSession: "cache-session",
+		},
+		{
+			name: "session alias has the same precedence as canonical header", promptCacheKey: "cache-session",
+			headers: http.Header{"Session_id": {"client-session"}},
+			wantUA:  defaultUA, wantOriginator: "codex-tui", wantVersion: "0.146.0", wantSession: "client-session",
+		},
+	}
+	for _, stream := range []bool{false, true} {
+		mode := "unary"
+		if stream {
+			mode = "stream"
+		}
+		for _, test := range tests {
+			t.Run(mode+"/"+test.name, func(t *testing.T) {
+				adapter, _, _, keyService, row := newAdapterFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
+				spec := validSpec(t, row, keyService)
+				model := test.model
+				if model == "" {
+					model = spec.UpstreamModel
+				}
+				body := `{"model":"` + model + `","input":"hello"}`
+				if test.promptCacheKey != "" {
+					body = `{"model":"` + model + `","input":"hello","prompt_cache_key":"` + test.promptCacheKey + `"}`
+				}
+				capturedHeaders := make(chan http.Header, 1)
+				transport := roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+					capturedHeaders <- request.Header.Clone()
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     http.Header{"Content-Type": {"text/event-stream"}},
+						Body:       io.NopCloser(strings.NewReader(`data: {"type":"response.completed","response":{"id":"resp_1","object":"response","status":"completed","model":"` + model + `","output":[]}}` + "\n\n")),
+						Request:    request,
+					}, nil
+				})
+				ctx := context.WithValue(t.Context(), "cliproxy.roundtripper", http.RoundTripper(transport))
+				input := gateway.ForwardInput{
+					Dialect: dialect.NewOpenAIResponses(), Group: state.GroupView{ID: row.GroupID, HeaderRules: test.rules},
+					Request:   &dialect.ParsedRequest{Method: http.MethodPost, Path: "/v1/responses", Header: test.headers.Clone(), Body: []byte(body)},
+					RequestID: spec.RequestID, AttemptID: spec.AttemptID, AttemptSequence: spec.Sequence,
+					ClientProtocol: spec.ClientProtocol, Operation: spec.Operation, ChannelID: spec.ChannelID,
+					RouteMode: spec.RouteMode, TargetConfig: spec.TargetConfig, Credential: spec.Credential,
+					ExternalModel: model, UpstreamModelID: model,
+				}
+				forwarder := gateway.NewExecutionForwarder(adapter)
+				var result gateway.UpstreamResult
+				if stream {
+					result = forwarder.ForwardStream(ctx, input, httptest.NewRecorder())
+				} else {
+					result = forwarder.Forward(ctx, input)
+				}
+				if result.Err != nil || result.StatusCode != http.StatusOK {
+					t.Fatalf("forward error = %v, status = %d", result.Err, result.StatusCode)
+				}
+				captured := <-capturedHeaders
+				for name, want := range map[string]string{"User-Agent": test.wantUA, "Originator": test.wantOriginator, "Version": test.wantVersion} {
+					if got := captured.Get(name); got != want {
+						t.Errorf("%s = %q, want %q", name, got, want)
+					}
+				}
+				if test.wantSession != "" && captured.Get("Session-Id") != test.wantSession {
+					t.Errorf("Session-Id = %q, want %q", captured.Get("Session-Id"), test.wantSession)
+				}
+				if captured.Get("Session_id") != "" {
+					t.Error("upstream retained the underscore session alias")
+				}
+				if captured.Get("Authorization") != "Bearer access" || captured.Get("Chatgpt-Account-Id") != "account-1" {
+					t.Error("upstream credential headers changed")
+				}
+				if !reflect.DeepEqual(input.Request.Header, test.headers) {
+					t.Error("forwarding mutated the downstream headers")
+				}
+			})
+		}
+	}
+}

--- a/internal/execution/cpa/codex_provider.go
+++ b/internal/execution/cpa/codex_provider.go
@@ -102,7 +102,8 @@ func (bridge *codexProviderBridge) CountTokensLocal(
 		Model: request.Model, Payload: append([]byte(nil), request.Payload...), Format: request.Format,
 		RequestPath: request.RequestPath,
 		Headers:     request.Headers.Clone(), OriginalRequest: append([]byte(nil), request.OriginalRequest...),
-		BaseURL: request.BaseURL, ProxyURL: request.ProxyURL, ProxyFromEnvironment: request.ProxyFromEnvironment,
+		ConfiguredHeaders: append([]string(nil), request.ConfiguredHeaders...),
+		BaseURL:           request.BaseURL, ProxyURL: request.ProxyURL, ProxyFromEnvironment: request.ProxyFromEnvironment,
 	})
 	headers := response.Headers.Clone()
 	if headers == nil {
@@ -306,7 +307,8 @@ func (bridge *codexProviderBridge) Execute(
 		Model: request.Model, Payload: append([]byte(nil), request.Payload...), Format: request.Format,
 		RequestPath: request.RequestPath,
 		Headers:     request.Headers.Clone(), OriginalRequest: append([]byte(nil), request.OriginalRequest...),
-		BaseURL: request.BaseURL, ProxyURL: request.ProxyURL, ProxyFromEnvironment: request.ProxyFromEnvironment,
+		ConfiguredHeaders: append([]string(nil), request.ConfiguredHeaders...),
+		BaseURL:           request.BaseURL, ProxyURL: request.ProxyURL, ProxyFromEnvironment: request.ProxyFromEnvironment,
 	})
 	return providerResponse{
 		Payload: append([]byte(nil), response.Payload...), Headers: response.Headers.Clone(),
@@ -333,7 +335,8 @@ func (bridge *codexProviderBridge) ExecuteStream(
 		Model: request.Model, Payload: append([]byte(nil), request.Payload...), Format: request.Format,
 		RequestPath: request.RequestPath,
 		Headers:     request.Headers.Clone(), OriginalRequest: append([]byte(nil), request.OriginalRequest...),
-		BaseURL: request.BaseURL, ProxyURL: request.ProxyURL, ProxyFromEnvironment: request.ProxyFromEnvironment,
+		ConfiguredHeaders: append([]string(nil), request.ConfiguredHeaders...),
+		BaseURL:           request.BaseURL, ProxyURL: request.ProxyURL, ProxyFromEnvironment: request.ProxyFromEnvironment,
 	})
 	if response == nil {
 		return nil, err

--- a/internal/execution/cpa/provider.go
+++ b/internal/execution/cpa/provider.go
@@ -101,13 +101,14 @@ func annotateProviderErrorEvidence(evidence *execution.ErrorEvidence, err error)
 }
 
 type providerRequest struct {
-	AttemptID       string
-	Model           string
-	Payload         []byte
-	Format          string
-	RequestPath     string
-	Headers         http.Header
-	OriginalRequest []byte
+	AttemptID         string
+	Model             string
+	Payload           []byte
+	Format            string
+	RequestPath       string
+	Headers           http.Header
+	ConfiguredHeaders []string
+	OriginalRequest   []byte
 	// ContinuityKey is a private, tenant-scoped key used only by providers
 	// whose tool/thinking protocol needs an isolated multi-request replay lane.
 	ContinuityKey string

--- a/internal/gateway/execution_forward.go
+++ b/internal/gateway/execution_forward.go
@@ -747,6 +747,7 @@ func newExecutionAttemptSpec(input ForwardInput) (execution.AttemptSpec, error) 
 		Path:                     input.Request.Path,
 		RawQuery:                 input.Request.RawQuery,
 		Header:                   headers,
+		ConfiguredHeaders:        input.Group.HeaderRules.ConfiguredNames(),
 		Body:                     input.Request.Body,
 		IncludeUsage:             input.ObserveUsage,
 		ForceCredentialRefresh:   input.ForceCredentialRefresh,

--- a/internal/state/snapshot.go
+++ b/internal/state/snapshot.go
@@ -125,6 +125,18 @@ type HeaderRules struct {
 	Remove []string
 }
 
+// ConfiguredNames 标记显式设置或移除的字段，区分规则与客户端原始请求头。
+func (rules HeaderRules) ConfiguredNames() []string {
+	if len(rules.Set)+len(rules.Remove) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(rules.Set)+len(rules.Remove))
+	for name := range rules.Set {
+		names = append(names, name)
+	}
+	return append(names, rules.Remove...)
+}
+
 type GroupView struct {
 	PriceMultiplier    pricing.PriceMultiplier
 	ID                 uint

--- a/internal/subscription/providers/codex/codex.go
+++ b/internal/subscription/providers/codex/codex.go
@@ -272,6 +272,7 @@ type ExecuteRequest struct {
 	Format               string
 	RequestPath          string
 	Headers              http.Header
+	ConfiguredHeaders    []string
 	OriginalRequest      []byte
 	BaseURL              string
 	ProxyURL             string
@@ -412,6 +413,7 @@ func executeRequestToBridge(value ExecuteRequest) cpaembedded.ExecuteRequest {
 		Format:               value.Format,
 		RequestPath:          value.RequestPath,
 		Headers:              value.Headers.Clone(),
+		ConfiguredHeaders:    append([]string(nil), value.ConfiguredHeaders...),
 		OriginalRequest:      append([]byte(nil), value.OriginalRequest...),
 		BaseURL:              value.BaseURL,
 		ProxyURL:             value.ProxyURL,

--- a/third_party/cpaembedded/README.md
+++ b/third_party/cpaembedded/README.md
@@ -37,6 +37,22 @@ It intentionally excludes CPA Manager, selector, account pool, file store, serve
 watcher, and Auto executors. The Codex WS facade blocks HTTP fallback and business
 request replay; it does not enable WS in the HTTP data plane.
 
+## Codex HTTP request identity
+
+The HTTP bridge preserves CPA's default and model-specific User-Agent values.
+Explicit GPT-Load request-header rules for `User-Agent`, `Originator`, and
+`Version` take precedence after CPA constructs the upstream request, including
+explicit removal. Downstream headers alone do not override CPA's default identity.
+Unless `Version` is explicitly configured, it follows the final `codex-tui` or
+`codex_cli_rs` User-Agent version; an unrecognized custom UA drops the unrelated
+client version.
+
+Both `Session-Id` and `Session_id` are accepted, with `Session-Id` taking precedence
+if both exist. The upstream receives one `Session-Id`; explicit client sessions
+keep CPA's existing precedence over its prompt-cache fallback. This applies to
+HTTP inference, including streaming and images; account queries and the independent
+WebSocket facade keep their existing behavior.
+
 ## Codex WebSocket Session
 
 `internal/subscription/providers/codex.NewWSSession` exposes this independent

--- a/third_party/cpaembedded/embedded/codex_headers.go
+++ b/third_party/cpaembedded/embedded/codex_headers.go
@@ -1,0 +1,95 @@
+package embedded
+
+import (
+	"net/http"
+	"strings"
+)
+
+// codexHeadersRoundTripper 在 CPA 默认值与模型覆盖之后应用显式身份规则。
+type codexHeadersRoundTripper struct {
+	base       http.RoundTripper
+	source     http.Header
+	configured []string
+}
+
+func (transport codexHeadersRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	request = request.Clone(request.Context())
+	versionConfigured := false
+	for _, name := range transport.configured {
+		name = http.CanonicalHeaderKey(name)
+		switch name {
+		case "User-Agent", "Originator", "Version":
+			value := codexHeaderValue(transport.source, name)
+			if value != "" || name == "User-Agent" {
+				// 空 UA 显式禁止 net/http 重新补入 Go 默认 UA。
+				request.Header.Set(name, value)
+			} else {
+				request.Header.Del(name)
+			}
+			if name == "Version" {
+				versionConfigured = true
+			}
+		}
+	}
+	if !versionConfigured {
+		if version := codexUserAgentVersion(request.Header.Get("User-Agent")); version != "" {
+			request.Header.Set("Version", version)
+		} else {
+			request.Header.Del("Version")
+		}
+	}
+	normalizeCodexSessionHeader(request.Header)
+	// CPA 的直接图片路径不读取 opts.Headers，补回调用者显式提供的会话。
+	if request.Header.Get("Session-Id") == "" {
+		if session := transport.source.Get("Session-Id"); session != "" {
+			request.Header.Set("Session-Id", session)
+		}
+	}
+	return transport.base.RoundTrip(request)
+}
+
+func codexUserAgentVersion(userAgent string) string {
+	fields := strings.Fields(userAgent)
+	if len(fields) == 0 {
+		return ""
+	}
+	product, version, _ := strings.Cut(fields[0], "/")
+	if product == "codex-tui" || product == "codex_cli_rs" {
+		return version
+	}
+	return ""
+}
+
+func normalizedCodexHeaders(headers http.Header) http.Header {
+	cloned := headers.Clone()
+	normalizeCodexSessionHeader(cloned)
+	return cloned
+}
+
+// normalizeCodexSessionHeader 兼容下划线拼法；同时存在时以连字符字段为准。
+func normalizeCodexSessionHeader(headers http.Header) {
+	session := strings.TrimSpace(codexHeaderValue(headers, "Session-Id"))
+	if session == "" {
+		session = strings.TrimSpace(codexHeaderValue(headers, "Session_id"))
+	}
+	for name := range headers {
+		if strings.EqualFold(name, "Session-Id") || strings.EqualFold(name, "Session_id") {
+			delete(headers, name)
+		}
+	}
+	if session != "" {
+		headers.Set("Session-Id", session)
+	}
+}
+
+func codexHeaderValue(headers http.Header, name string) string {
+	if value := headers.Get(name); value != "" {
+		return value
+	}
+	for key, values := range headers {
+		if strings.EqualFold(key, name) && len(values) > 0 {
+			return values[0]
+		}
+	}
+	return ""
+}

--- a/third_party/cpaembedded/embedded/codex_headers.go
+++ b/third_party/cpaembedded/embedded/codex_headers.go
@@ -19,8 +19,8 @@ func (transport codexHeadersRoundTripper) RoundTrip(request *http.Request) (*htt
 		name = http.CanonicalHeaderKey(name)
 		switch name {
 		case "User-Agent", "Originator", "Version":
-			value := codexHeaderValue(transport.source, name)
-			if value != "" || name == "User-Agent" {
+			value, present := codexHeaderValue(transport.source, name)
+			if present || name == "User-Agent" {
 				// 空 UA 显式禁止 net/http 重新补入 Go 默认 UA。
 				request.Header.Set(name, value)
 			} else {
@@ -68,9 +68,11 @@ func normalizedCodexHeaders(headers http.Header) http.Header {
 
 // normalizeCodexSessionHeader 兼容下划线拼法；同时存在时以连字符字段为准。
 func normalizeCodexSessionHeader(headers http.Header) {
-	session := strings.TrimSpace(codexHeaderValue(headers, "Session-Id"))
+	session, _ := codexHeaderValue(headers, "Session-Id")
+	session = strings.TrimSpace(session)
 	if session == "" {
-		session = strings.TrimSpace(codexHeaderValue(headers, "Session_id"))
+		session, _ = codexHeaderValue(headers, "Session_id")
+		session = strings.TrimSpace(session)
 	}
 	for name := range headers {
 		if strings.EqualFold(name, "Session-Id") || strings.EqualFold(name, "Session_id") {
@@ -82,14 +84,18 @@ func normalizeCodexSessionHeader(headers http.Header) {
 	}
 }
 
-func codexHeaderValue(headers http.Header, name string) string {
-	if value := headers.Get(name); value != "" {
-		return value
-	}
-	for key, values := range headers {
-		if strings.EqualFold(key, name) && len(values) > 0 {
-			return values[0]
+func codexHeaderValue(headers http.Header, name string) (string, bool) {
+	values, present := headers[http.CanonicalHeaderKey(name)]
+	if !present {
+		for key, candidate := range headers {
+			if strings.EqualFold(key, name) {
+				values, present = candidate, true
+				break
+			}
 		}
 	}
-	return ""
+	if len(values) > 0 {
+		return values[0], present
+	}
+	return "", present
 }

--- a/third_party/cpaembedded/embedded/codex_headers_test.go
+++ b/third_party/cpaembedded/embedded/codex_headers_test.go
@@ -28,6 +28,16 @@ func TestCodexHTTPIdentityOnImagesAndWireRemoval(t *testing.T) {
 			want:     http.Header{"User-Agent": {customUA}, "Originator": {"custom-client"}, "Version": {"0.200.0"}, "Session-Id": {"image-session"}},
 		},
 		{
+			name: "explicit empty identity headers remain present",
+			request: ExecuteRequest{
+				Model: "gpt-5", Format: "openai-response", Payload: []byte(`{"model":"gpt-5","input":"hello"}`),
+				Headers:           http.Header{"User-Agent": {customUA}, "Originator": {""}, "Version": {""}},
+				ConfiguredHeaders: []string{"User-Agent", "Originator", "Version"},
+			},
+			response: "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5\",\"output\":[]}}\n\n",
+			want:     http.Header{"User-Agent": {customUA}, "Originator": {""}, "Version": {""}},
+		},
+		{
 			name: "removed UA is not replaced by Go transport",
 			request: ExecuteRequest{
 				Model: "gpt-5", Format: "openai-response", Payload: []byte(`{"model":"gpt-5","input":"hello"}`),
@@ -61,6 +71,11 @@ func TestCodexHTTPIdentityOnImagesAndWireRemoval(t *testing.T) {
 			}
 			captured := <-capturedHeaders
 			for _, name := range []string{"User-Agent", "Originator", "Version", "Session-Id", "Session_id"} {
+				_, present := captured[name]
+				_, wantPresent := test.want[name]
+				if present != wantPresent {
+					t.Errorf("wire %s present = %t, want %t", name, present, wantPresent)
+				}
 				if got, want := captured.Get(name), test.want.Get(name); got != want {
 					t.Errorf("wire %s = %q, want %q", name, got, want)
 				}

--- a/third_party/cpaembedded/embedded/codex_headers_test.go
+++ b/third_party/cpaembedded/embedded/codex_headers_test.go
@@ -1,0 +1,70 @@
+package embedded
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCodexHTTPIdentityOnImagesAndWireRemoval(t *testing.T) {
+	const customUA = "codex-tui/0.200.0 (Mac OS 26.5.0; arm64)"
+	for _, test := range []struct {
+		name     string
+		request  ExecuteRequest
+		response string
+		want     http.Header
+	}{
+		{
+			name: "images honor identity and session headers",
+			request: ExecuteRequest{
+				Model: "gpt-image-2", Format: "openai-image", RequestPath: "/v1/images/generations",
+				Payload:           []byte(`{"model":"gpt-image-2","prompt":"draw a circle"}`),
+				Headers:           http.Header{"User-Agent": {customUA}, "Originator": {"custom-client"}, "Session_id": {"image-session"}},
+				ConfiguredHeaders: []string{"User-Agent", "Originator"},
+			},
+			response: `{"created":1,"data":[{"b64_json":"aA=="}]}`,
+			want:     http.Header{"User-Agent": {customUA}, "Originator": {"custom-client"}, "Version": {"0.200.0"}, "Session-Id": {"image-session"}},
+		},
+		{
+			name: "removed UA is not replaced by Go transport",
+			request: ExecuteRequest{
+				Model: "gpt-5", Format: "openai-response", Payload: []byte(`{"model":"gpt-5","input":"hello"}`),
+				ConfiguredHeaders: []string{"User-Agent", "Originator", "Version"},
+			},
+			response: "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5\",\"output\":[]}}\n\n",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			capturedHeaders := make(chan http.Header, 1)
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedHeaders <- r.Header.Clone()
+				if test.request.Format == "openai-image" {
+					w.Header().Set("Content-Type", "application/json")
+				} else {
+					w.Header().Set("Content-Type", "text/event-stream")
+				}
+				if _, err := io.WriteString(w, test.response); err != nil {
+					t.Errorf("write upstream response: %v", err)
+				}
+			}))
+			defer server.Close()
+			request := test.request
+			request.BaseURL = server.URL
+			ctx := context.WithValue(t.Context(), "cliproxy.roundtripper", server.Client().Transport)
+			_, err := NewCodexHTTPExecutor().ExecuteCanonical(ctx, "credential-1", CodexCredential{
+				Type: ProviderCodex, AccessToken: "access", RefreshToken: "refresh", AccountID: "account-1",
+			}, request)
+			if err != nil {
+				t.Fatalf("ExecuteCanonical() error = %v", err)
+			}
+			captured := <-capturedHeaders
+			for _, name := range []string{"User-Agent", "Originator", "Version", "Session-Id", "Session_id"} {
+				if got, want := captured.Get(name), test.want.Get(name); got != want {
+					t.Errorf("wire %s = %q, want %q", name, got, want)
+				}
+			}
+		})
+	}
+}

--- a/third_party/cpaembedded/embedded/embedded.go
+++ b/third_party/cpaembedded/embedded/embedded.go
@@ -143,14 +143,15 @@ type HTTPExecutor interface {
 }
 
 type ExecuteRequest struct {
-	AttemptID       string
-	Model           string
-	Payload         []byte
-	Format          string
-	RequestPath     string
-	Headers         http.Header
-	OriginalRequest []byte
-	ContinuityKey   string
+	AttemptID         string
+	Model             string
+	Payload           []byte
+	Format            string
+	RequestPath       string
+	Headers           http.Header
+	ConfiguredHeaders []string
+	OriginalRequest   []byte
+	ContinuityKey     string
 	// BaseURL 是可选的订阅 API 代理根地址，原生路径由渠道解析。
 	BaseURL              string
 	ProxyURL             string
@@ -389,6 +390,7 @@ func (e *CodexHTTPExecutor) Identifier() string { return ProviderCodex }
 // ExecuteCanonical runs one unary Codex request through CPA's stateless HTTP
 // executor and captures request-path, reasoning, and quota observations.
 func (e *CodexHTTPExecutor) ExecuteCanonical(ctx context.Context, credentialID string, credential CodexCredential, request ExecuteRequest) (ExecuteResponse, error) {
+	request.Headers = normalizedCodexHeaders(request.Headers)
 	format := sdktranslator.FromString(request.Format)
 	endpoints, err := ResolveCodexAPIEndpoints(request.BaseURL)
 	if err != nil {
@@ -397,7 +399,7 @@ func (e *CodexHTTPExecutor) ExecuteCanonical(ctx context.Context, credentialID s
 	auth := NewCodexAuth(credentialID, credential, endpoints.ExecutionBase)
 	auth.ProxyURL = request.ProxyURL
 	observation := newExecutionObservation(request)
-	executionCtx := e.executionContext(ctx, auth, observation, request.ProxyFromEnvironment)
+	executionCtx := e.executionContext(ctx, auth, observation, request.ProxyFromEnvironment, &request)
 	response, err := e.inner.Execute(executionCtx, authWithoutProxyURL(auth), cliproxyexecutor.Request{
 		Model: request.Model, Payload: append([]byte(nil), request.Payload...), Format: format,
 	}, codexExecutionOptions(request, format, false))
@@ -420,6 +422,7 @@ func (e *CodexHTTPExecutor) ExecuteCanonical(ctx context.Context, credentialID s
 // CountTokensCanonical runs Codex token counting and normalizes Responses API
 // token-count payloads into the public response shape.
 func (e *CodexHTTPExecutor) CountTokensCanonical(ctx context.Context, credentialID string, credential CodexCredential, request ExecuteRequest) (ExecuteResponse, error) {
+	request.Headers = normalizedCodexHeaders(request.Headers)
 	format := sdktranslator.FromString(request.Format)
 	endpoints, err := ResolveCodexAPIEndpoints(request.BaseURL)
 	if err != nil {
@@ -428,7 +431,7 @@ func (e *CodexHTTPExecutor) CountTokensCanonical(ctx context.Context, credential
 	auth := NewCodexAuth(credentialID, credential, endpoints.ExecutionBase)
 	auth.ProxyURL = request.ProxyURL
 	observation := newExecutionObservation(request)
-	executionCtx := e.executionContext(ctx, auth, observation, request.ProxyFromEnvironment)
+	executionCtx := e.executionContext(ctx, auth, observation, request.ProxyFromEnvironment, &request)
 	response, err := e.inner.CountTokens(executionCtx, authWithoutProxyURL(auth), cliproxyexecutor.Request{
 		Model: request.Model, Payload: append([]byte(nil), request.Payload...), Format: format,
 	}, codexExecutionOptions(request, format, false))
@@ -481,6 +484,7 @@ func normalizeCodexResponsesTokenCount(payload []byte) ([]byte, error) {
 // ExecuteStreamCanonical runs one streaming Codex request and forwards copied
 // chunks while retaining handshake and passive quota observations.
 func (e *CodexHTTPExecutor) ExecuteStreamCanonical(ctx context.Context, credentialID string, credential CodexCredential, request ExecuteRequest) (*ExecuteStreamResponse, error) {
+	request.Headers = normalizedCodexHeaders(request.Headers)
 	format := sdktranslator.FromString(request.Format)
 	endpoints, err := ResolveCodexAPIEndpoints(request.BaseURL)
 	if err != nil {
@@ -489,7 +493,7 @@ func (e *CodexHTTPExecutor) ExecuteStreamCanonical(ctx context.Context, credenti
 	auth := NewCodexAuth(credentialID, credential, endpoints.ExecutionBase)
 	auth.ProxyURL = request.ProxyURL
 	observation := newExecutionObservation(request)
-	executionCtx := e.executionContext(ctx, auth, observation, request.ProxyFromEnvironment)
+	executionCtx := e.executionContext(ctx, auth, observation, request.ProxyFromEnvironment, &request)
 	response, err := e.inner.ExecuteStream(executionCtx, authWithoutProxyURL(auth), cliproxyexecutor.Request{
 		Model: request.Model, Payload: append([]byte(nil), request.Payload...), Format: format,
 	}, codexExecutionOptions(request, format, true))
@@ -539,12 +543,14 @@ func codexExecutionOptions(
 }
 
 func (e *CodexHTTPExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
-	executionCtx := e.executionContext(ctx, auth, nil, false)
+	opts.Headers = normalizedCodexHeaders(opts.Headers)
+	executionCtx := e.executionContext(ctx, auth, nil, false, &ExecuteRequest{Headers: opts.Headers})
 	return e.inner.Execute(executionCtx, authWithoutProxyURL(auth), req, opts)
 }
 
 func (e *CodexHTTPExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
-	executionCtx := e.executionContext(ctx, auth, nil, false)
+	opts.Headers = normalizedCodexHeaders(opts.Headers)
+	executionCtx := e.executionContext(ctx, auth, nil, false, &ExecuteRequest{Headers: opts.Headers})
 	return e.inner.ExecuteStream(executionCtx, authWithoutProxyURL(auth), req, opts)
 }
 
@@ -565,7 +571,7 @@ func (e *CodexHTTPExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.
 }
 
 func (e *CodexHTTPExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth, req *http.Request) (*http.Response, error) {
-	executionCtx := e.executionContext(ctx, auth, nil, false)
+	executionCtx := e.executionContext(ctx, auth, nil, false, nil)
 	return e.inner.HttpRequest(executionCtx, authWithoutProxyURL(auth), req)
 }
 
@@ -745,11 +751,18 @@ func (e *CodexHTTPExecutor) executionContext(
 	auth *cliproxyauth.Auth,
 	observation *executionObservation,
 	proxyFromEnvironment bool,
+	request *ExecuteRequest,
 ) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	transport := executionRoundTripper(ctx, e.cfg, auth, proxyFromEnvironment)
+	if request != nil {
+		transport = codexHeadersRoundTripper{
+			base: transport, source: request.Headers.Clone(),
+			configured: append([]string(nil), request.ConfiguredHeaders...),
+		}
+	}
 	return context.WithValue(ctx, "cliproxy.roundtripper", noRedirectRoundTripper{base: transport, observation: observation})
 }
 

--- a/third_party/cpaembedded/embedded/environment_proxy_test.go
+++ b/third_party/cpaembedded/embedded/environment_proxy_test.go
@@ -99,7 +99,7 @@ func TestEnvironmentProxyRoundTripperRejectsInvalidProxyWithoutFallback(t *testi
 func TestCPAProtectedExecutorsInstallEnvironmentProxyRoundTripper(t *testing.T) {
 	t.Parallel()
 
-	codexContext := NewCodexHTTPExecutor().executionContext(t.Context(), nil, nil, true)
+	codexContext := NewCodexHTTPExecutor().executionContext(t.Context(), nil, nil, true, nil)
 	assertEnvironmentProxyContext(t, codexContext)
 	claudeExecutor, ok := NewClaudeHTTPExecutor().(*claudeHTTPExecutor)
 	if !ok {


### PR DESCRIPTION
### 关联 Issue / Related Issue
无

### 变更内容 / Change Content
- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

Codex HTTP 推理会在 CPA 内覆盖显式配置的 User-Agent 和 Originator，同时可能保留另一版本的 Version；Session_id 也会在部分路径丢失。

- 沿现有请求结构记录显式设置或移除的字段，在 CPA 默认值和模型覆盖之后应用 User-Agent、Originator、Version 规则。未配置时保留现有默认身份与模型专用 UA。
- 未显式配置 Version 时，从最终 codex-tui 或 codex_cli_rs UA 提取版本；无法识别的自定义 UA 不继承无关客户端版本。显式 Version 配置优先。
- 兼容 Session-Id 与 Session_id，同时存在时优先采用非空 Session-Id，出站统一为 Session-Id；直接图片路径也保留调用者提供的会话。

影响范围为 Codex HTTP 推理，包含流式及图片请求。未修改数据库、依赖、TLS 指纹、账号查询或独立 WebSocket 会话接口。

验证：
- 回归测试先确认预期行为失败，再验证修复后通过；覆盖默认/模型 UA、显式配置与移除、版本规则、会话别名和请求数据隔离。
- `make check` 通过。
- 在 `third_party/cpaembedded` 执行 `go test -count=1 ./...` 通过，包含本地 HTTPS 图片请求和 UA 移除验证。
- `git --no-pager diff --check` 与暂存区差异检查通过。

未调用真实账号，不将本修复描述为已经解决上游 overloaded。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.
