### PR TITLE
fix(monitor): 更新日志筛选快捷时间

### DIFF
--- a/web/src/features/monitor/LogsTab.vue
+++ b/web/src/features/monitor/LogsTab.vue
@@ -30,6 +30,7 @@ import QueryFeedback from '@/components/ui/QueryFeedback.vue'
 import SkeletonSurface from '@/components/ui/SkeletonSurface.vue'
 import StatusBadge from '@/components/ui/StatusBadge.vue'
 import { formatEstimatedCost, formatISOInstant, formatLocalInstantWithSeconds } from '@/lib/format'
+import { resolveDateTimePreset, type DateTimePreset } from '@/lib/time'
 import { useAuthSession } from '@/features/auth/auth-session'
 
 import {
@@ -66,6 +67,9 @@ import {
 } from './monitor-route'
 
 const props = defineProps<{ filters: AppliedLogFilters }>()
+const emit = defineEmits<{
+  'time-range-resolved': [range: { from_ms: number; to_ms: number; preset: DateTimePreset }]
+}>()
 const client = useApiClient()
 const session = useAuthSession()
 const route = useRoute()
@@ -370,7 +374,18 @@ async function applyFilters(): Promise<void> {
   filterErrors.value = errors
   if (Object.keys(errors).length > 0) return
 
-  await commitFilters(applyLogFilterDraft(draft.value, appliedFilters.value))
+  const filters = applyLogFilterDraft(draft.value, appliedFilters.value)
+  const preset = filters.preset
+  // 显式应用筛选时推进快捷范围；自定义范围及其他日志操作继续保留原区间。
+  if (preset) {
+    const interval = resolveDateTimePreset(preset, Math.floor(Date.now() / 1000) * 1000)
+    if (interval.to_ms > interval.from_ms) {
+      filters.from_ms = interval.from_ms
+      filters.to_ms = interval.to_ms
+      emit('time-range-resolved', { ...interval, preset })
+    }
+  }
+  await commitFilters(filters)
 }
 
 async function resetFilters(): Promise<void> {

--- a/web/src/features/monitor/MonitorView.vue
+++ b/web/src/features/monitor/MonitorView.vue
@@ -266,6 +266,15 @@ function selectTimeShortcut(preset: DateTimePreset, from: number, to: number): v
   applyTimeRange(from, to, preset)
 }
 
+function updateResolvedTimeRange(range: {
+  from_ms: number
+  to_ms: number
+  preset?: DateTimePreset
+}): void {
+  if (range.to_ms <= range.from_ms) return
+  resolvedTimeRange.value = range
+}
+
 function resetTimeDraft(): void {
   timeDraft.value = {
     from: localDateTimeInput(timeFilters.value.from_ms),
@@ -385,7 +394,11 @@ function applyTimeRange(from: number, to: number, preset?: DateTimePreset): void
             <HealthTab ref="healthTab" />
           </div>
           <div v-else-if="activeTab === 'logs'" class="monitor-panel">
-            <LogsTab ref="logsTab" :filters="logFilters" />
+            <LogsTab
+              ref="logsTab"
+              :filters="logFilters"
+              @time-range-resolved="updateResolvedTimeRange"
+            />
           </div>
           <div v-else-if="activeTab === 'usage'" class="monitor-panel">
             <UsageTab ref="usageTab" :filters="usageFilters" />


### PR DESCRIPTION
### 关联 Issue / Related Issue

无

### 变更内容 / Change Content

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

- 请求日志顶部和高级筛选提交时，若当前使用快捷日期，则按当前时间重新计算查询范围并保留快捷日期状态。
- 自定义时间继续使用固定起止时间。
- 日期组件内的“应用”继续将范围转换为自定义时间。

### 自查清单 / Checklist

- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [x] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.（本次无需更新）
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.（无兼容性或数据迁移影响）