### PR TITLE
fix(execution): 统一普通渠道出站 UA 规则

### DIFF
--- a/internal/execution/bifrost/executor.go
+++ b/internal/execution/bifrost/executor.go
@@ -65,6 +65,7 @@ type streamSDKResult struct {
 
 // Execute executes one non-streaming attempt.
 func (r *Runtime) Execute(parent context.Context, spec execution.AttemptSpec) (result execution.AttemptResult) {
+	spec = withUserAgent(spec)
 	defer func() {
 		normalizeImagesAttemptResult(spec, &result)
 		normalizeEmbeddingsAttemptResult(spec, &result)
@@ -180,6 +181,7 @@ func (r *Runtime) ExecuteStream(
 	spec execution.AttemptSpec,
 	sink execution.StreamSink,
 ) (result execution.StreamResult) {
+	spec = withUserAgent(spec)
 	defer func() {
 		normalizeImagesStreamResult(spec, &result)
 	}()

--- a/internal/execution/bifrost/user_agent.go
+++ b/internal/execution/bifrost/user_agent.go
@@ -1,0 +1,25 @@
+package bifrost
+
+import (
+	"net/http"
+	"strings"
+
+	"gpt-load/internal/execution"
+	"gpt-load/internal/platform/version"
+)
+
+// withUserAgent 仅对普通渠道统一出站身份；订阅渠道由各自适配器处理。
+func withUserAgent(spec execution.AttemptSpec) execution.AttemptSpec {
+	for _, name := range spec.ConfiguredHeaders {
+		if strings.EqualFold(name, "User-Agent") && strings.TrimSpace(spec.Header.Get("User-Agent")) != "" {
+			return spec
+		}
+	}
+	spec.Header = spec.Header.Clone()
+	if spec.Header == nil {
+		spec.Header = make(http.Header)
+	}
+	// 未配置、删除或留空都使用系统身份，不继承客户端或 HTTP 库的默认值。
+	spec.Header.Set("User-Agent", "GPT-Load/"+version.Version)
+	return spec
+}

--- a/internal/execution/bifrost/user_agent_test.go
+++ b/internal/execution/bifrost/user_agent_test.go
@@ -1,0 +1,186 @@
+package bifrost
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/gorilla/websocket"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/platform/version"
+	"gpt-load/internal/protocol"
+)
+
+func TestNewAPIModelDiscoveryUserAgentOnWire(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		header     http.Header
+		configured []string
+		want       string
+	}{
+		{name: "system default", want: "GPT-Load/" + version.Version},
+		{name: "ignore client", header: http.Header{"User-Agent": {"client/1.0"}}, want: "GPT-Load/" + version.Version},
+		{name: "configured override", header: http.Header{"User-Agent": {"operator/2.0"}}, configured: []string{"user-agent"}, want: "operator/2.0"},
+		{name: "explicit removal", configured: []string{"User-Agent"}, want: "GPT-Load/" + version.Version},
+		{name: "explicit empty", header: http.Header{"User-Agent": {""}}, configured: []string{"User-Agent"}, want: "GPT-Load/" + version.Version},
+		{name: "explicit whitespace", header: http.Header{"User-Agent": {" \t "}}, configured: []string{"User-Agent"}, want: "GPT-Load/" + version.Version},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			seen := make(chan http.Header, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				seen <- r.Header.Clone()
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"success":true,"data":[{"id":"model-one"}]}`))
+			}))
+			defer server.Close()
+			manager, target := newNewAPIManagerForTest(t, server.URL)
+			spec := utilitySpec(channel.NewAPI, protocol.OpenAICompletions, execution.OperationListModels, http.MethodGet, "/v1/models", nil)
+			spec.TargetConfig = target.TargetConfig
+			spec.Header = test.header.Clone()
+			spec.ConfiguredHeaders = test.configured
+			spec = freezeTestAttempt(spec)
+			original := spec.Header.Clone()
+			result := manager.Execute(t.Context(), spec)
+			if result.Error != nil || result.StatusCode != http.StatusOK {
+				t.Fatalf("discovery failed: %+v", result)
+			}
+			header := <-seen
+			if got := header.Get("User-Agent"); got != test.want {
+				t.Errorf("wire User-Agent = %q, want %q", got, test.want)
+			}
+			if !reflect.DeepEqual(spec.Header, original) {
+				t.Error("execution mutated input headers")
+			}
+		})
+	}
+}
+
+func TestRequestUserAgentOnWire(t *testing.T) {
+	for _, route := range []string{"native", "typed"} {
+		for _, operation := range []string{"unary", "stream", "probe"} {
+			for _, policy := range []string{"default", "configured", "removed", "empty", "whitespace"} {
+				name := route + "/" + operation + "/" + policy
+				want := "GPT-Load/" + version.Version
+				if policy == "configured" {
+					want = "operator/2.0"
+				}
+				t.Run(name, func(t *testing.T) {
+					seen := make(chan string, 1)
+					server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						seen <- r.Header.Get("User-Agent")
+						if operation == "stream" {
+							w.Header().Set("Content-Type", "text/event-stream")
+							_, _ = w.Write([]byte("data: {\"id\":\"chat_1\",\"object\":\"chat.completion.chunk\",\"model\":\"upstream-model\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"ok\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"))
+							return
+						}
+						writeSuccess(w, "ok")
+					}))
+					defer server.Close()
+					runtime := newTestRuntime(t)
+					spec := compatibleSpec(server.URL)
+					if route == "typed" {
+						// 非 /v1 前缀走 SDK typed fallback，覆盖不同的 HTTP 构造路径。
+						spec.TargetConfig = json.RawMessage(`{"base_url":"` + server.URL + `/tenant/openai"}`)
+					}
+					spec.Header.Set("User-Agent", "client/1.0")
+					if policy != "default" {
+						spec.Header.Set("User-Agent", want)
+						spec.ConfiguredHeaders = []string{"User-Agent"}
+					}
+					switch policy {
+					case "removed":
+						spec.Header.Del("User-Agent")
+					case "empty":
+						spec.Header.Set("User-Agent", "")
+					case "whitespace":
+						spec.Header.Set("User-Agent", " \t ")
+					}
+					if operation == "probe" {
+						spec.Operation = execution.OperationProbe
+						spec.Method, spec.Path = "", ""
+						spec.Body = nil
+					}
+					spec = freezeTestAttempt(spec)
+					original := spec.Header.Clone()
+					if operation == "stream" {
+						result := runtime.ExecuteStream(t.Context(), spec, func(execution.StreamEvent) error { return nil })
+						if result.Error != nil {
+							t.Fatalf("stream failed: %+v", result)
+						}
+					} else {
+						result := runtime.Execute(t.Context(), spec)
+						if result.Error != nil || result.StatusCode != http.StatusOK {
+							t.Fatalf("request failed: %+v", result)
+						}
+					}
+					if got := <-seen; got != want {
+						t.Errorf("wire User-Agent = %q, want %q", got, want)
+					}
+					if !reflect.DeepEqual(spec.Header, original) {
+						t.Error("execution mutated input headers")
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestWebsocketUserAgentOnWire(t *testing.T) {
+	for _, policy := range []string{"default", "configured", "removed", "empty", "whitespace"} {
+		want := "GPT-Load/" + version.Version
+		if policy == "configured" {
+			want = "operator/2.0"
+		}
+		t.Run(policy, func(t *testing.T) {
+			seen := make(chan string, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				seen <- r.Header.Get("User-Agent")
+				conn, err := (&websocket.Upgrader{}).Upgrade(w, r, nil)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				defer conn.Close()
+				_, _, _ = conn.ReadMessage()
+			}))
+			defer server.Close()
+			manager, _ := newNewAPIManagerForTest(t, server.URL)
+			spec := compatibleSpec(server.URL)
+			spec.ChannelID = string(channel.OpenAI)
+			spec.ClientProtocol = protocol.OpenAIResponses
+			spec.Operation = execution.OperationResponsesCreate
+			spec.Path = "/v1/responses"
+			spec.Body = []byte(`{"model":"upstream-model","input":"hello"}`)
+			spec.Header.Set("User-Agent", "client/1.0")
+			if policy != "default" {
+				spec.Header.Set("User-Agent", want)
+				spec.ConfiguredHeaders = []string{"user-agent"}
+			}
+			switch policy {
+			case "removed":
+				spec.Header.Del("User-Agent")
+			case "empty":
+				spec.Header.Set("User-Agent", "")
+			case "whitespace":
+				spec.Header.Set("User-Agent", " \t ")
+			}
+			spec = freezeTestAttempt(spec)
+			original := spec.Header.Clone()
+			session, result := manager.OpenWebsocket(t.Context(), spec)
+			if result.Error != nil || session == nil {
+				t.Fatalf("websocket failed: %+v", result)
+			}
+			defer session.Close()
+			if got := <-seen; got != want {
+				t.Errorf("wire User-Agent = %q, want %q", got, want)
+			}
+			if !reflect.DeepEqual(spec.Header, original) {
+				t.Error("execution mutated input headers")
+			}
+		})
+	}
+}

--- a/internal/execution/bifrost/websocket.go
+++ b/internal/execution/bifrost/websocket.go
@@ -13,6 +13,7 @@ import (
 
 // OpenWebsocket 复用目标、凭据和代理合同，原生 WS 不进入 HTTP SDK 的重试链。
 func (manager *RuntimeManager) OpenWebsocket(ctx context.Context, spec execution.AttemptSpec) (execution.WebsocketSession, execution.WebsocketResult) {
+	spec = withUserAgent(spec)
 	reject := func() (execution.WebsocketSession, execution.WebsocketResult) {
 		failure := notSentUnaryFailure(execution.ErrorKindInvalidRequest, "unsupported native websocket request")
 		return nil, execution.WebsocketResult{DispatchState: execution.DispatchNotSent, Error: failure.Error}


### PR DESCRIPTION
### 关联 Issue / Related Issue

无。

### 变更内容 / Change Content

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

- 普通渠道默认发送 `GPT-Load/<版本号>`，不自动透传客户端 UA，避免 HTTP 库隐式补充的 `fasthttp` 被部分上游拦截。
- 现有请求头规则中的非空自定义 UA 优先；未配置、删除、空字符串或纯空白均回退系统默认值。
- 普通请求、流式请求、模型发现、凭据探测和原生 WebSocket 采用一致规则；不修改订阅渠道现有身份规则，不改依赖或新增配置。
- 新增实际出站回归测试，覆盖 native/typed HTTP、模型发现和 WebSocket，并验证不修改输入请求头。
- 兼容性：普通渠道不再自动沿用客户端 UA；需要指定身份时请使用现有请求头规则。删除 UA 不再意味着不发送该请求头。无数据库迁移。

验证：
- RED：删除、空字符串、纯空白回退系统 UA 的新预期在修复前失败。
- GREEN：UA 出站测试与 Codex 固定身份回归通过。
- `make check` 全部通过。

### 自查清单 / Checklist

- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [ ] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.

未修改公开文档；行为和兼容性说明见本 PR。
