### PR TITLE
fix(monitor): 统一筛选操作与跳转的快捷时间行为

### DIFF
--- a/web/src/features/access-keys/AccessKeyCollection.vue
+++ b/web/src/features/access-keys/AccessKeyCollection.vue
@@ -52,8 +52,7 @@ function viewUsage(id: number): void {
     monitorLocation({
       tab: 'usage',
       access_key_id: String(id),
-      from_ms: String(props.usageWindow.from_ms),
-      to_ms: String(props.usageWindow.to_ms),
+      preset: props.usageWindow.range,
     }),
   )
 }
@@ -62,8 +61,7 @@ function viewLogs(id: number): void {
     monitorLocation({
       tab: 'logs',
       access_key_id: String(id),
-      from_ms: String(props.usageWindow.from_ms),
-      to_ms: String(props.usageWindow.to_ms),
+      preset: props.usageWindow.range,
     }),
   )
 }

--- a/web/src/features/home/HomeSpend.vue
+++ b/web/src/features/home/HomeSpend.vue
@@ -35,8 +35,8 @@ function modelName(model: string): string {
 function modelUsageLocation(model: string) {
   return monitorLocation(
     model === ''
-      ? { tab: 'usage', range: '30d' }
-      : { tab: 'usage', range: '30d', upstream_model: model },
+      ? { tab: 'usage', preset: '30d' }
+      : { tab: 'usage', preset: '30d', upstream_model: model },
   )
 }
 
@@ -52,7 +52,7 @@ function tokenCellAttributes(totalTokens: number): { title: string; 'aria-label'
   <section class="home-spend" aria-labelledby="home-spend-title">
     <HomeSectionHeading id="home-spend-title" :title="t('home.ledger.spend.title')">
       <template #actions>
-        <RouterLink class="home-spend__link" :to="monitorLocation({ tab: 'usage', range: '30d' })">
+        <RouterLink class="home-spend__link" :to="monitorLocation({ tab: 'usage', preset: '30d' })">
           {{ t('home.ledger.spend.viewDetail') }}
         </RouterLink>
       </template>

--- a/web/src/features/monitor/LogsTab.vue
+++ b/web/src/features/monitor/LogsTab.vue
@@ -374,9 +374,12 @@ async function applyFilters(): Promise<void> {
   filterErrors.value = errors
   if (Object.keys(errors).length > 0) return
 
-  const filters = applyLogFilterDraft(draft.value, appliedFilters.value)
+  await commitRefreshedFilters(applyLogFilterDraft(draft.value, appliedFilters.value))
+}
+
+async function commitRefreshedFilters(filters: AppliedLogFilters): Promise<void> {
   const preset = filters.preset
-  // 显式应用筛选时推进快捷范围；自定义范围及其他日志操作继续保留原区间。
+  // 应用和重置筛选时推进快捷范围；自定义范围及其他日志操作保留原区间。
   if (preset) {
     const interval = resolveDateTimePreset(preset, Math.floor(Date.now() / 1000) * 1000)
     if (interval.to_ms > interval.from_ms) {
@@ -389,7 +392,7 @@ async function applyFilters(): Promise<void> {
 }
 
 async function resetFilters(): Promise<void> {
-  await commitFilters({
+  await commitRefreshedFilters({
     from_ms: appliedFilters.value.from_ms,
     to_ms: appliedFilters.value.to_ms,
     preset: appliedFilters.value.preset,

--- a/web/src/features/monitor/LogsTab.vue
+++ b/web/src/features/monitor/LogsTab.vue
@@ -87,6 +87,7 @@ const advancedOpen = computed(() => routeState.value.filtersOpen)
 const draft = ref(createLogFilterDraft(appliedFilters.value))
 let draftBeforeAdvanced: LogFilterDraft | undefined
 const filterErrors = ref<LogFilterErrors>({})
+const filterCommitPending = ref(false)
 const paginationPending = ref(false)
 const pageTransitionOrigin = ref<LogsMonitorState | null>(null)
 const currentCursor = computed(() => routeState.value.cursorHistory.at(-1))
@@ -110,7 +111,10 @@ const channelsByID = computed<Record<string, ChannelDto>>(() =>
     (channelsQuery.data.value?.items ?? []).map((channel) => [channel.channel_id, channel]),
   ),
 )
-const logsQuery = useQuery(requestLogQueryOptions(client, appliedFilters, currentCursor))
+const logsQuery = useQuery({
+  ...requestLogQueryOptions(client, appliedFilters, currentCursor),
+  enabled: computed(() => !filterCommitPending.value),
+})
 const logs = computed(() => logsQuery.data.value?.items ?? [])
 const {
   initial: initialLoading,
@@ -338,7 +342,7 @@ async function commitFilters(filters: AppliedLogFilters): Promise<void> {
     routeState.value.selectedRequestID === undefined &&
     !routeState.value.filtersOpen
   ) {
-    await logsQuery.refetch()
+    if (!filterCommitPending.value) await logsQuery.refetch({ cancelRefetch: false })
     return
   }
 
@@ -378,17 +382,28 @@ async function applyFilters(): Promise<void> {
 }
 
 async function commitRefreshedFilters(filters: AppliedLogFilters): Promise<void> {
-  const preset = filters.preset
-  // 应用和重置筛选时推进快捷范围；自定义范围及其他日志操作保留原区间。
-  if (preset) {
-    const interval = resolveDateTimePreset(preset, Math.floor(Date.now() / 1000) * 1000)
-    if (interval.to_ms > interval.from_ms) {
-      filters.from_ms = interval.from_ms
-      filters.to_ms = interval.to_ms
-      emit('time-range-resolved', { ...interval, preset })
+  if (filterCommitPending.value) return
+  filterCommitPending.value = true
+  try {
+    // 时间、筛选和游标分步更新期间不查询，避免请求中间状态。
+    await nextTick()
+    const preset = filters.preset
+    if (preset) {
+      const interval = resolveDateTimePreset(preset, Math.floor(Date.now() / 1000) * 1000)
+      if (interval.to_ms > interval.from_ms) {
+        filters.from_ms = interval.from_ms
+        filters.to_ms = interval.to_ms
+        emit('time-range-resolved', { ...interval, preset })
+      }
     }
+    await commitFilters(filters)
+    await nextTick()
+  } finally {
+    filterCommitPending.value = false
   }
-  await commitFilters(filters)
+  await nextTick()
+  // 查询条件未变化时也刷新；已自动发出的请求直接复用。
+  await logsQuery.refetch({ cancelRefetch: false })
 }
 
 async function resetFilters(): Promise<void> {

--- a/web/src/features/monitor/MonitorView.vue
+++ b/web/src/features/monitor/MonitorView.vue
@@ -401,7 +401,11 @@ function applyTimeRange(from: number, to: number, preset?: DateTimePreset): void
             />
           </div>
           <div v-else-if="activeTab === 'usage'" class="monitor-panel">
-            <UsageTab ref="usageTab" :filters="usageFilters" />
+            <UsageTab
+              ref="usageTab"
+              :filters="usageFilters"
+              @time-range-resolved="updateResolvedTimeRange"
+            />
           </div>
           <div v-else class="monitor-panel">
             <InspectorTab />

--- a/web/src/features/monitor/UsageTab.vue
+++ b/web/src/features/monitor/UsageTab.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useQuery } from '@tanstack/vue-query'
 import { Database } from '@lucide/vue'
-import { computed, ref, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 
@@ -78,6 +78,7 @@ const routeState = computed(() => parseUsageMonitorState(route.query))
 const filterOpen = computed(() => routeState.value.filtersOpen)
 const draft = ref<UsageFilterDraft>(createUsageFilterDraft(appliedFilters.value))
 const filterErrors = ref<UsageFilterErrors>({})
+const filterCommitPending = ref(false)
 
 const groupsQuery = useQuery({
   ...groupOptionsQueryOptions(client, () => !isAccessKey.value),
@@ -100,7 +101,10 @@ const accessKeysQuery = useQuery({
   refetchOnWindowFocus: false,
   refetchOnReconnect: false,
 })
-const usageQuery = useQuery(usageQueryOptions(client, appliedFilters))
+const usageQuery = useQuery({
+  ...usageQueryOptions(client, appliedFilters),
+  enabled: computed(() => !filterCommitPending.value),
+})
 const report = computed(() => usageQuery.data.value)
 // 切换筛选时的占位报告只用于过渡展示，不能作为跨页导航的时间依据。
 const navigationReport = computed(() =>
@@ -381,17 +385,28 @@ async function applyFilters(): Promise<void> {
 }
 
 async function commitRefreshedFilters(filters: AppliedUsageFilters): Promise<void> {
-  const preset = filters.preset
-  // 应用和重置筛选时推进快捷范围；自定义范围及其他用量操作保留原区间。
-  if (preset) {
-    const interval = resolveDateTimePreset(preset, Math.floor(Date.now() / 1000) * 1000)
-    if (interval.to_ms > interval.from_ms) {
-      filters.from_ms = interval.from_ms
-      filters.to_ms = interval.to_ms
-      emit('time-range-resolved', { ...interval, preset })
+  if (filterCommitPending.value) return
+  filterCommitPending.value = true
+  try {
+    // 时间和筛选分步更新期间不查询，避免请求中间状态。
+    await nextTick()
+    const preset = filters.preset
+    if (preset) {
+      const interval = resolveDateTimePreset(preset, Math.floor(Date.now() / 1000) * 1000)
+      if (interval.to_ms > interval.from_ms) {
+        filters.from_ms = interval.from_ms
+        filters.to_ms = interval.to_ms
+        emit('time-range-resolved', { ...interval, preset })
+      }
     }
+    await navigate(filters)
+    await nextTick()
+  } finally {
+    filterCommitPending.value = false
   }
-  await navigate(filters)
+  await nextTick()
+  // 查询条件未变化时也刷新；已自动发出的请求直接复用。
+  await usageQuery.refetch({ cancelRefetch: false })
 }
 
 async function resetFilters(): Promise<void> {

--- a/web/src/features/monitor/UsageTab.vue
+++ b/web/src/features/monitor/UsageTab.vue
@@ -36,6 +36,7 @@ import {
   formatLocalTimeRange,
 } from '@/lib/format'
 import { useAuthSession } from '@/features/auth/auth-session'
+import { resolveDateTimePreset, type DateTimePreset } from '@/lib/time'
 
 import MonitorSectionHeading from './MonitorSectionHeading.vue'
 import UsageBarChart from './UsageBarChart.vue'
@@ -60,6 +61,9 @@ import UsageFilterForm from './UsageFilterForm.vue'
 import UsageSummary from './UsageSummary.vue'
 
 const props = defineProps<{ filters: AppliedUsageFilters }>()
+const emit = defineEmits<{
+  'time-range-resolved': [range: { from_ms: number; to_ms: number; preset: DateTimePreset }]
+}>()
 const client = useApiClient()
 const session = useAuthSession()
 const route = useRoute()
@@ -373,11 +377,25 @@ async function applyFilters(): Promise<void> {
   const errors = validateUsageFilterDraft(draft.value)
   filterErrors.value = errors
   if (Object.keys(errors).length > 0) return
-  await navigate(applyUsageFilterDraft(draft.value, appliedFilters.value))
+  await commitRefreshedFilters(applyUsageFilterDraft(draft.value, appliedFilters.value))
+}
+
+async function commitRefreshedFilters(filters: AppliedUsageFilters): Promise<void> {
+  const preset = filters.preset
+  // 应用和重置筛选时推进快捷范围；自定义范围及其他用量操作保留原区间。
+  if (preset) {
+    const interval = resolveDateTimePreset(preset, Math.floor(Date.now() / 1000) * 1000)
+    if (interval.to_ms > interval.from_ms) {
+      filters.from_ms = interval.from_ms
+      filters.to_ms = interval.to_ms
+      emit('time-range-resolved', { ...interval, preset })
+    }
+  }
+  await navigate(filters)
 }
 
 async function resetFilters(): Promise<void> {
-  await navigate({
+  await commitRefreshedFilters({
     from_ms: appliedFilters.value.from_ms,
     to_ms: appliedFilters.value.to_ms,
     preset: appliedFilters.value.preset,


### PR DESCRIPTION
### 关联 Issue / Related Issue
无

### 变更内容 / Change Content
- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

请求日志主筛选区和侧边栏、用量侧边栏的“应用／重置”统一按点击时刻重新计算快捷日期，自定义起止时间保持不变。日期控件内“应用”生成自定义时间的行为保持不变。

筛选提交期间暂停自动查询，待时间、筛选条件和日志分页游标全部更新后再查询，避免先发送“新时间＋旧筛选”的中间请求。显式刷新复用正在执行的请求，筛选条件不变时也会重新获取数据。

访问密钥跳转用量和请求日志改传最近 7 天的 preset，首页费用详情和模型排行跳转统一使用最近 30 天的 preset，使目标页刷新时可以推进快捷时间。

验证：`make check` 全部通过，包括前端 lint、格式、类型检查与构建，以及 Go 静态检查、构建和完整后端测试。按仓库约定未运行前端测试。

仅修改前端筛选和跳转行为，无 API 或数据库迁移影响，无需更新公开文档。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [ ] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.
