### PR TITLE
fix(usage): 统一修正 Anthropic 流式输入与缓存用量

### DIFF
--- a/internal/dialect/anthropic_compaction_usage.go
+++ b/internal/dialect/anthropic_compaction_usage.go
@@ -1,0 +1,71 @@
+package dialect
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"gpt-load/internal/usage"
+)
+
+// 服务端压缩的额外用量位于 iterations；顶层只包含回答轮次。
+// 仅计入 compaction，不能再累加重复描述回答或服务端 fallback 的轮次。
+func (e *anthropicUsageStreamExtractor) observeCompaction(object map[string]json.RawMessage) usage.Diagnostics {
+	raw, present := object["iterations"]
+	if !present || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return usage.Diagnostics{}
+	}
+	var iterations []map[string]json.RawMessage
+	if json.Unmarshal(raw, &iterations) != nil {
+		return usageDiagnostic(usage.DiagnosticInvalidNumber)
+	}
+	var tokens usage.Tokens
+	var diagnostics usage.Diagnostics
+	for _, iteration := range iterations {
+		var kind string
+		if json.Unmarshal(iteration["type"], &kind) != nil || kind != "compaction" {
+			continue
+		}
+		patch, _ := anthropicUsagePatch(iteration, true, false)
+		diagnostics.Merge(patch.Diagnostics)
+		if !usageIntegerUsable(patch.Diagnostics) || patch.Diagnostics.Has(usage.DiagnosticMissingRequiredField) {
+			return diagnostics
+		}
+		var accumulator usage.Accumulator
+		if err := accumulator.MergePatch(patch); err != nil {
+			diagnostics.Add(usage.DiagnosticInvalidNumber)
+			return diagnostics
+		}
+		result, _ := accumulator.Finalize(true)
+		combined, ok := addAnthropicUsageTokens(tokens, result.Tokens)
+		if !ok {
+			diagnostics.Add(usage.DiagnosticInvalidNumber)
+			return diagnostics
+		}
+		tokens = combined
+	}
+	// iterations 是快照，重复上报不能重复计费；字段缺失时保留上次快照。
+	e.compaction = tokens
+	return diagnostics
+}
+
+func addAnthropicUsageTokens(left, right usage.Tokens) (usage.Tokens, bool) {
+	for _, field := range []struct {
+		target *int64
+		value  int64
+	}{
+		{&left.UncachedInput, right.UncachedInput},
+		{&left.CacheRead, right.CacheRead},
+		{&left.CacheWrite5M, right.CacheWrite5M},
+		{&left.CacheWrite1H, right.CacheWrite1H},
+		{&left.CacheWriteUnknown, right.CacheWriteUnknown},
+		{&left.Output, right.Output},
+	} {
+		value, ok := usage.CheckedAdd(*field.target, field.value)
+		if !ok {
+			return usage.Tokens{}, false
+		}
+		*field.target = value
+	}
+	_, ok := usage.CheckedTotal(left)
+	return left, ok
+}

--- a/internal/dialect/anthropic_usage.go
+++ b/internal/dialect/anthropic_usage.go
@@ -33,6 +33,10 @@ func (d *Anthropic) ExtractUsage(body []byte) (usage.Result, error) {
 }
 
 func (d *Anthropic) NewUsageStreamExtractor() UsageStreamExtractor {
+	return d.NewUsageStreamSnapshotExtractor()
+}
+
+func (d *Anthropic) NewUsageStreamSnapshotExtractor() UsageStreamSnapshotExtractor {
 	return &anthropicUsageStreamExtractor{}
 }
 
@@ -62,6 +66,7 @@ type anthropicUsageStreamExtractor struct {
 	stopped            bool
 	cacheWriteFallback bool
 	trusted            anthropicCumulativeUsage
+	compaction         usage.Tokens
 }
 
 func (e *anthropicUsageStreamExtractor) Observe(payload []byte) error {
@@ -91,7 +96,23 @@ func (e *anthropicUsageStreamExtractor) Observe(payload []byte) error {
 }
 
 func (e *anthropicUsageStreamExtractor) Finalize() (usage.Result, bool) {
-	return e.accumulator.Finalize(true)
+	result, finalized := e.accumulator.Finalize(true)
+	if !finalized {
+		return result, false
+	}
+	if tokens, ok := addAnthropicUsageTokens(result.Tokens, e.compaction); ok {
+		result.Tokens = tokens
+	} else {
+		result.Diagnostics.Add(usage.DiagnosticInvalidNumber)
+		result.State = usage.StatePartial
+	}
+	return result, true
+}
+
+func (e *anthropicUsageStreamExtractor) Snapshot() usage.Result {
+	copy := *e
+	result, _ := copy.Finalize()
+	return result
 }
 
 func (e *anthropicUsageStreamExtractor) observeStart(root map[string]json.RawMessage) error {
@@ -120,6 +141,7 @@ func (e *anthropicUsageStreamExtractor) observeStart(root map[string]json.RawMes
 	}
 	if validInput {
 		e.validStart = true
+		diagnostics.Merge(e.observeCompaction(usageObject))
 		return e.mergeCumulative(next, diagnostics)
 	}
 	return e.mergeDiagnostics(diagnostics)
@@ -140,6 +162,7 @@ func (e *anthropicUsageStreamExtractor) observeDelta(root map[string]json.RawMes
 		diagnostics.Add(usage.DiagnosticInvalidEventSequence)
 		return e.mergeDiagnostics(diagnostics)
 	}
+	diagnostics.Merge(e.observeCompaction(usageObject))
 	return e.mergeCumulative(next, diagnostics)
 }
 
@@ -212,12 +235,8 @@ func (e *anthropicUsageStreamExtractor) mergeCumulative(
 	}
 
 	if next.aggregatePresent {
-		if e.trusted.aggregatePresent && next.aggregate < e.trusted.aggregate {
-			diagnostics.Add(usage.DiagnosticInvalidEventSequence)
-		} else {
-			e.trusted.aggregate = next.aggregate
-			e.trusted.aggregatePresent = true
-		}
+		e.trusted.aggregate = next.aggregate
+		e.trusted.aggregatePresent = true
 	}
 
 	if e.trusted.aggregatePresent {
@@ -283,7 +302,10 @@ func mergeAnthropicCumulativeField(
 	if nextPresent&field == 0 {
 		return
 	}
-	if *trustedPresent&field != 0 && nextValue < *trustedValue {
+	// 输入与缓存是可修正的用量快照：兼容上游可能先估算全部输入，
+	// 再补报较小的未缓存输入。缺失字段保留，明确的零和下降值覆盖。
+	// 输出仍是生成过程的累计计数，保留原有的倒退检查。
+	if field == anthropicUsageOutput && *trustedPresent&field != 0 && nextValue < *trustedValue {
 		diagnostics.Add(usage.DiagnosticInvalidEventSequence)
 		return
 	}

--- a/internal/dialect/anthropic_usage_test.go
+++ b/internal/dialect/anthropic_usage_test.go
@@ -41,6 +41,112 @@ func TestUsageAnthropicCanonicalFixtures(t *testing.T) {
 	}
 }
 
+func TestUsageAnthropicStreamAcceptsInputCorrections(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		start string
+		delta string
+		want  usage.Tokens
+	}{
+		{
+			name:  "final uncached input replaces initial estimate",
+			start: `{"input_tokens":1200,"output_tokens":0}`,
+			delta: `{"input_tokens":100,"cache_read_input_tokens":900,"output_tokens":10}`,
+			want:  usage.Tokens{UncachedInput: 100, CacheRead: 900, Output: 10},
+		},
+		{
+			name:  "explicit zero corrects input and cache reads",
+			start: `{"input_tokens":1200,"cache_read_input_tokens":900,"output_tokens":0}`,
+			delta: `{"input_tokens":0,"cache_read_input_tokens":0,"output_tokens":10}`,
+			want:  usage.Tokens{Output: 10},
+		},
+		{
+			name:  "cache classification can be corrected in both directions",
+			start: `{"input_tokens":100,"cache_read_input_tokens":900}`,
+			delta: `{"input_tokens":200,"cache_read_input_tokens":800,"output_tokens":10}`,
+			want:  usage.Tokens{UncachedInput: 200, CacheRead: 800, Output: 10},
+		},
+		{
+			name:  "cache write aggregate and TTL details accept corrections",
+			start: `{"input_tokens":100,"cache_creation_input_tokens":80,"cache_creation":{"ephemeral_5m_input_tokens":30,"ephemeral_1h_input_tokens":50}}`,
+			delta: `{"cache_creation_input_tokens":20,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":20},"output_tokens":10}`,
+			want:  usage.Tokens{UncachedInput: 100, CacheWrite1H: 20, Output: 10},
+		},
+		{
+			name:  "aggregate-only cache writes can be corrected to zero",
+			start: `{"input_tokens":100,"cache_creation_input_tokens":80}`,
+			delta: `{"cache_creation_input_tokens":0,"output_tokens":10}`,
+			want:  usage.Tokens{UncachedInput: 100, Output: 10},
+		},
+		{
+			name:  "missing fields retain real initial usage",
+			start: `{"input_tokens":100,"cache_read_input_tokens":900,"cache_creation":{"ephemeral_5m_input_tokens":20,"ephemeral_1h_input_tokens":30}}`,
+			delta: `{"output_tokens":10}`,
+			want:  usage.Tokens{UncachedInput: 100, CacheRead: 900, CacheWrite5M: 20, CacheWrite1H: 30, Output: 10},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			extractor := NewAnthropic().NewUsageStreamExtractor()
+			for _, event := range []string{
+				`{"type":"message_start","message":{"usage":` + test.start + `}}`,
+				`{"type":"message_delta","usage":` + test.delta + `}`,
+				`{"type":"message_delta","usage":` + test.delta + `}`,
+				`{"type":"message_stop"}`,
+			} {
+				if err := extractor.Observe([]byte(event)); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got, finalized := extractor.Finalize()
+			if !finalized || got.State != usage.StateComplete || got.Tokens != test.want ||
+				got.Diagnostics.Has(usage.DiagnosticInvalidEventSequence) || got.Diagnostics.Has(usage.DiagnosticInconsistentTotal) {
+				t.Fatalf("usage = %+v, want complete %+v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestUsageAnthropicStreamCompactionSnapshots(t *testing.T) {
+	const initial = `{"type":"message_start","message":{"usage":{"input_tokens":100,"output_tokens":0,"iterations":[{"type":"compaction","input_tokens":50,"output_tokens":5,"cache_creation":{"ephemeral_5m_input_tokens":10,"ephemeral_1h_input_tokens":20}}]}}}`
+	for _, test := range []struct {
+		name        string
+		delta       string
+		want        usage.Tokens
+		diagnostics []usage.DiagnosticCode
+	}{
+		{name: "omitted snapshot preserves compaction", delta: `{"output_tokens":10}`,
+			want: usage.Tokens{UncachedInput: 150, CacheWrite5M: 10, CacheWrite1H: 20, Output: 15}},
+		{name: "repeated snapshot is not additive", delta: `{"output_tokens":10,"iterations":[{"type":"compaction","input_tokens":50,"output_tokens":5,"cache_creation":{"ephemeral_5m_input_tokens":10,"ephemeral_1h_input_tokens":20}}]}`,
+			want: usage.Tokens{UncachedInput: 150, CacheWrite5M: 10, CacheWrite1H: 20, Output: 15}},
+		{name: "empty snapshot clears compaction", delta: `{"output_tokens":10,"iterations":[]}`,
+			want: usage.Tokens{UncachedInput: 100, Output: 10}},
+		{name: "invalid iteration preserves last good snapshot", delta: `{"output_tokens":10,"iterations":[{"type":"compaction","input_tokens":-1,"output_tokens":5}]}`,
+			want: usage.Tokens{UncachedInput: 150, CacheWrite5M: 10, CacheWrite1H: 20, Output: 15}, diagnostics: []usage.DiagnosticCode{usage.DiagnosticNegativeValue}},
+		{name: "invalid container preserves last good snapshot", delta: `{"output_tokens":10,"iterations":{}}`,
+			want: usage.Tokens{UncachedInput: 150, CacheWrite5M: 10, CacheWrite1H: 20, Output: 15}, diagnostics: []usage.DiagnosticCode{usage.DiagnosticInvalidNumber}},
+		{name: "overflowing snapshot preserves last good snapshot", delta: `{"output_tokens":10,"iterations":[{"type":"compaction","input_tokens":9223372036854775807,"output_tokens":1}]}`,
+			want: usage.Tokens{UncachedInput: 150, CacheWrite5M: 10, CacheWrite1H: 20, Output: 15}, diagnostics: []usage.DiagnosticCode{usage.DiagnosticInvalidNumber}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			stream := NewAnthropic().NewUsageStreamExtractor()
+			for _, event := range []string{initial,
+				`{"type":"message_delta","usage":` + test.delta + `}`,
+				`{"type":"message_delta","usage":` + test.delta + `}`,
+				`{"type":"message_stop"}`,
+			} {
+				if err := stream.Observe([]byte(event)); err != nil {
+					t.Fatal(err)
+				}
+			}
+			result, _ := stream.Finalize()
+			if result.State != usage.StateComplete || result.Tokens != test.want {
+				t.Fatalf("usage = %+v, want %+v", result, test.want)
+			}
+			requireUsageDiagnostics(t, result.Diagnostics, test.diagnostics...)
+		})
+	}
+}
+
 func TestUsageAnthropicCacheCreationMapping(t *testing.T) {
 	extractor := NewAnthropic()
 	tests := []struct {

--- a/internal/dialect/usage.go
+++ b/internal/dialect/usage.go
@@ -18,6 +18,13 @@ type UsageStreamExtractor interface {
 	Finalize() (usage.Result, bool)
 }
 
+// UsageStreamSnapshotExtractor lets an adapter normalize protocol conversions
+// from the observed usage without ending the upstream stream.
+type UsageStreamSnapshotExtractor interface {
+	UsageStreamExtractor
+	Snapshot() usage.Result
+}
+
 // StreamUsageInjector optionally derives an OpenAI streaming request that asks
 // the upstream to include terminal usage in the response stream.
 type StreamUsageInjector interface {

--- a/internal/execution/bifrost/anthropic_chat_stream.go
+++ b/internal/execution/bifrost/anthropic_chat_stream.go
@@ -1,0 +1,75 @@
+package bifrost
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/maximhq/bifrost/core/providers/anthropic"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// 继续使用 SDK 原有的 Anthropic→Chat 内容转换，仅将用量读取与其丢弃
+// message_delta 的 Chat 传输循环解耦，保留工具索引、思考和签名的转换行为。
+type anthropicChatStreamEncoder struct {
+	state           *anthropic.AnthropicStreamState
+	id              string
+	model           string
+	structuredIndex *int
+}
+
+func (e *anthropicChatStreamEncoder) encode(ctx *schemas.BifrostContext, response *schemas.BifrostResponsesStreamResponse, raw any) ([][]byte, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	body, ok := rawRequestJSON(raw)
+	var event anthropic.AnthropicStreamEvent
+	if !ok || json.Unmarshal(body, &event) != nil {
+		return nil, fmt.Errorf("decode Anthropic stream event")
+	}
+	if event.Message != nil {
+		e.id, e.model = event.Message.ID, event.Message.Model
+	}
+	if event.Type == anthropic.AnthropicStreamEventTypeMessageStop {
+		chat := response.ToBifrostChatResponse()
+		chat.ID, chat.Model = e.id, e.model
+		if response.Response != nil {
+			chat.ServiceTier = response.Response.ServiceTier
+			if response.Response.StopReason != nil && len(chat.Choices) > 0 {
+				chat.Choices[0].FinishReason = response.Response.StopReason
+			}
+		}
+		payload, _, err := encodeChatResponse(chat)
+		if err != nil {
+			return nil, err
+		}
+		return [][]byte{frameSSE(payload), []byte("data: [DONE]\n\n")}, nil
+	}
+	structuredTool, _ := ctx.Value(schemas.BifrostContextKeyStructuredOutputToolName).(string)
+	if event.Type == anthropic.AnthropicStreamEventTypeContentBlockStart && event.ContentBlock != nil &&
+		structuredTool != "" && event.ContentBlock.Name != nil && *event.ContentBlock.Name == structuredTool {
+		e.structuredIndex = event.Index
+		return nil, nil
+	}
+	if e.structuredIndex != nil && event.Index != nil && *e.structuredIndex == *event.Index {
+		if event.Type == anthropic.AnthropicStreamEventTypeContentBlockStop {
+			e.structuredIndex = nil
+			return nil, nil
+		}
+		if event.Delta != nil && event.Delta.Type == anthropic.AnthropicStreamDeltaTypeInputJSON {
+			event.Delta = &anthropic.AnthropicStreamDelta{Type: anthropic.AnthropicStreamDeltaTypeText, Text: event.Delta.PartialJSON}
+		}
+	}
+	chat, sdkErr, _ := event.ToBifrostChatCompletionStream(ctx, structuredTool, e.state)
+	if sdkErr != nil {
+		return nil, fmt.Errorf("convert Anthropic stream event")
+	}
+	if chat == nil {
+		return nil, nil
+	}
+	chat.ID, chat.Model = e.id, e.model
+	payload, _, err := encodeChatResponse(chat)
+	if err != nil {
+		return nil, err
+	}
+	return [][]byte{frameSSE(payload)}, nil
+}

--- a/internal/execution/bifrost/anthropic_chat_stream_test.go
+++ b/internal/execution/bifrost/anthropic_chat_stream_test.go
@@ -1,0 +1,176 @@
+package bifrost
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/providers/anthropic"
+	"github.com/maximhq/bifrost/core/schemas"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+	"gpt-load/internal/usage"
+)
+
+func TestAnthropicChatStreamPreservesContentAndRequest(t *testing.T) {
+	for _, test := range []struct {
+		name, body, blocks, stop, finish, text string
+		tools                                  bool
+	}{
+		{name: "thinking and multiple tools", body: `"tools":[{"type":"function","function":{"name":"first","parameters":{"type":"object"}}},{"type":"function","function":{"name":"second","parameters":{"type":"object"}}}]`,
+			blocks: strings.Join([]string{
+				`{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`,
+				`{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"reasoning text"}}`,
+				`{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig-test"}}`,
+				`{"type":"content_block_stop","index":0}`,
+				`{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"call1","name":"first","input":{}}}`,
+				`{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"a\":1}"}}`,
+				`{"type":"content_block_stop","index":1}`,
+				`{"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"call2","name":"second","input":{}}}`,
+				`{"type":"content_block_stop","index":2}`,
+			}, "\n"), stop: "tool_use", finish: "tool_calls", tools: true},
+		{name: "structured output", body: `"response_format":{"type":"json_schema","json_schema":{"name":"answer","schema":{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}}}`, blocks: strings.Join([]string{
+			`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+			`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{\"answer\":\"yes\"}"}}`,
+			`{"type":"content_block_stop","index":0}`,
+		}, "\n"), stop: "end_turn", finish: "stop", text: `{"answer":"yes"}`},
+		{name: "length stop", body: `"max_tokens":100`, blocks: strings.Join([]string{
+			`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+			`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}`,
+			`{"type":"content_block_stop","index":0}`,
+		}, "\n"), stop: "max_tokens", finish: "length", text: "hello"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			body := []byte(`{"model":"client-model","messages":[{"role":"system","content":"system text"},{"role":"user","content":"hello"}],` + test.body + `}`)
+			requestBodies := make(chan []byte, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				received, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				requestBodies <- received
+				blocks := test.blocks
+				events := []string{`{"type":"message_start","message":{"id":"msg_test","type":"message","role":"assistant","model":"served","content":[],"usage":{"input_tokens":1200,"output_tokens":0}}}`}
+				events = append(events, strings.Split(blocks, "\n")...)
+				events = append(events, `{"type":"message_delta","delta":{"stop_reason":"`+test.stop+`"},"usage":{"input_tokens":100,"cache_read_input_tokens":900,"output_tokens":10}}`, `{"type":"message_stop"}`)
+				w.Header().Set("Content-Type", "text/event-stream")
+				for _, event := range events {
+					var root struct {
+						Type string `json:"type"`
+					}
+					if err := json.Unmarshal([]byte(event), &root); err != nil {
+						t.Error(err)
+						return
+					}
+					_, _ = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", root.Type, event)
+				}
+			}))
+			defer server.Close()
+			runtime := newProtocolTestRuntime(t, testRuntimeOptions{allowPrivateNetwork: true, anthropicBaseURL: server.URL})
+			spec := convertedSpec(channel.Anthropic, protocol.OpenAICompletions, execution.OperationChatCompletion, "/v1/chat/completions", body)
+			prepared, failure := runtime.prepare(spec, true)
+			if failure != nil {
+				t.Fatalf("prepare: %+v", failure)
+			}
+			expected, buildErr := anthropic.BuildAnthropicChatRequestBody(schemas.NewBifrostContext(t.Context(), time.Time{}), prepared.request, anthropic.AnthropicRequestBuildConfig{Provider: prepared.request.Provider, IsStreaming: true})
+			if buildErr != nil {
+				t.Fatal(buildErr)
+			}
+			var data bytes.Buffer
+			result := runtime.ExecuteStream(t.Context(), spec, func(event execution.StreamEvent) error {
+				if event.Kind == execution.StreamEventData {
+					data.Write(event.Data)
+				}
+				return nil
+			})
+			if result.Error != nil {
+				t.Fatalf("stream: %+v", result.Error)
+			}
+			if result.Usage == nil || result.Usage.Normalized.Tokens != (usage.Tokens{UncachedInput: 100, CacheRead: 900, Output: 10}) {
+				t.Fatalf("usage: %+v", result.Usage)
+			}
+			var gotBody, wantBody any
+			if err := json.Unmarshal(<-requestBodies, &gotBody); err != nil {
+				t.Fatal(err)
+			}
+			if err := json.Unmarshal(expected, &wantBody); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(gotBody, wantBody) {
+				t.Fatalf("request changed: got %v want %s", gotBody, expected)
+			}
+			var content, thinking, signature, finish string
+			args := map[int]string{}
+			ids := map[int]string{}
+			done := 0
+			for _, line := range strings.Split(data.String(), "\n") {
+				if !strings.HasPrefix(line, "data: ") {
+					continue
+				}
+				payload := strings.TrimPrefix(line, "data: ")
+				if payload == "[DONE]" {
+					done++
+					continue
+				}
+				var chunk struct {
+					Choices []struct {
+						Finish *string `json:"finish_reason"`
+						Delta  struct {
+							Content   string `json:"content"`
+							Reasoning string `json:"reasoning"`
+							Details   []struct {
+								Signature string `json:"signature"`
+							} `json:"reasoning_details"`
+							Tools []struct {
+								Index    int    `json:"index"`
+								ID       string `json:"id"`
+								Function struct {
+									Arguments string `json:"arguments"`
+								} `json:"function"`
+							} `json:"tool_calls"`
+						} `json:"delta"`
+					} `json:"choices"`
+				}
+				if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+					t.Fatal(err)
+				}
+				for _, choice := range chunk.Choices {
+					content += choice.Delta.Content
+					thinking += choice.Delta.Reasoning
+					for _, detail := range choice.Delta.Details {
+						signature += detail.Signature
+					}
+					for _, tool := range choice.Delta.Tools {
+						args[tool.Index] += tool.Function.Arguments
+						if tool.ID != "" {
+							ids[tool.Index] = tool.ID
+						}
+					}
+					if choice.Finish != nil {
+						finish = *choice.Finish
+					}
+				}
+			}
+			if done != 1 || finish != test.finish || content != test.text {
+				t.Fatalf("stream content=%q finish=%q done=%d; wire=%s", content, finish, done, data.String())
+			}
+			if test.tools && (thinking != "reasoning text" || signature != "sig-test" || args[0] != `{"a":1}` || args[1] != "{}" || ids[0] != "call1" || ids[1] != "call2") {
+				t.Fatalf("lost tool/thinking content: thinking=%q signature=%q args=%v ids=%v; wire=%s", thinking, signature, args, ids, data.String())
+			}
+			if !test.tools && len(args) != 0 {
+				t.Fatalf("unexpected tools: %v", args)
+			}
+			assertNoPrivateLeak(t, data.String(), "raw_response", "raw_request", "system text", "client-secret")
+		})
+	}
+}

--- a/internal/execution/bifrost/anthropic_usage.go
+++ b/internal/execution/bifrost/anthropic_usage.go
@@ -1,0 +1,132 @@
+package bifrost
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+
+	"github.com/maximhq/bifrost/core/schemas"
+
+	"gpt-load/internal/dialect"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+	"gpt-load/internal/usage"
+)
+
+type anthropicWireUsage struct {
+	extractor dialect.UsageStreamSnapshotExtractor
+	seen      bool
+	invalid   bool
+	lastUsage json.RawMessage
+}
+
+func captureAnthropicWireUsage(ctx *schemas.BifrostContext, prepared preparedAttempt) *anthropicWireUsage {
+	if prepared.upstreamProtocol != protocol.Anthropic {
+		return nil
+	}
+	// 只取每个事件随 SDK chunk 返回的原始响应，不缓冲整个回答。
+	// 响应 hook 再启用 integration type，避免 SDK 分派时误清除兼容上游的捕获开关。
+	ctx.SetValue(schemas.BifrostContextKeyAllowPerRequestRawOverride, true)
+	ctx.SetValue(schemas.BifrostContextKeySendBackRawResponse, true)
+	ctx.SetValue(anthropicUsageCaptureKey, true)
+	return &anthropicWireUsage{extractor: dialect.NewAnthropic().NewUsageStreamSnapshotExtractor()}
+}
+
+func (capture *anthropicWireUsage) observe(raw *any) {
+	if capture == nil || raw == nil || *raw == nil {
+		return
+	}
+	value := *raw
+	*raw = nil // 原始回答不得进入后续客户端序列化或普通日志。
+	capture.seen = true
+	body, ok := rawRequestJSON(value)
+	if !ok {
+		capture.invalid = true
+		return
+	}
+	if err := capture.extractor.Observe(body); err != nil {
+		capture.invalid = true
+	}
+	// 证据只保留最后一次原始 usage 对象，不保留消息内容。
+	var event struct {
+		Usage   json.RawMessage `json:"usage"`
+		Message struct {
+			Usage json.RawMessage `json:"usage"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(body, &event); err != nil {
+		capture.invalid = true
+		return
+	}
+	if len(event.Usage) > 0 && string(event.Usage) != "null" {
+		capture.lastUsage = event.Usage
+	} else if len(event.Message.Usage) > 0 && string(event.Message.Usage) != "null" {
+		capture.lastUsage = event.Message.Usage
+	}
+}
+
+func (capture *anthropicWireUsage) evidence() *execution.UsageEvidence {
+	if capture == nil || !capture.seen {
+		return nil
+	}
+	result := capture.extractor.Snapshot()
+	if capture.invalid {
+		result.Diagnostics.Add(usage.DiagnosticInvalidPayload)
+	}
+	return &execution.UsageEvidence{Normalized: result, Raw: append([]byte(nil), capture.lastUsage...)}
+}
+
+func (capture *anthropicWireUsage) discardErrorRaw(err *schemas.BifrostError) {
+	if capture != nil && err != nil {
+		err.ExtraFields.RawResponse = nil
+	}
+}
+
+func (capture *anthropicWireUsage) applyResponses(target *schemas.ResponsesResponseUsage) error {
+	evidence := capture.evidence()
+	if target == nil || evidence == nil {
+		return nil
+	}
+	tokens := evidence.Normalized.Tokens
+	total, ok := usage.CheckedTotal(tokens)
+	if !ok || total > int64(math.MaxInt) {
+		return fmt.Errorf("Anthropic usage exceeds SDK token range")
+	}
+	target.InputTokens = int(total - tokens.Output)
+	target.OutputTokens = int(tokens.Output)
+	target.TotalTokens = int(total)
+	if target.InputTokensDetails == nil {
+		target.InputTokensDetails = &schemas.ResponsesResponseInputTokens{}
+	}
+	details := target.InputTokensDetails
+	details.CachedReadTokens = int(tokens.CacheRead)
+	details.CachedWriteTokens = int(tokens.CacheWrite5M + tokens.CacheWrite1H + tokens.CacheWriteUnknown)
+	details.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{
+		CachedWriteTokens5m: int(tokens.CacheWrite5M), CachedWriteTokens1h: int(tokens.CacheWrite1H),
+	}
+	return nil
+}
+
+// 在首个响应事件的同步 hook 中启用 message_delta，既保留后续用量事件，
+// 又不触发 SDK 请求分派阶段按供应商名单清除 raw capture 和 URL 的行为。
+// 此标记只由已确定上游协议为 Anthropic 的流式尝试设置。
+type anthropicUsageContextKey struct{}
+
+var anthropicUsageCaptureKey anthropicUsageContextKey
+
+type anthropicUsageStreamHook struct{}
+
+func (anthropicUsageStreamHook) GetName() string { return "gpt-load-anthropic-usage" }
+func (anthropicUsageStreamHook) Cleanup() error  { return nil }
+func (anthropicUsageStreamHook) PreRequestHook(_ *schemas.BifrostContext, _ *schemas.BifrostRequest) error {
+	return nil
+}
+func (anthropicUsageStreamHook) PreLLMHook(_ *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
+	return req, nil, nil
+}
+func (anthropicUsageStreamHook) PostLLMHook(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, err *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
+	if enabled, _ := ctx.Value(anthropicUsageCaptureKey).(bool); enabled && resp != nil && resp.ResponsesStreamResponse != nil {
+		ctx.Root().SetValue(schemas.BifrostContextKeyIntegrationType, "anthropic")
+	}
+	return resp, err, nil
+}

--- a/internal/execution/bifrost/anthropic_usage_test.go
+++ b/internal/execution/bifrost/anthropic_usage_test.go
@@ -27,6 +27,12 @@ func TestNativeAnthropicGatewayUsage(t *testing.T) {
 			want    usage.Tokens
 		}{
 			{
+				name:  "missing captured usage retains executor evidence",
+				start: `{"output_tokens":0}`,
+				delta: `{"input_tokens":100,"cache_read_input_tokens":900,"output_tokens":10}`,
+				want:  usage.Tokens{UncachedInput: 100, CacheRead: 900, Output: 10},
+			},
+			{
 				name:  "final input corrects initial estimate",
 				start: `{"input_tokens":1200,"output_tokens":0}`,
 				delta: `{"input_tokens":100,"cache_read_input_tokens":900,"output_tokens":10}`,

--- a/internal/execution/bifrost/anthropic_usage_test.go
+++ b/internal/execution/bifrost/anthropic_usage_test.go
@@ -1,0 +1,206 @@
+package bifrost
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/dialect"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/gateway"
+	"gpt-load/internal/protocol"
+	"gpt-load/internal/usage"
+)
+
+// 经过真实 SDK 和网关，避免正确的原始用量又被 SDK 的最大值结果覆盖。
+func TestNativeAnthropicGatewayUsage(t *testing.T) {
+	for _, channelID := range []channel.ID{channel.Anthropic, channel.NewAPI, channel.Sub2API, channel.CLIProxyAPI, channel.GPTLoad} {
+		for _, test := range []struct {
+			name    string
+			start   string
+			delta   string
+			partial bool
+			want    usage.Tokens
+		}{
+			{
+				name:  "final input corrects initial estimate",
+				start: `{"input_tokens":1200,"output_tokens":0}`,
+				delta: `{"input_tokens":100,"cache_read_input_tokens":900,"output_tokens":10}`,
+				want:  usage.Tokens{UncachedInput: 100, CacheRead: 900, Output: 10},
+			},
+			{
+				name:  "all input cached",
+				start: `{"input_tokens":1200,"output_tokens":0}`,
+				delta: `{"input_tokens":0,"cache_read_input_tokens":1000,"output_tokens":10}`,
+				want:  usage.Tokens{CacheRead: 1000, Output: 10},
+			},
+			{
+				name:  "real initial usage survives omitted final fields",
+				start: `{"input_tokens":100,"cache_read_input_tokens":900,"output_tokens":0}`,
+				delta: `{"output_tokens":10}`,
+				want:  usage.Tokens{UncachedInput: 100, CacheRead: 900, Output: 10},
+			},
+			{
+				name:  "cache write corrections retain TTL split",
+				start: `{"input_tokens":1200,"cache_creation_input_tokens":200,"cache_creation":{"ephemeral_5m_input_tokens":100,"ephemeral_1h_input_tokens":100}}`,
+				delta: `{"input_tokens":100,"cache_read_input_tokens":800,"cache_creation_input_tokens":100,"cache_creation":{"ephemeral_5m_input_tokens":40,"ephemeral_1h_input_tokens":60},"output_tokens":10}`,
+				want:  usage.Tokens{UncachedInput: 100, CacheRead: 800, CacheWrite5M: 40, CacheWrite1H: 60, Output: 10},
+			},
+			{
+				name:  "compaction is billable but serving iterations are not counted twice",
+				start: `{"input_tokens":1200,"output_tokens":0}`,
+				delta: `{"input_tokens":100,"cache_read_input_tokens":900,"output_tokens":10,"iterations":[{"type":"compaction","input_tokens":50,"cache_read_input_tokens":100,"output_tokens":5},{"type":"message","input_tokens":100,"cache_read_input_tokens":900,"output_tokens":10},{"type":"fallback_message","input_tokens":100,"cache_read_input_tokens":900,"output_tokens":10}]}`,
+				want:  usage.Tokens{UncachedInput: 150, CacheRead: 1000, Output: 15},
+			},
+			{
+				name:    "interrupted stream keeps corrected partial usage",
+				start:   `{"input_tokens":1200,"output_tokens":0}`,
+				delta:   `{"input_tokens":100,"cache_read_input_tokens":900,"output_tokens":10}`,
+				partial: true,
+				want:    usage.Tokens{UncachedInput: 100, CacheRead: 900, Output: 10},
+			},
+		} {
+			t.Run(string(channelID)+"/"+test.name, func(t *testing.T) {
+				wire := fmt.Sprintf("event: message_start\r\ndata: "+`{"type":"message_start","message":{"id":"msg_usage","type":"message","role":"assistant","model":"test-model","content":[],"usage":%s}}`+"\r\n\r\n", test.start)
+				wire += fmt.Sprintf("event: message_delta\r\ndata: "+`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":%s}`+"\r\n\r\n", test.delta)
+				if !test.partial {
+					wire += "event: message_stop\r\ndata: {\"type\":\"message_stop\"}\r\n\r\n"
+				}
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "text/event-stream")
+					_, _ = fmt.Fprint(w, wire)
+				}))
+				defer server.Close()
+				registry := channel.NewRegistry()
+				resolved, err := registry.Resolve(channelID, json.RawMessage(`{"base_url":"`+server.URL+`"}`))
+				if err != nil {
+					t.Fatal(err)
+				}
+				manager, err := newRuntimeManager(runtimeOptions{allowPrivateNetwork: true}, registry)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := manager.Start(t.Context()); err != nil {
+					t.Fatal(err)
+				}
+				defer manager.Shutdown()
+				input := gateway.ForwardInput{
+					Dialect: dialect.NewAnthropic(), ClientProtocol: protocol.Anthropic,
+					RequestID: "usage-request", AttemptID: "usage-attempt", AttemptSequence: 1,
+					ChannelID: string(channelID), Operation: execution.OperationChatCompletion,
+					RouteMode: execution.RouteNative, TargetConfig: resolved.TargetConfig,
+					ExternalModel: "test-model", UpstreamModelID: "test-model", ObserveUsage: true,
+					Credential: execution.NewCredentialSnapshot(17, 1, 1, []byte(`{"api_key":"local-test-key"}`)),
+					Request: &dialect.ParsedRequest{
+						Method: http.MethodPost, Path: "/v1/messages", Header: http.Header{"Content-Type": {"application/json"}},
+						Body: []byte(`{"model":"test-model","max_tokens":16,"stream":true,"messages":[{"role":"user","content":"hello"}]}`),
+					},
+				}
+				downstream := httptest.NewRecorder()
+				result := gateway.NewExecutionForwarder(manager).ForwardStream(t.Context(), input, downstream)
+				if !test.partial && (result.Err != nil || result.ExecutionError != nil) {
+					t.Fatalf("forward failed: %v / %+v", result.Err, result.ExecutionError)
+				}
+				wantState := usage.StateComplete
+				if test.partial {
+					wantState = usage.StatePartial
+				}
+				if result.Usage.Tokens != test.want || result.Usage.State != wantState || result.Usage.Diagnostics.Has(usage.DiagnosticInvalidEventSequence) {
+					t.Fatalf("usage = %+v, want %+v/%s", result.Usage, test.want, wantState)
+				}
+				if downstream.Body.String() != wire {
+					t.Fatal("native response wire changed")
+				}
+			})
+		}
+	}
+}
+
+func TestTypedAnthropicStreamUsesFinalUsage(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		channel  channel.ID
+		protocol protocol.Protocol
+		path     string
+		body     string
+		mode     execution.RouteMode
+	}{
+		{"DeepSeek native Anthropic", channel.DeepSeek, protocol.Anthropic, "/v1/messages", `{"model":"test-model","stream":true,"max_tokens":16,"messages":[{"role":"user","content":"hello"}]}`, execution.RouteNative},
+		{"Anthropic to Responses", channel.Anthropic, protocol.OpenAIResponses, "/v1/responses", `{"model":"test-model","stream":true,"input":"hello"}`, execution.RouteConverted},
+		{"Anthropic to Gemini", channel.Anthropic, protocol.Gemini, "/v1beta/models/test-model:streamGenerateContent", `{"contents":[{"role":"user","parts":[{"text":"hello"}]}]}`, execution.RouteConverted},
+		{"Anthropic to Chat Completions", channel.Anthropic, protocol.OpenAICompletions, "/v1/chat/completions", `{"model":"test-model","stream":true,"messages":[{"role":"user","content":"hello"}]}`, execution.RouteConverted},
+	} {
+		for _, sample := range []struct {
+			name, initial, final string
+			partial              bool
+			want                 usage.Tokens
+		}{
+			{"corrected input", `{"input_tokens":1200,"output_tokens":0}`, `{"input_tokens":100,"cache_read_input_tokens":900,"output_tokens":10}`, false, usage.Tokens{UncachedInput: 100, CacheRead: 900, Output: 10}},
+			{"explicit zero", `{"input_tokens":1200,"output_tokens":0}`, `{"input_tokens":0,"cache_read_input_tokens":1000,"output_tokens":10}`, false, usage.Tokens{CacheRead: 1000, Output: 10}},
+			{"omitted final input", `{"input_tokens":100,"cache_read_input_tokens":900,"output_tokens":0}`, `{"output_tokens":10}`, false, usage.Tokens{UncachedInput: 100, CacheRead: 900, Output: 10}},
+			{"cache TTL and compaction", `{"input_tokens":1200,"output_tokens":0}`, `{"input_tokens":100,"cache_read_input_tokens":800,"cache_creation_input_tokens":100,"cache_creation":{"ephemeral_5m_input_tokens":40,"ephemeral_1h_input_tokens":60},"output_tokens":10,"iterations":[{"type":"compaction","input_tokens":50,"output_tokens":5},{"type":"message","input_tokens":100,"output_tokens":10}]}`, false, usage.Tokens{UncachedInput: 150, CacheRead: 800, CacheWrite5M: 40, CacheWrite1H: 60, Output: 15}},
+			{"truncated", `{"input_tokens":1200,"output_tokens":0}`, `{"input_tokens":100,"cache_read_input_tokens":900,"output_tokens":10}`, true, usage.Tokens{UncachedInput: 100, CacheRead: 900, Output: 10}},
+		} {
+			t.Run(test.name+"/"+sample.name, func(t *testing.T) {
+				wire := "event: message_start\ndata: " + `{"type":"message_start","message":{"id":"msg_usage","type":"message","role":"assistant","model":"test-model","content":[],"usage":{"input_tokens":1200,"output_tokens":0}}}` + "\n\n" +
+					"event: content_block_start\ndata: " + `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}` + "\n\n" +
+					"event: content_block_delta\ndata: " + `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"OK"}}` + "\n\n" +
+					"event: content_block_stop\ndata: " + `{"type":"content_block_stop","index":0}` + "\n\n" +
+					"event: message_delta\ndata: " + `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":100,"cache_read_input_tokens":900,"output_tokens":10}}` + "\n\n" +
+					"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+				wire = strings.Replace(wire, `{"input_tokens":1200,"output_tokens":0}`, sample.initial, 1)
+				wire = strings.Replace(wire, `{"input_tokens":100,"cache_read_input_tokens":900,"output_tokens":10}`, sample.final, 1)
+				if sample.partial {
+					wire = strings.TrimSuffix(wire, "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")
+				}
+
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "text/event-stream")
+					_, _ = fmt.Fprint(w, wire)
+				}))
+				defer server.Close()
+				registry := channel.NewRegistry()
+				resolved, err := registry.Resolve(test.channel, json.RawMessage(`{"base_url":"`+server.URL+`"}`))
+				if err != nil {
+					t.Fatal(err)
+				}
+				manager, err := newRuntimeManager(runtimeOptions{allowPrivateNetwork: true}, registry)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := manager.Start(t.Context()); err != nil {
+					t.Fatal(err)
+				}
+				defer manager.Shutdown()
+				selected := map[protocol.Protocol]dialect.Dialect{
+					protocol.Gemini: dialect.NewGemini(), protocol.Anthropic: dialect.NewAnthropic(), protocol.OpenAIResponses: dialect.NewOpenAIResponses(), protocol.OpenAICompletions: dialect.NewOpenAI(),
+				}[test.protocol]
+				input := gateway.ForwardInput{
+					Dialect: selected, ClientProtocol: test.protocol, RequestID: "typed-usage", AttemptID: "typed-usage-1", AttemptSequence: 1,
+					ChannelID: string(test.channel), Operation: execution.OperationChatCompletion, RouteMode: test.mode,
+					TargetConfig: resolved.TargetConfig, ExternalModel: "test-model", UpstreamModelID: "test-model", ObserveUsage: true,
+					Credential: execution.NewCredentialSnapshot(17, 1, 1, []byte(`{"api_key":"local-test-key"}`)),
+					Request:    &dialect.ParsedRequest{Method: http.MethodPost, Path: test.path, Body: []byte(test.body)},
+				}
+				if test.protocol == protocol.OpenAIResponses {
+					input.Operation = execution.OperationResponsesCreate
+				}
+				downstream := httptest.NewRecorder()
+				result := gateway.NewExecutionForwarder(manager).ForwardStream(t.Context(), input, downstream)
+				want := sample.want
+				wantState := usage.StateComplete
+				if sample.partial {
+					wantState = usage.StatePartial
+				}
+				if (!sample.partial && (result.Err != nil || result.ExecutionError != nil)) || result.Usage.Tokens != want || result.Usage.State != wantState {
+					t.Fatalf("usage = %+v, error=%v/%+v, want %+v; wire=%s", result.Usage, result.Err, result.ExecutionError, want, downstream.Body.String())
+				}
+				assertNoPrivateLeak(t, downstream.Body.String(), "raw_response", "raw_request", "local-test-key")
+			})
+		}
+	}
+}

--- a/internal/execution/bifrost/converted.go
+++ b/internal/execution/bifrost/converted.go
@@ -592,6 +592,22 @@ func (r *Runtime) executeConvertedResponsesStream(
 
 	bifrostContext := r.newStreamingSDKContext(callContext, spec, prepared.directKey)
 	enableConvertedWireCapture(bifrostContext, prepared)
+	if prepared.request != nil && prepared.upstreamProtocol == protocol.Anthropic {
+		body, err := anthropic.BuildAnthropicChatRequestBody(bifrostContext, prepared.request, anthropic.AnthropicRequestBuildConfig{
+			Provider: prepared.request.Provider, IsStreaming: true,
+		})
+		if err != nil || len(body) == 0 {
+			return execution.StreamResult{DispatchState: execution.DispatchNotSent, Error: convertedSerializationEvidence()}
+		}
+		prepared.responsesRequest.RawRequestBody = body
+		bifrostContext.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+	}
+	wireUsage := captureAnthropicWireUsage(bifrostContext, prepared)
+	defer func() {
+		if evidence := wireUsage.evidence(); evidence != nil {
+			result.Usage = evidence
+		}
+	}()
 	setTypedRequestURL(bifrostContext, prepared.typedURL)
 	outcomeChannel := make(chan responsesStreamSDKResult, 1)
 	go func() {
@@ -610,6 +626,7 @@ func (r *Runtime) executeConvertedResponsesStream(
 	}
 	preResponse.stop()
 	if outcome.err != nil {
+		wireUsage.discardErrorRaw(outcome.err)
 		captureAppliedReasoning(&outcome.err.ExtraFields.RawRequest, &appliedReasoning)
 		result := convertedStreamErrorResult(outcome.err, bifrostContext, prepared.secrets, false, 0, nil, "", nil)
 		markPromotedStreamRejectionReplaySafe(&result)
@@ -633,6 +650,7 @@ func (r *Runtime) executeConvertedResponsesStream(
 	}
 
 	encoder := newConvertedResponsesStreamEncoder(prepared.clientProtocol)
+	encoder.anthropicSource = wireUsage != nil
 	sequence := uint64(1)
 	model := spec.UpstreamModel
 	var usageEvidence *execution.UsageEvidence
@@ -670,6 +688,7 @@ func (r *Runtime) executeConvertedResponsesStream(
 			if chunk == nil || chunk.BifrostResponsesStreamResponse == nil {
 				callCancel()
 				if chunk != nil && chunk.BifrostError != nil {
+					wireUsage.discardErrorRaw(chunk.BifrostError)
 					captureAppliedReasoning(&chunk.BifrostError.ExtraFields.RawRequest, &appliedReasoning)
 					return streamErrorResult(chunk.BifrostError, bifrostContext, prepared.secrets, true, http.StatusOK, headers, model, usageEvidence)
 				}
@@ -678,19 +697,33 @@ func (r *Runtime) executeConvertedResponsesStream(
 
 			response := chunk.BifrostResponsesStreamResponse
 			captureAppliedReasoning(&response.ExtraFields.RawRequest, &appliedReasoning)
+			raw := response.ExtraFields.RawResponse
+			wireUsage.observe(&response.ExtraFields.RawResponse)
+			if wireUsage != nil && response.Type == "message_delta" && prepared.clientProtocol != protocol.Anthropic {
+				// 该事件只为取得原始用量；其他客户端协议在各自终止事件中接收最终用量。
+				idleTimer.resume()
+				continue
+			}
 			var chunkUsage *execution.UsageEvidence
 			if response.Response != nil {
 				if response.Response.Model != "" {
 					model = response.Response.Model
 				}
 				var err error
+				if err = wireUsage.applyResponses(response.Response.Usage); err != nil {
+					callCancel()
+					return streamErrorResult(nil, bifrostContext, prepared.secrets, true, http.StatusOK, headers, model, usageEvidence)
+				}
 				chunkUsage, err = usageEvidenceFromResponses(response.Response.Usage)
 				if err != nil {
 					callCancel()
 					return streamErrorResult(nil, bifrostContext, prepared.secrets, true, http.StatusOK, headers, model, usageEvidence)
 				}
 			}
-			frames, err := encoder.encode(bifrostContext, response)
+			if evidence := wireUsage.evidence(); evidence != nil {
+				chunkUsage = evidence
+			}
+			frames, err := encoder.encode(bifrostContext, response, raw)
 			if err != nil {
 				callCancel()
 				return streamErrorResult(nil, bifrostContext, prepared.secrets, true, http.StatusOK, headers, model, usageEvidence)
@@ -723,8 +756,10 @@ func (r *Runtime) executeConvertedResponsesStream(
 }
 
 type convertedResponsesStreamEncoder struct {
-	clientProtocol protocol.Protocol
-	geminiState    *gemini.BifrostToGeminiStreamState
+	clientProtocol  protocol.Protocol
+	anthropicSource bool
+	geminiState     *gemini.BifrostToGeminiStreamState
+	chatState       *anthropicChatStreamEncoder
 }
 
 func newConvertedResponsesStreamEncoder(clientProtocol protocol.Protocol) *convertedResponsesStreamEncoder {
@@ -732,14 +767,20 @@ func newConvertedResponsesStreamEncoder(clientProtocol protocol.Protocol) *conve
 	if clientProtocol == protocol.Gemini {
 		encoder.geminiState = gemini.NewBifrostToGeminiStreamState()
 	}
+	if clientProtocol == protocol.OpenAICompletions {
+		encoder.chatState = &anthropicChatStreamEncoder{state: anthropic.NewAnthropicStreamState()}
+	}
 	return encoder
 }
 
 func (e *convertedResponsesStreamEncoder) encode(
 	ctx *schemas.BifrostContext,
 	response *schemas.BifrostResponsesStreamResponse,
+	raw any,
 ) ([][]byte, error) {
 	switch e.clientProtocol {
+	case protocol.OpenAICompletions:
+		return e.chatState.encode(ctx, response, raw)
 	case protocol.OpenAIResponses:
 		wire := response.WithDefaults()
 		if wire == nil {
@@ -760,6 +801,15 @@ func (e *convertedResponsesStreamEncoder) encode(
 			body, err := json.Marshal(event)
 			if err != nil {
 				return nil, fmt.Errorf("marshal Anthropic stream event")
+			}
+			// 同协议重建只沿用上游的原始用量事件，保留缺失/零及 iterations 的语义。
+			// SDK 已完成内容块状态推进；这里不重算或重复叠加用量。
+			if e.anthropicSource && raw != nil && (event.Type == anthropic.AnthropicStreamEventTypeMessageStart || event.Type == anthropic.AnthropicStreamEventTypeMessageDelta) {
+				original, ok := rawRequestJSON(raw)
+				if !ok {
+					return nil, fmt.Errorf("decode Anthropic usage event")
+				}
+				body = original
 			}
 			frames = append(frames, frameNamedSSE(string(event.Type), body))
 		}

--- a/internal/execution/bifrost/executor.go
+++ b/internal/execution/bifrost/executor.go
@@ -208,6 +208,11 @@ func (r *Runtime) ExecuteStream(
 			"count tokens does not support streaming",
 		))
 	}
+	if prepared.request != nil && prepared.upstreamProtocol == protocol.Anthropic {
+		// SDK 的 Chat 流会丢弃 message_delta；借用保留原始事件的读取路径，
+		// 请求仍按原有 Chat builder 生成，客户端仍使用原有 Anthropic→Chat 转换。
+		prepared.responsesRequest = prepared.request.ToResponsesRequest()
+	}
 	if prepared.responsesRequest != nil {
 		return r.executeConvertedResponsesStream(parent, spec, prepared, sink)
 	}

--- a/internal/execution/bifrost/runtime.go
+++ b/internal/execution/bifrost/runtime.go
@@ -136,7 +136,7 @@ func (r *Runtime) Start(ctx context.Context) error {
 	}
 	bifrostCore, err := core.Init(ctx, schemas.BifrostConfig{
 		Account:         r.account,
-		LLMPlugins:      []schemas.LLMPlugin{},
+		LLMPlugins:      []schemas.LLMPlugin{anthropicUsageStreamHook{}},
 		MCPPlugins:      []schemas.MCPPlugin{},
 		Logger:          r.logger,
 		InitialPoolSize: 64,

--- a/internal/execution/cpa/adapter.go
+++ b/internal/execution/cpa/adapter.go
@@ -361,6 +361,13 @@ func (a *Adapter) ExecuteStream(
 	emitPayloads := func(payloads [][]byte) *execution.StreamResult {
 		for _, unframed := range payloads {
 			payload := frameSSE(spec.ClientProtocol, unframed)
+			if spec.ClientProtocol == protocol.Anthropic && spec.RouteMode == execution.RouteConverted {
+				payload, err = normalizeConvertedAnthropicStartUsage(payload)
+				if err != nil {
+					failure := streamInternalError(upstreamProtocol, headers, applied, "normalize converted Anthropic usage", ready)
+					return &failure
+				}
+			}
 			payload, rewriteErr := rewriteStreamModelAlias(spec, payload)
 			if rewriteErr != nil {
 				failure := streamInternalError(upstreamProtocol, headers, applied, "rewrite subscription response model", ready)

--- a/internal/execution/cpa/anthropic_usage.go
+++ b/internal/execution/cpa/anthropic_usage.go
@@ -1,0 +1,66 @@
+package cpa
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// CPA 跨协议流在 message_start 中注入全部输入的本地估算，但 Anthropic 的
+// input_tokens 表示未缓存输入。用零占位，避免估算值阻止最终真实 usage 更新，
+// 或在中断时被当作已计费用量。原生 Anthropic 不经过此修正。
+func normalizeConvertedAnthropicStartUsage(payload []byte) ([]byte, error) {
+	if !bytes.Contains(payload, []byte(`"message_start"`)) {
+		return payload, nil
+	}
+	// CPA 转换器以单行 JSON 生成 data 字段；一个 chunk 可以包含多个完整事件。
+	lines := bytes.SplitAfter(payload, []byte{'\n'})
+	for i, line := range lines {
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		body := bytes.TrimSpace(line[len("data:"):])
+		var event map[string]json.RawMessage
+		if err := json.Unmarshal(body, &event); err != nil {
+			return nil, err
+		}
+		if string(event["type"]) != `"message_start"` {
+			continue
+		}
+		rawMessage, exists := event["message"]
+		if !exists {
+			continue
+		}
+		var message map[string]json.RawMessage
+		if err := json.Unmarshal(rawMessage, &message); err != nil {
+			return nil, err
+		}
+		rawUsage, exists := message["usage"]
+		if !exists {
+			continue
+		}
+		var usage map[string]json.RawMessage
+		if err := json.Unmarshal(rawUsage, &usage); err != nil {
+			return nil, err
+		}
+		if _, exists := usage["input_tokens"]; !exists {
+			continue
+		}
+		usage["input_tokens"] = json.RawMessage("0")
+		var err error
+		message["usage"], err = json.Marshal(usage)
+		if err != nil {
+			return nil, err
+		}
+		event["message"], err = json.Marshal(message)
+		if err != nil {
+			return nil, err
+		}
+		rewritten, err := json.Marshal(event)
+		if err != nil {
+			return nil, err
+		}
+		terminator := line[len(bytes.TrimRight(line, "\r\n")):]
+		lines[i] = append(append([]byte("data: "), rewritten...), terminator...)
+	}
+	return bytes.Join(lines, nil), nil
+}

--- a/internal/execution/cpa/anthropic_usage.go
+++ b/internal/execution/cpa/anthropic_usage.go
@@ -6,8 +6,8 @@ import (
 )
 
 // CPA 跨协议流在 message_start 中注入全部输入的本地估算，但 Anthropic 的
-// input_tokens 表示未缓存输入。用零占位，避免估算值阻止最终真实 usage 更新，
-// 或在中断时被当作已计费用量。原生 Anthropic 不经过此修正。
+// input_tokens 表示未缓存输入。用零占位，避免向客户端报告虚假的未缓存输入，
+// 或在中断时把本地估算当作已计费用量。原生 Anthropic 不经过此修正。
 func normalizeConvertedAnthropicStartUsage(payload []byte) ([]byte, error) {
 	if !bytes.Contains(payload, []byte(`"message_start"`)) {
 		return payload, nil

--- a/internal/execution/cpa/anthropic_usage_test.go
+++ b/internal/execution/cpa/anthropic_usage_test.go
@@ -1,0 +1,195 @@
+package cpa
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/dialect"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/gateway"
+	"gpt-load/internal/protocol"
+	"gpt-load/internal/state"
+	stateloader "gpt-load/internal/state/loader"
+	"gpt-load/internal/usage"
+)
+
+type usageStreamFixtureBridge struct {
+	providerBridge
+	chunks <-chan providerStreamChunk
+}
+
+func (bridge usageStreamFixtureBridge) ExecuteStream(context.Context, string, providerCredential, providerRequest) (*providerStreamResponse, error) {
+	return &providerStreamResponse{Headers: http.Header{"Content-Type": {"text/event-stream"}}, Chunks: bridge.chunks}, nil
+}
+
+func TestCPAAnthropicStreamUsageBoundaries(t *testing.T) {
+	const start = "event: message_start\r\ndata: " + `{"type":"message_start","message":{"id":"msg_1","model":"upstream","content":[],"usage":{"input_tokens":902,"output_tokens":0}}}` + "\r\n\r\n"
+	const delta = "event: message_delta\r\ndata: " + `{"type":"message_delta","usage":{"input_tokens":100,"cache_read_input_tokens":900,"output_tokens":10},"delta":{"stop_reason":"end_turn"}}` + "\r\n\r\n"
+	const stop = "event: message_stop\r\ndata: " + `{"type":"message_stop"}` + "\r\n\r\n"
+	for _, test := range []struct {
+		name   string
+		native bool
+		wire   string
+		err    error
+		want   usage.Tokens
+		state  usage.State
+	}{
+		{name: "combined events and model alias", wire: start + delta + stop,
+			want: usage.Tokens{UncachedInput: 100, CacheRead: 900, Output: 10}, state: usage.StateComplete},
+		{name: "native initial usage stays authoritative", native: true,
+			wire: start + strings.Replace(delta, `"input_tokens":100,`, "", 1) + stop,
+			want: usage.Tokens{UncachedInput: 902, CacheRead: 900, Output: 10}, state: usage.StateComplete},
+		{name: "read failure cannot bill the estimate", wire: start, err: io.ErrUnexpectedEOF, state: usage.StatePartial},
+		{name: "cancellation cannot bill the estimate", wire: start, err: context.Canceled, state: usage.StatePartial},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			adapter, _, _, keyService, row := newAdapterFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
+			spec := validSpec(t, row, keyService)
+			kind := channel.ProviderCodex
+			spec.ClientProtocol, spec.RouteMode = protocol.Anthropic, execution.RouteConverted
+			spec.Operation, spec.Path = execution.OperationChatCompletion, "/v1/messages"
+			spec.Body = []byte(`{"model":"client-model","max_tokens":32,"stream":true,"messages":[{"role":"user","content":"hello"}]}`)
+			if test.native {
+				adapter, keyService, row = newClaudeAdapterFixture(t)
+				spec = validClaudeSpec(t, row, keyService)
+				kind = channel.ProviderClaude
+			}
+			spec.ClientModel = "client-model"
+			chunks := make(chan providerStreamChunk, 2)
+			chunks <- providerStreamChunk{Payload: []byte(test.wire)}
+			if test.err != nil {
+				chunks <- providerStreamChunk{Err: test.err}
+			}
+			close(chunks)
+			adapter.providers[kind] = usageStreamFixtureBridge{providerBridge: adapter.providers[kind], chunks: chunks}
+			input := gateway.ForwardInput{
+				Dialect: dialect.NewAnthropic(), Group: state.GroupView{ID: row.GroupID},
+				Request:   &dialect.ParsedRequest{Method: spec.Method, Path: spec.Path, Body: spec.Body},
+				RequestID: spec.RequestID, AttemptID: spec.AttemptID, AttemptSequence: spec.Sequence,
+				ClientProtocol: spec.ClientProtocol, Operation: spec.Operation, ChannelID: spec.ChannelID,
+				RouteMode: spec.RouteMode, TargetConfig: spec.TargetConfig, Credential: spec.Credential,
+				ExternalModel: spec.ClientModel, UpstreamModelID: spec.UpstreamModel, ObserveUsage: true,
+			}
+			downstream := httptest.NewRecorder()
+			result := gateway.NewExecutionForwarder(adapter).ForwardStream(t.Context(), input, downstream)
+			if result.Err != nil || (result.ExecutionError != nil) != (test.err != nil) {
+				t.Fatalf("forward error = %v, execution error = %+v, want failure=%t", result.Err, result.ExecutionError, test.err != nil)
+			}
+			if result.Usage.Tokens != test.want || result.Usage.State != test.state ||
+				result.Usage.Diagnostics.Has(usage.DiagnosticInvalidEventSequence) {
+				t.Fatalf("usage = %+v, want %+v/%s; wire=%s", result.Usage, test.want, test.state, downstream.Body)
+			}
+			if !strings.Contains(downstream.Body.String(), `"model":"client-model"`) {
+				t.Fatalf("client model alias lost: %s", downstream.Body)
+			}
+		})
+	}
+}
+
+// 经过真实 CPA 转换和网关统计，防止只修正客户端展示或只修正日志。
+func TestCPAConvertedAnthropicStreamUsesFinalUsage(t *testing.T) {
+	for _, provider := range []string{"codex", "grok", "antigravity"} {
+		for _, thinking := range []bool{false, true} {
+			name := provider + "/without thinking"
+			if thinking {
+				name = provider + "/with thinking"
+			}
+			t.Run(name, func(t *testing.T) {
+				server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "text/event-stream")
+					_, _ = io.WriteString(w, convertedAnthropicUpstreamFixture(provider))
+				}))
+				defer server.Close()
+				previousTransport := http.DefaultTransport
+				http.DefaultTransport = server.Client().Transport
+				defer func() { http.DefaultTransport = previousTransport }()
+
+				canonical, identity, model := convertedAnthropicCredentialFixture(provider)
+				adapter, _, _, _, row := newSubscriptionAdapterFixture(t, provider, canonical, identity)
+				request := map[string]any{
+					"model": model, "max_tokens": 8192, "stream": true,
+					"messages": []any{map[string]any{"role": "user", "content": strings.Repeat("stable input text ", 300)}},
+				}
+				if thinking {
+					request["thinking"] = map[string]any{"type": "adaptive"}
+					request["output_config"] = map[string]any{"effort": "high"}
+				}
+				body, err := json.Marshal(request)
+				if err != nil {
+					t.Fatal(err)
+				}
+				target, err := json.Marshal(map[string]string{"base_url": server.URL})
+				if err != nil {
+					t.Fatal(err)
+				}
+				input := gateway.ForwardInput{
+					Dialect: dialect.NewAnthropic(), Group: state.GroupView{ID: row.GroupID},
+					Request:   &dialect.ParsedRequest{Method: http.MethodPost, Path: "/v1/messages", Body: body},
+					RequestID: "request-1", AttemptID: "attempt-1", AttemptSequence: 1,
+					ClientProtocol: protocol.Anthropic, Operation: execution.OperationChatCompletion,
+					ChannelID: provider, RouteMode: execution.RouteConverted, TargetConfig: target,
+					Credential: execution.NewCredentialSnapshot(row.ID, row.SecretVersion,
+						stateloader.CredentialIdentityGeneration(row.IdentityFingerprint, provider, "subscription", json.RawMessage(`{}`)), canonical),
+					ExternalModel: model, UpstreamModelID: model, ObserveUsage: true,
+				}
+				downstream := httptest.NewRecorder()
+				result := gateway.NewExecutionForwarder(adapter).ForwardStream(t.Context(), input, downstream)
+				if result.Err != nil || result.StatusCode != http.StatusOK {
+					t.Fatalf("ForwardStream() = %v, status=%d; wire=%s", result.Err, result.StatusCode, downstream.Body)
+				}
+				want := usage.Tokens{UncachedInput: 100, CacheRead: 900, Output: 10}
+				if result.Usage.Tokens != want || result.Usage.State != usage.StateComplete ||
+					result.Usage.Diagnostics.Has(usage.DiagnosticInvalidEventSequence) {
+					t.Errorf("gateway usage = %+v, want %+v without a regressing estimate", result.Usage, want)
+				}
+				assertConvertedAnthropicWireUsage(t, downstream.Body.String(), want)
+			})
+		}
+	}
+}
+
+func assertConvertedAnthropicWireUsage(t *testing.T, wire string, want usage.Tokens) {
+	t.Helper()
+	extractor := dialect.NewAnthropic().NewUsageStreamExtractor()
+	for _, line := range strings.Split(wire, "\n") {
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		payload := []byte(strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+		if err := extractor.Observe(payload); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, _ := extractor.Finalize()
+	if got.Tokens != want || got.State != usage.StateComplete || got.Diagnostics.Has(usage.DiagnosticInvalidEventSequence) {
+		t.Errorf("client usage = %+v, want %+v; wire=%s", got, want, wire)
+	}
+}
+
+func convertedAnthropicCredentialFixture(provider string) ([]byte, string, string) {
+	switch provider {
+	case "codex":
+		return []byte(`{"type":"codex","access_token":"test-access","refresh_token":"test-refresh","account_id":"test-account","expired":"2030-01-01T00:00:00Z"}`), "test-account", "gpt-5.6-sol"
+	case "grok":
+		return []byte(`{"type":"grok","access_token":"test-access","refresh_token":"test-refresh","account_id":"test-account","email":"test@example.com","token_type":"Bearer","expired":"2030-01-01T00:00:00Z","token_endpoint":"https://auth.x.ai/oauth/token"}`), "test-account", "grok-4.3"
+	default:
+		return []byte(`{"type":"antigravity","access_token":"test-access","refresh_token":"test-refresh","account_id":"test-account","email":"test@example.com","project_id":"test-project","expired":"2030-01-01T00:00:00Z"}`), "test-account", "gemini-live"
+	}
+}
+
+func convertedAnthropicUpstreamFixture(provider string) string {
+	if provider == "antigravity" {
+		return `{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]}}]}}` + "\n" +
+			`{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":""}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1000,"cachedContentTokenCount":900,"candidatesTokenCount":10,"thoughtsTokenCount":0,"totalTokenCount":1010}}}` + "\n"
+	}
+	return "data: " + `{"type":"response.created","response":{"id":"resp_1","model":"upstream-model","status":"in_progress","output":[]}}` + "\n\n" +
+		"data: " + `{"type":"response.output_text.delta","response_id":"resp_1","output_index":0,"content_index":0,"delta":"ok"}` + "\n\n" +
+		"data: " + `{"type":"response.completed","response":{"id":"resp_1","object":"response","status":"completed","model":"upstream-model","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":1000,"input_tokens_details":{"cached_tokens":900},"output_tokens":10,"total_tokens":1010}}}` + "\n\n"
+}

--- a/internal/gateway/anthropic_usage_test.go
+++ b/internal/gateway/anthropic_usage_test.go
@@ -1,0 +1,75 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"gpt-load/internal/dialect"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+	"gpt-load/internal/usage"
+)
+
+func TestExecutionForwarderAnthropicUsageAuthority(t *testing.T) {
+	sdkUsage := usage.Result{State: usage.StateComplete, Tokens: usage.Tokens{UncachedInput: 1200, CacheRead: 900, Output: 10}}
+	for _, test := range []struct {
+		name     string
+		mode     execution.RouteMode
+		observe  bool
+		canceled bool
+		want     usage.Result
+	}{
+		{name: "native fragmented stream", mode: execution.RouteNative, observe: true,
+			want: usage.Result{State: usage.StateComplete, Tokens: usage.Tokens{UncachedInput: 100, CacheRead: 900, Output: 10}}},
+		{name: "canceled native stream", mode: execution.RouteNative, observe: true, canceled: true,
+			want: usage.Result{State: usage.StatePartial, Tokens: usage.Tokens{UncachedInput: 100, CacheRead: 900, Output: 10}}},
+		{name: "converted stream retains upstream accounting", mode: execution.RouteConverted, observe: true, want: sdkUsage},
+		{name: "disabled wire observation retains executor accounting", mode: execution.RouteNative, want: sdkUsage},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			input := executionForwardInput()
+			input.Dialect, input.ClientProtocol = dialect.NewAnthropic(), protocol.Anthropic
+			input.RouteMode, input.RouteRequirement = test.mode, execution.RouteRequirementAny
+			input.ObserveUsage = test.observe
+			input.Request.Path = "/v1/messages"
+			input.Request.Body = []byte(`{"model":"public","max_tokens":16,"stream":true,"messages":[{"role":"user","content":"hello"}]}`)
+			wire := "data: " + `{"type":"message_start","message":{"id":"msg","model":"public","usage":{"input_tokens":1200,"output_tokens":0}}}` + "\r\n\r\n" +
+				"data: " + `{"type":"message_delta","usage":{"input_tokens":100,"cache_read_input_tokens":900,"output_tokens":10},"delta":{"stop_reason":"end_turn"}}` + "\r\n\r\n"
+			if !test.canceled {
+				wire += "data: {\"type\":\"message_stop\"}\r\n\r\n"
+			}
+			executor := fakeExecutionExecutor{stream: func(_ context.Context, _ execution.AttemptSpec, sink execution.StreamSink) execution.StreamResult {
+				header := http.Header{"Content-Type": {"text/event-stream"}}
+				if err := sink(execution.StreamEvent{Sequence: 1, Kind: execution.StreamEventReady, StatusCode: http.StatusOK, Header: header}); err != nil {
+					t.Fatal(err)
+				}
+				sequence := uint64(1)
+				for start := 0; start < len(wire); start += 7 {
+					sequence++
+					if err := sink(execution.StreamEvent{Sequence: sequence, Kind: execution.StreamEventData, Data: []byte(wire[start:min(start+7, len(wire))])}); err != nil {
+						t.Fatal(err)
+					}
+				}
+				result := execution.StreamResult{
+					DispatchState: execution.DispatchMaybeSent, ResponseStarted: true,
+					StatusCode: http.StatusOK, Header: header,
+					Usage: &execution.UsageEvidence{Normalized: sdkUsage},
+				}
+				if test.canceled {
+					result.Error = &execution.ErrorEvidence{Kind: execution.ErrorKindCanceled, Summary: "request canceled"}
+				}
+				return result
+			}}
+			downstream := httptest.NewRecorder()
+			result := NewExecutionForwarder(executor).ForwardStream(t.Context(), input, downstream)
+			if result.Usage != test.want {
+				t.Fatalf("usage = %+v, want %+v", result.Usage, test.want)
+			}
+			if downstream.Body.String() != wire {
+				t.Fatal("forwarded SSE changed")
+			}
+		})
+	}
+}

--- a/internal/gateway/execution_forward.go
+++ b/internal/gateway/execution_forward.go
@@ -329,7 +329,13 @@ func (forwarder *ExecutionForwarder) ForwardStream(
 	}
 	capturedUsage := streamEvents.finalizeUsage()
 	result := upstreamFromExecutionStreamResult(ctx, input, terminal, streamUsage)
-	result.Usage = preferCapturedStreamUsage(result.Usage, capturedUsage)
+	if input.ObserveUsage && input.ClientProtocol == protocol.Anthropic && input.RouteMode == execution.RouteNative {
+		// 原生 Anthropic 流以实际事件为用量依据。SDK 的最大值合并会丢失
+		// 输入修正、明确的零、缓存 TTL 明细，以及流是否完整结束的信息。
+		result.Usage = capturedUsage
+	} else {
+		result.Usage = preferCapturedStreamUsage(result.Usage, capturedUsage)
+	}
 	result.Committed = committed
 	if len(errorBody) > 0 {
 		result.Body = append([]byte(nil), errorBody...)

--- a/internal/gateway/execution_forward.go
+++ b/internal/gateway/execution_forward.go
@@ -329,11 +329,13 @@ func (forwarder *ExecutionForwarder) ForwardStream(
 	}
 	capturedUsage := streamEvents.finalizeUsage()
 	result := upstreamFromExecutionStreamResult(ctx, input, terminal, streamUsage)
-	if input.ObserveUsage && input.ClientProtocol == protocol.Anthropic && input.RouteMode == execution.RouteNative {
+	if input.ObserveUsage && input.ClientProtocol == protocol.Anthropic &&
+		input.RouteMode == execution.RouteNative && capturedUsage.State != usage.StateMissing {
 		// 原生 Anthropic 流以实际事件为用量依据。SDK 的最大值合并会丢失
 		// 输入修正、明确的零、缓存 TTL 明细，以及流是否完整结束的信息。
 		result.Usage = capturedUsage
 	} else {
+		// 未采集到用量时，保留执行层已经取得的证据。
 		result.Usage = preferCapturedStreamUsage(result.Usage, capturedUsage)
 	}
 	result.Committed = committed


### PR DESCRIPTION
### 关联 Issue / Related Issue
无

### 变更内容 / Change Content
- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

修复 Anthropic 流式用量在最终输入值低于首帧估算时仍保留旧值，导致输入消耗偏高、缓存率偏低的问题。例如首帧估算 1200，最终报告未缓存输入 100、缓存读取 900，现在按最终值统计，缓存率为 90%。

- 公共解析器接受输入与缓存快照的修正，区分字段缺失和显式零，保留缓存写入 TTL 与中断流状态；压缩轮次用量只计入一次。
- 原生 Anthropic 路径采用实际流事件计量；Bifrost 跨协议路径在 SDK 丢弃或最大值合并前读取原始用量，复用公共解析器，并保留同协议响应中原始用量字段的含义。
- 保留 CPA 跨协议首帧本地估算的处理，避免向客户端报告虚假输入或将中断前的估算当作实际消耗。
- 回归覆盖 Anthropic、New API、Sub2API、CLIProxyAPI、GPT-Load 原生渠道，以及 DeepSeek 原生 Anthropic 和 Anthropic 上游转换到 Chat、Responses、Gemini；验证工具调用、思考签名、结构化输出及请求内容兼容性。

验证：`make check` 通过。无需配置或数据库迁移；历史请求日志不回算。本次不包含消息顺序与请求重建策略的调整，无需更新公开文档。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [ ] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.
