### PR TITLE
fix(execution): 保留原生消息前缀并保护转换语义

### DIFF
--- a/internal/dialect/request_execution.go
+++ b/internal/dialect/request_execution.go
@@ -108,6 +108,47 @@ func hasMeaningfulField(object map[string]any, field string) bool {
 	}
 }
 
+// CountMidConversationSystemMessages 只观察真实角色，不把用户文本中的提示标签当作系统消息。
+func CountMidConversationSystemMessages(clientProtocol protocol.Protocol, body []byte) int {
+	root, ok := decodeExecutionFeatureObject(body)
+	if !ok {
+		return 0
+	}
+	field := "messages"
+	switch clientProtocol {
+	case protocol.OpenAICompletions, protocol.Anthropic:
+	case protocol.OpenAIResponses:
+		field = "input"
+	default:
+		return 0
+	}
+	messages, _ := root[field].([]any)
+	seenConversation, count := false, 0
+	for _, raw := range messages {
+		message, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		role, _ := message["role"].(string)
+		if role == "system" || role == "developer" {
+			if seenConversation && hasMeaningfulField(message, "content") {
+				count++
+			}
+			continue
+		}
+		switch role {
+		case "user", "assistant", "tool":
+			seenConversation = true
+		}
+		itemType, _ := message["type"].(string)
+		switch itemType {
+		case "function_call", "function_call_output", "reasoning":
+			seenConversation = true
+		}
+	}
+	return count
+}
+
 func responsesCreateRequirements(
 	body []byte,
 ) (execution.RouteRequirement, execution.ResponsesStorePreference) {

--- a/internal/dialect/request_execution.go
+++ b/internal/dialect/request_execution.go
@@ -141,8 +141,8 @@ func CountMidConversationSystemMessages(clientProtocol protocol.Protocol, body [
 			seenConversation = true
 		}
 		itemType, _ := message["type"].(string)
-		switch itemType {
-		case "function_call", "function_call_output", "reasoning":
+		if clientProtocol == protocol.OpenAIResponses && itemType != "" {
+			// 非指令项目也属于有序历史，不按部分工具类型枚举会话起点。
 			seenConversation = true
 		}
 	}

--- a/internal/execution/bifrost/conversion_fidelity.go
+++ b/internal/execution/bifrost/conversion_fidelity.go
@@ -1,0 +1,168 @@
+package bifrost
+
+import (
+	"context"
+
+	"github.com/maximhq/bifrost/core/providers/anthropic"
+	"github.com/maximhq/bifrost/core/schemas"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/dialect"
+	"gpt-load/internal/execution"
+)
+
+func finishConvertedPreparation(spec execution.AttemptSpec, providerKind channel.ProviderKind, prepared preparedAttempt) (preparedAttempt, *execution.AttemptResult) {
+	if spec.RouteMode != execution.RouteConverted ||
+		(spec.Operation != execution.OperationChatCompletion && spec.Operation != execution.OperationResponsesCreate) {
+		return prepared, nil
+	}
+	vertexChat := providerKind == channel.ProviderGoogleVertex && vertexUsesChatFallback(spec.UpstreamModel)
+	if providerKind == channel.ProviderAnthropic || providerKind == channel.ProviderGemini ||
+		providerKind == channel.ProviderAWSBedrock || (providerKind == channel.ProviderGoogleVertex && !vertexChat) {
+		preserveResponsesGlobalInstructions(prepared.responsesRequest)
+	}
+	chatFallback := providerKind == channel.ProviderOpenAICompatible || providerKind == channel.ProviderGroq ||
+		providerKind == channel.ProviderDeepSeek || vertexChat
+	if chatFallback {
+		if chatFallbackDropsTools(prepared.responsesRequest) {
+			failure := notSentConversionFailure(execution.ErrorCodeCriticalSemanticLoss, "Chat conversion cannot preserve requested tools or tool choice")
+			return preparedAttempt{}, &failure
+		}
+		normalizeChatFallbackToolMode(prepared.responsesRequest)
+		if providerKind == channel.ProviderDeepSeek && deepSeekConversionDisablesThinking(prepared.responsesRequest) {
+			failure := notSentConversionFailure(execution.ErrorCodeCriticalSemanticLoss, "DeepSeek conversion cannot preserve explicit thinking with this tool choice or history")
+			return preparedAttempt{}, &failure
+		}
+	}
+	wantSystems := dialect.CountMidConversationSystemMessages(spec.ClientProtocol, spec.Body)
+	if wantSystems == 0 {
+		return prepared, nil
+	}
+	preserved := true
+	switch providerKind {
+	case channel.ProviderGemini, channel.ProviderAWSBedrock:
+		// 这些现有转换器只能把中途系统指令前移或变成用户文本。
+		preserved = false
+	case channel.ProviderGoogleVertex:
+		// Vertex 的非 Claude/Gemini 模型使用 OpenAI wire，可以原位保留系统消息。
+		preserved = vertexChat
+	case channel.ProviderAnthropic:
+		// 仅对此输入形状复用 SDK 的 ModelCaps 和实际位置规则，避免复制模型表或近似工具分组。
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		defer ctx.Cancel()
+		var request *anthropic.AnthropicMessageRequest
+		var err error
+		if prepared.request != nil {
+			request, err = anthropic.ToAnthropicChatRequest(ctx, prepared.request)
+		} else {
+			request, err = anthropic.ToAnthropicResponsesRequest(ctx, prepared.responsesRequest)
+		}
+		keptSystems := 0
+		if err == nil && request != nil {
+			for _, message := range request.Messages {
+				if message.Role == anthropic.AnthropicMessageRoleSystem {
+					keptSystems++
+				}
+			}
+		}
+		preserved = keptSystems == wantSystems
+	}
+	if !preserved {
+		failure := notSentConversionFailure(execution.ErrorCodeCriticalSemanticLoss, "conversion cannot preserve mid-conversation system instructions")
+		return preparedAttempt{}, &failure
+	}
+	return prepared, nil
+}
+
+func vertexUsesChatFallback(model string) bool {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	defer ctx.Cancel()
+	return !schemas.IsAnthropicModelFamily(ctx, model) && !schemas.IsGeminiModelFamily(ctx, model) &&
+		!schemas.IsGemmaModelFamily(ctx, model) && !schemas.IsAllDigitsASCII(model)
+}
+
+func preserveResponsesGlobalInstructions(request *schemas.BifrostResponsesRequest) {
+	if request == nil || request.Params == nil || request.Params.Instructions == nil || *request.Params.Instructions == "" {
+		return
+	}
+	// 这些 SDK 转换器优先使用 input 内的 system，可能覆盖并存的 instructions。
+	// 将全局指令放在输入前端，让同一转换器按顺序处理，并避免重复发送。
+	request.Input = append([]schemas.ResponsesMessage{{
+		Type:    schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+		Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleSystem),
+		Content: &schemas.ResponsesMessageContent{ContentStr: request.Params.Instructions},
+	}}, request.Input...)
+	request.Params.Instructions = nil
+}
+
+func chatFallbackDropsTools(request *schemas.BifrostResponsesRequest) bool {
+	if request == nil || request.Params == nil {
+		return false
+	}
+	// 仅检查 SDK 的参数映射；不重复转换消息，也不自行维护工具能力表。
+	converted := (&schemas.BifrostResponsesRequest{Params: request.Params}).ToChatRequest()
+	if len(converted.Params.Tools) != len(request.Params.Tools) {
+		return true
+	}
+	choice := request.Params.ToolChoice
+	if choice == nil || converted.Params.ToolChoice != nil {
+		return false
+	}
+	// 没有声明工具时，省略 auto/none 不会改变行为；强制调用约束仍不能丢失。
+	mode := ""
+	if choice.ResponsesToolChoiceStr != nil {
+		mode = *choice.ResponsesToolChoiceStr
+	} else if value := choice.ResponsesToolChoiceStruct; value != nil && len(value.Tools) == 0 && value.Name == nil && value.ServerLabel == nil {
+		mode = string(value.Type)
+	}
+	return mode != "auto" && mode != "none"
+}
+
+func normalizeChatFallbackToolMode(request *schemas.BifrostResponsesRequest) {
+	if request == nil || request.Params == nil || request.Params.ToolChoice == nil {
+		return
+	}
+	choice := request.Params.ToolChoice.ResponsesToolChoiceStruct
+	if choice == nil || len(choice.Tools) != 0 || choice.Name != nil || choice.ServerLabel != nil {
+		return
+	}
+	switch choice.Type {
+	case schemas.ResponsesToolChoiceTypeAuto, schemas.ResponsesToolChoiceTypeNone, schemas.ResponsesToolChoiceTypeRequired:
+		// SDK 的结构化 mode:auto 会误映射为 any；采用同义字符串保留原始约束。
+		request.Params.ToolChoice = &schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr(string(choice.Type))}
+	}
+}
+
+func deepSeekConversionDisablesThinking(request *schemas.BifrostResponsesRequest) bool {
+	if request == nil || request.Params == nil || request.Params.Reasoning == nil {
+		return false
+	}
+	reasoning := request.Params.Reasoning
+	enabled := (reasoning.Effort != nil && *reasoning.Effort != "" && *reasoning.Effort != "none") ||
+		(reasoning.MaxTokens != nil && *reasoning.MaxTokens != 0)
+	if !enabled {
+		return false
+	}
+	chat := request.ToChatRequest()
+	// 对齐锁定 SDK 的 requiresDeepSeekThinkingDisabled，仅阻断显式开启思考的冲突输入。
+	if choice := chat.Params.ToolChoice; choice != nil {
+		var kind schemas.ChatToolChoiceType
+		if choice.ChatToolChoiceStr != nil {
+			kind = schemas.ChatToolChoiceType(*choice.ChatToolChoiceStr)
+		} else if choice.ChatToolChoiceStruct != nil {
+			kind = choice.ChatToolChoiceStruct.Type
+		}
+		switch kind {
+		case schemas.ChatToolChoiceTypeRequired, schemas.ChatToolChoiceTypeAny, schemas.ChatToolChoiceTypeFunction,
+			schemas.ChatToolChoiceTypeCustom, schemas.ChatToolChoiceTypeAllowedTools:
+			return true
+		}
+	}
+	for _, message := range chat.Input {
+		if message.Role == schemas.ChatMessageRoleAssistant && message.ChatAssistantMessage != nil &&
+			len(message.ToolCalls) != 0 && message.Reasoning == nil {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/execution/bifrost/conversion_fidelity_test.go
+++ b/internal/execution/bifrost/conversion_fidelity_test.go
@@ -1,0 +1,301 @@
+package bifrost
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+)
+
+func TestConvertedMidConversationInstructionsAreNotWeakened(t *testing.T) {
+	t.Parallel()
+	for _, clientProtocol := range []protocol.Protocol{protocol.OpenAICompletions, protocol.OpenAIResponses} {
+		for _, test := range []struct {
+			name      string
+			channel   channel.ID
+			model     string
+			roles     []string
+			wantError bool
+		}{
+			{"unsupported model", channel.Anthropic, "claude-sonnet-4-6", []string{"user", "system", "assistant"}, true},
+			{"unsupported position", channel.Anthropic, "claude-opus-4-8", []string{"user", "assistant", "system", "user"}, true},
+			{"supported position", channel.Anthropic, "claude-opus-4-8", []string{"user", "system", "assistant"}, false},
+			{"ordinary user reminder", channel.Anthropic, "claude-sonnet-4-6", []string{"user", "assistant", "user"}, false},
+			{"Gemini system hoist", channel.Gemini, "gemini-2.5-pro", []string{"user", "assistant", "system", "user"}, true},
+		} {
+			for _, stream := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%s/%s/stream=%t", clientProtocol, test.name, stream), func(t *testing.T) {
+					var calls atomic.Int64
+					server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+						calls.Add(1)
+						var received struct {
+							Messages []struct{ Role string } `json:"messages"`
+						}
+						if err := json.NewDecoder(request.Body).Decode(&received); err != nil {
+							t.Error(err)
+						}
+						if !test.wantError && test.name == "supported position" &&
+							(len(received.Messages) < 2 || received.Messages[1].Role != "system") {
+							t.Error("supported system instruction did not keep its position")
+						}
+						if stream {
+							writer.Header().Set("Content-Type", "text/event-stream")
+							_, _ = io.WriteString(writer, anthropicResponsesStreamFixture)
+						} else {
+							writer.Header().Set("Content-Type", "application/json")
+							_, _ = io.WriteString(writer, anthropicResponsesConvertedFixture)
+						}
+					}))
+					defer server.Close()
+					runtime := newProtocolTestRuntime(t, testRuntimeOptions{allowPrivateNetwork: true,
+						anthropicBaseURL: server.URL, geminiBaseURL: server.URL + "/v1beta"})
+					operation, path, field := execution.OperationChatCompletion, "/v1/chat/completions", "messages"
+					if clientProtocol == protocol.OpenAIResponses {
+						operation, path, field = execution.OperationResponsesCreate, "/v1/responses", "input"
+					}
+					messages := make([]map[string]any, 0, len(test.roles))
+					for _, role := range test.roles {
+						messages = append(messages, map[string]any{"role": role, "content": "<system-reminder>instruction</system-reminder>"})
+					}
+					body, err := json.Marshal(map[string]any{"model": "client-model", field: messages, "max_tokens": 32, "stream": stream})
+					if err != nil {
+						t.Fatal(err)
+					}
+					spec := convertedSpec(test.channel, clientProtocol, operation, path, body)
+					spec.UpstreamModel = test.model
+					var evidence *execution.ErrorEvidence
+					if stream {
+						result := runtime.ExecuteStream(t.Context(), spec, func(execution.StreamEvent) error { return nil })
+						evidence = result.Error
+					} else {
+						evidence = runtime.Execute(t.Context(), spec).Error
+					}
+					if test.wantError {
+						if calls.Load() != 0 || evidence == nil || evidence.Kind != execution.ErrorKindConversionUnsupported ||
+							evidence.Code != execution.ErrorCodeCriticalSemanticLoss {
+							t.Fatalf("lossy conversion: calls=%d error=%+v", calls.Load(), evidence)
+						}
+					} else if calls.Load() != 1 || evidence != nil {
+						t.Fatalf("supported conversion: calls=%d error=%+v", calls.Load(), evidence)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestChatFallbackDoesNotDropRequestedTools(t *testing.T) {
+	t.Parallel()
+	for _, channelID := range []channel.ID{channel.OpenAICompatible, channel.Groq} {
+		for _, test := range []struct {
+			name      string
+			tools     string
+			choice    string
+			wantError bool
+		}{
+			{"no tools automatic", `[]`, `"auto"`, false},
+			{"no tools disabled", `[]`, `"none"`, false},
+			{"no tools required", `[]`, `"required"`, true},
+			{"web search", `[{"type":"web_search_preview"}]`, `"auto"`, true},
+			{"function", `[{"type":"function","name":"lookup","parameters":{"type":"object"}}]`, `"required"`, false},
+			{"allowed tools", `[{"type":"function","name":"lookup","parameters":{"type":"object"}}]`, `{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"lookup"}]}`, true},
+		} {
+			for _, stream := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%s/%s/stream=%t", channelID, test.name, stream), func(t *testing.T) {
+					var calls atomic.Int64
+					server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+						calls.Add(1)
+						_, body, events := nativeFidelityFixture(protocol.OpenAICompletions)
+						if stream {
+							writer.Header().Set("Content-Type", "text/event-stream")
+							_, _ = io.WriteString(writer, events)
+						} else {
+							writer.Header().Set("Content-Type", "application/json")
+							_, _ = io.WriteString(writer, body)
+						}
+					}))
+					defer server.Close()
+					runtime := newRuntimeForTest(t, testRuntimeOptions{allowPrivateNetwork: true})
+					runtime.baseURLs[channelID] = server.URL
+					body := []byte(fmt.Sprintf(`{"model":"client-model","input":"hello","store":false,"tools":%s,"tool_choice":%s}`, test.tools, test.choice))
+					spec := convertedSpec(channelID, protocol.OpenAIResponses, execution.OperationResponsesCreate, "/v1/responses", body)
+					var evidence *execution.ErrorEvidence
+					if stream {
+						evidence = runtime.ExecuteStream(t.Context(), spec, func(execution.StreamEvent) error { return nil }).Error
+					} else {
+						evidence = runtime.Execute(t.Context(), spec).Error
+					}
+					if test.wantError {
+						if calls.Load() != 0 || evidence == nil || evidence.Kind != execution.ErrorKindConversionUnsupported || evidence.Code != execution.ErrorCodeCriticalSemanticLoss {
+							t.Fatalf("tool requirement was lost: calls=%d error=%+v", calls.Load(), evidence)
+						}
+					} else if calls.Load() != 1 || evidence != nil {
+						t.Fatalf("function tool was rejected: calls=%d error=%+v", calls.Load(), evidence)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestDeepSeekConversionDoesNotDisableExplicitThinking(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name      string
+		thinking  string
+		mode      string
+		history   string
+		wantError bool
+	}{
+		{"forced tool with thinking", `{"thinkingBudget":4096}`, "ANY", "", true},
+		{"automatic tools with thinking", `{"thinkingLevel":"high"}`, "AUTO", "", false},
+		{"forced tool without explicit thinking", `{}`, "ANY", "", false},
+		{"missing replay with thinking", `{"thinkingLevel":"high"}`, "AUTO", `,{"role":"model","parts":[{"functionCall":{"name":"lookup","args":{}}}]},{"role":"user","parts":[{"functionResponse":{"name":"lookup","response":{"result":"ok"}}}]}`, true},
+		{"thinking disabled", `{"thinkingBudget":0}`, "ANY", "", false},
+	} {
+		for _, stream := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/stream=%t", test.name, stream), func(t *testing.T) {
+				var calls atomic.Int64
+				var wireBody []byte
+				server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+					wireBody, _ = io.ReadAll(request.Body)
+					calls.Add(1)
+					_, body, events := nativeFidelityFixture(protocol.OpenAICompletions)
+					if stream {
+						writer.Header().Set("Content-Type", "text/event-stream")
+						_, _ = io.WriteString(writer, events)
+					} else {
+						writer.Header().Set("Content-Type", "application/json")
+						_, _ = io.WriteString(writer, body)
+					}
+				}))
+				defer server.Close()
+				runtime := newRuntimeForTest(t, testRuntimeOptions{allowPrivateNetwork: true})
+				runtime.baseURLs[channel.DeepSeek] = server.URL
+				body := []byte(fmt.Sprintf(`{"contents":[{"role":"user","parts":[{"text":"hello"}]}%s],"generationConfig":{"thinkingConfig":%s},"tools":[{"functionDeclarations":[{"name":"lookup","parameters":{"type":"object"}}]}],"toolConfig":{"functionCallingConfig":{"mode":"%s"}}}`, test.history, test.thinking, test.mode))
+				spec := convertedSpec(channel.DeepSeek, protocol.Gemini, execution.OperationChatCompletion, "/v1beta/models/client-model:generateContent", body)
+				if stream {
+					spec.Path = "/v1beta/models/client-model:streamGenerateContent"
+				}
+				var evidence *execution.ErrorEvidence
+				if stream {
+					evidence = runtime.ExecuteStream(t.Context(), spec, func(execution.StreamEvent) error { return nil }).Error
+				} else {
+					evidence = runtime.Execute(t.Context(), spec).Error
+				}
+				if test.wantError {
+					if calls.Load() != 0 || evidence == nil || evidence.Kind != execution.ErrorKindConversionUnsupported || evidence.Code != execution.ErrorCodeCriticalSemanticLoss {
+						t.Fatalf("thinking was silently disabled: calls=%d error=%+v wire=%s", calls.Load(), evidence, wireBody)
+					}
+				} else if calls.Load() != 1 || evidence != nil {
+					t.Fatalf("valid thinking/tool combination was rejected: calls=%d error=%+v", calls.Load(), evidence)
+				} else if test.name == "automatic tools with thinking" {
+					wire := nativeFidelityObject(t, wireBody)
+					thinking, _ := wire["thinking"].(map[string]any)
+					if wire["tool_choice"] != "auto" || thinking["type"] == "disabled" {
+						t.Fatalf("automatic tools changed thinking or forced a tool: %s", wireBody)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestCloudConversionKeepsSupportedSystemRoles(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		channel    channel.ID
+		model      string
+		config     string
+		credential string
+		wantError  bool
+	}{
+		{channel.GoogleVertex, "claude-opus-4-8", `{"location":"us-central1"}`, `{"service_account_json":"{\"type\":\"service_account\",\"project_id\":\"test-project\",\"client_email\":\"svc@example.com\",\"private_key\":\"synthetic\"}"}`, true},
+		{channel.GoogleVertex, "gemini-2.5-pro", `{"location":"us-central1"}`, `{"service_account_json":"{\"type\":\"service_account\",\"project_id\":\"test-project\",\"client_email\":\"svc@example.com\",\"private_key\":\"synthetic\"}"}`, true},
+		{channel.GoogleVertex, "meta/llama-4", `{"location":"us-central1"}`, `{"service_account_json":"{\"type\":\"service_account\",\"project_id\":\"test-project\",\"client_email\":\"svc@example.com\",\"private_key\":\"synthetic\"}"}`, false},
+		{channel.AWSBedrock, "anthropic.claude-opus-4-8", `{"region":"us-east-1"}`, `{"api_key":"synthetic"}`, true},
+		{channel.AWSBedrock, "amazon.nova-pro-v1:0", `{"region":"us-east-1"}`, `{"api_key":"synthetic"}`, true},
+	} {
+		for _, clientProtocol := range []protocol.Protocol{protocol.OpenAICompletions, protocol.OpenAIResponses} {
+			t.Run(fmt.Sprintf("%s/%s/%s", test.channel, test.model, clientProtocol), func(t *testing.T) {
+				field, path, operation := "messages", "/v1/chat/completions", execution.OperationChatCompletion
+				if clientProtocol == protocol.OpenAIResponses {
+					field, path, operation = "input", "/v1/responses", execution.OperationResponsesCreate
+				}
+				body := []byte(fmt.Sprintf(`{"model":"client-model","%s":[{"role":"user","content":"hello"},{"role":"system","content":"instruction"},{"role":"assistant","content":"ok"},{"role":"user","content":"next"}]}`, field))
+				spec := convertedSpec(test.channel, clientProtocol, operation, path, body)
+				spec.TargetConfig = json.RawMessage(test.config)
+				spec.UpstreamModel = test.model
+				spec.Credential = execution.NewCredentialSnapshot(1, 1, 1, []byte(test.credential))
+				spec = freezeTestAttempt(spec)
+				runtime := newTestRuntime(t)
+				for _, stream := range []bool{false, true} {
+					_, failure := runtime.prepare(spec, stream)
+					if test.wantError {
+						if failure == nil || failure.Error == nil || failure.Error.Code != execution.ErrorCodeCriticalSemanticLoss || failure.DispatchState != execution.DispatchNotSent {
+							t.Fatalf("lossy cloud conversion was not rejected before dispatch: %+v", failure)
+						}
+					} else if failure != nil {
+						t.Fatalf("OpenAI wire can preserve system roles: %+v", failure.Error)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestConvertedResponsesKeepsAllGlobalInstructions(t *testing.T) {
+	t.Parallel()
+	for _, channelID := range []channel.ID{channel.Anthropic, channel.Gemini, channel.OpenAICompatible} {
+		for _, stream := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/stream=%t", channelID, stream), func(t *testing.T) {
+				var calls atomic.Int64
+				server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+					calls.Add(1)
+					body, _ := io.ReadAll(request.Body)
+					wire := string(body)
+					first, second := strings.Index(wire, "FIRST_GLOBAL"), strings.Index(wire, "SECOND_GLOBAL")
+					if first < 0 || second < 0 || first > second || strings.Count(wire, "FIRST_GLOBAL") != 1 || strings.Count(wire, "SECOND_GLOBAL") != 1 {
+						t.Errorf("global instructions were dropped, duplicated or reordered: %s", body)
+					}
+					_, response, events := nativeFidelityFixture(protocol.OpenAICompletions)
+					if channelID == channel.Anthropic {
+						response, events = anthropicResponsesConvertedFixture, anthropicResponsesStreamFixture
+					} else if channelID == channel.Gemini {
+						response, events = geminiResponsesConvertedFixture, geminiResponsesStreamFixture
+					}
+					writer.Header().Set("Content-Type", "application/json")
+					if stream {
+						writer.Header().Set("Content-Type", "text/event-stream")
+						response = events
+					}
+					_, _ = io.WriteString(writer, response)
+				}))
+				defer server.Close()
+				runtime := newProtocolTestRuntime(t, testRuntimeOptions{allowPrivateNetwork: true, anthropicBaseURL: server.URL, geminiBaseURL: server.URL + "/v1beta"})
+				spec := convertedSpec(channelID, protocol.OpenAIResponses, execution.OperationResponsesCreate, "/v1/responses", []byte(`{"model":"client-model","instructions":"FIRST_GLOBAL","input":[{"role":"system","content":"SECOND_GLOBAL"},{"role":"user","content":"hello"}],"store":false}`))
+				if channelID == channel.OpenAICompatible {
+					spec.TargetConfig = json.RawMessage(`{"base_url":"` + server.URL + `/v1"}`)
+					spec = freezeTestAttempt(spec)
+				}
+				var evidence *execution.ErrorEvidence
+				if stream {
+					evidence = runtime.ExecuteStream(t.Context(), spec, func(execution.StreamEvent) error { return nil }).Error
+				} else {
+					evidence = runtime.Execute(t.Context(), spec).Error
+				}
+				if calls.Load() != 1 || evidence != nil {
+					t.Fatalf("valid global instructions were rejected: calls=%d error=%+v", calls.Load(), evidence)
+				}
+			})
+		}
+	}
+}

--- a/internal/execution/bifrost/conversion_fidelity_test.go
+++ b/internal/execution/bifrost/conversion_fidelity_test.go
@@ -92,6 +92,72 @@ func TestConvertedMidConversationInstructionsAreNotWeakened(t *testing.T) {
 	}
 }
 
+func TestConvertedInstructionsAfterRolelessResponsesHistory(t *testing.T) {
+	t.Parallel()
+	const search = `{"type":"web_search_call","id":"ws_history","status":"completed","action":{"type":"search","query":"synthetic"}}`
+	const custom = `{"type":"custom_tool_call","id":"ct_history","call_id":"call_history","name":"synthetic_tool","input":"synthetic input"}`
+	for _, test := range []struct {
+		name      string
+		history   string
+		role      string
+		wantError bool
+	}{
+		{"search then system", search, "system", true},
+		{"search then developer", search, "developer", true},
+		{"custom then system", custom, "system", true},
+		{"custom then developer", custom, "developer", true},
+		{"ordinary user reminder", search, "user", false},
+		{"leading global instructions", `{"role":"system","content":"global instruction"}`, "developer", false},
+	} {
+		for _, stream := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/stream=%t", test.name, stream), func(t *testing.T) {
+				var calls atomic.Int64
+				server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+					calls.Add(1)
+					body, err := io.ReadAll(request.Body)
+					if err != nil {
+						t.Error(err)
+					}
+					if test.wantError {
+						t.Errorf("lossy instruction reached upstream: %s", body)
+					} else if !strings.Contains(string(body), "caller reminder") {
+						t.Errorf("preserved instruction or user text is missing: %s", body)
+					}
+					writer.Header().Set("Content-Type", "application/json")
+					response := anthropicResponsesConvertedFixture
+					if stream {
+						writer.Header().Set("Content-Type", "text/event-stream")
+						response = anthropicResponsesStreamFixture
+					}
+					_, _ = io.WriteString(writer, response)
+				}))
+				defer server.Close()
+				runtime := newProtocolTestRuntime(t, testRuntimeOptions{allowPrivateNetwork: true, anthropicBaseURL: server.URL})
+				body := []byte(fmt.Sprintf(`{"model":"client-model","store":false,"input":[%s,{"role":"%s","content":"<system-reminder>caller reminder</system-reminder>"},{"role":"user","content":"continue"}]}`, test.history, test.role))
+				spec := convertedSpec(channel.Anthropic, protocol.OpenAIResponses, execution.OperationResponsesCreate, "/v1/responses", body)
+				spec.UpstreamModel = "claude-sonnet-4-6"
+				var evidence *execution.ErrorEvidence
+				var dispatch execution.DispatchState
+				if stream {
+					result := runtime.ExecuteStream(t.Context(), spec, func(execution.StreamEvent) error { return nil })
+					evidence, dispatch = result.Error, result.DispatchState
+				} else {
+					result := runtime.Execute(t.Context(), spec)
+					evidence, dispatch = result.Error, result.DispatchState
+				}
+				if test.wantError {
+					if calls.Load() != 0 || dispatch != execution.DispatchNotSent || evidence == nil ||
+						evidence.Kind != execution.ErrorKindConversionUnsupported || evidence.Code != execution.ErrorCodeCriticalSemanticLoss {
+						t.Fatalf("lossy conversion: calls=%d dispatch=%s error=%+v", calls.Load(), dispatch, evidence)
+					}
+				} else if calls.Load() != 1 || evidence != nil {
+					t.Fatalf("preservable input was rejected: calls=%d error=%+v", calls.Load(), evidence)
+				}
+			})
+		}
+	}
+}
+
 func TestChatFallbackDoesNotDropRequestedTools(t *testing.T) {
 	t.Parallel()
 	for _, channelID := range []channel.ID{channel.OpenAICompatible, channel.Groq} {

--- a/internal/execution/bifrost/executor.go
+++ b/internal/execution/bifrost/executor.go
@@ -806,7 +806,7 @@ func (r *Runtime) prepare(spec execution.AttemptSpec, stream bool) (preparedAtte
 			failure := notSentUnaryFailure(execution.ErrorKindInvalidRequest, "invalid compatible channel target")
 			return preparedAttempt{}, &failure
 		}
-		return preparedAttempt{
+		return finishConvertedPreparation(spec, providerKind, preparedAttempt{
 			provider:         provider,
 			mode:             mode,
 			upstreamProtocol: upstreamProtocol,
@@ -815,7 +815,7 @@ func (r *Runtime) prepare(spec execution.AttemptSpec, stream bool) (preparedAtte
 			clientProtocol:   spec.ClientProtocol,
 			directKey:        directKey,
 			secrets:          secrets,
-		}, nil
+		})
 	}
 
 	var openAIRequest openai.OpenAIChatRequest
@@ -844,10 +844,10 @@ func (r *Runtime) prepare(spec execution.AttemptSpec, stream bool) (preparedAtte
 		failure := notSentUnaryFailure(execution.ErrorKindInvalidRequest, "invalid compatible channel target")
 		return preparedAttempt{}, &failure
 	}
-	return preparedAttempt{
+	return finishConvertedPreparation(spec, providerKind, preparedAttempt{
 		provider: provider, mode: mode, upstreamProtocol: upstreamProtocol, request: request, typedURL: typedURL,
 		clientProtocol: spec.ClientProtocol, directKey: directKey, secrets: secrets,
-	}, nil
+	})
 }
 
 func newProbeRequest(

--- a/internal/execution/bifrost/executor.go
+++ b/internal/execution/bifrost/executor.go
@@ -611,7 +611,21 @@ func (r *Runtime) prepare(spec execution.AttemptSpec, stream bool) (preparedAtte
 			clientProtocol: spec.ClientProtocol, directKey: directKey, secrets: secrets,
 		}, nil
 	}
-	if convertedImages || mode == channel.RouteNative && providerSupportsPassthrough(providerKind, customTargetBaseURL, spec.ClientProtocol) {
+	_, nativeMessagePassthrough := nativeMessageProvider(providerKind, spec)
+	if nativeMessagePassthrough && providerKind == channel.ProviderDeepSeek && spec.ClientProtocol == protocol.Anthropic {
+		var input struct {
+			Container json.RawMessage `json:"container"`
+		}
+		if err := json.Unmarshal(spec.Body, &input); err != nil {
+			failure := notSentUnaryFailure(execution.ErrorKindInvalidRequest, "invalid Anthropic request body")
+			return preparedAttempt{}, &failure
+		}
+		if len(input.Container) > 0 && !bytes.Equal(bytes.TrimSpace(input.Container), []byte("null")) {
+			failure := notSentConversionFailure(execution.ErrorCodeCriticalSemanticLoss, "DeepSeek Anthropic route cannot preserve container semantics")
+			return preparedAttempt{}, &failure
+		}
+	}
+	if convertedImages || mode == channel.RouteNative && (nativeMessagePassthrough || providerSupportsPassthrough(providerKind)) {
 		body, sanitizedHeaders, err := sanitizeNativePassthroughRequest(spec, stream)
 		if err != nil {
 			failure := notSentUnaryFailure(execution.ErrorKindInvalidRequest, "invalid native request body")
@@ -645,6 +659,14 @@ func (r *Runtime) prepare(spec execution.AttemptSpec, stream bool) (preparedAtte
 		}
 		passthroughHeaders := safePassthroughHeaders(sanitizedHeaders)
 		passthroughUpstreamURL := ""
+		if nativeMessagePassthrough && spec.ClientProtocol != protocol.Anthropic {
+			passthroughUpstreamURL = r.fixedConfig.targetBaseURL
+		}
+		if providerKind == channel.ProviderOpenAICompatible &&
+			(spec.ClientProtocol == protocol.OpenAICompletions || spec.ClientProtocol == protocol.OpenAIResponses) {
+			passthroughUpstreamURL = r.fixedConfig.targetBaseURL
+			passthroughPath = strings.TrimPrefix(passthroughPath, "/v1")
+		}
 		if providerKind == channel.ProviderMultiProtocolGateway &&
 			(spec.ClientProtocol == protocol.OpenAICompletions ||
 				spec.ClientProtocol == protocol.OpenAIResponses ||
@@ -852,24 +874,14 @@ func newProbeRequest(
 	}
 }
 
-func providerSupportsPassthrough(
-	providerKind channel.ProviderKind,
-	baseURL string,
-	clientProtocol protocol.Protocol,
-) bool {
+func providerSupportsPassthrough(providerKind channel.ProviderKind) bool {
 	switch providerKind {
 	case channel.ProviderOpenAI, channel.ProviderAnthropic, channel.ProviderGemini, channel.ProviderGoogleVertex:
 		return true
 	case channel.ProviderMultiProtocolGateway:
 		return true
 	case channel.ProviderOpenAICompatible:
-		if clientProtocol == protocol.OpenAIImages {
-			return true
-		}
-		// Bifrost's OpenAI passthrough inserts /v1. A compatible
-		// full API prefix with another suffix must use the typed custom path,
-		// without changing the frozen route mode or channel capability.
-		return strings.HasSuffix(baseURL, "/v1")
+		return true
 	default:
 		return false
 	}
@@ -1068,6 +1080,11 @@ func nativePassthroughPath(spec execution.AttemptSpec, providerKind channel.Prov
 		}
 		return spec.Path[:modelStart+len(marker)] + url.PathEscape(spec.UpstreamModel) + spec.Path[colon:], nil
 	case channel.ProviderAnthropic:
+		return spec.Path, nil
+	case channel.ProviderDeepSeek:
+		path, _, err := deepSeekNativeTypedTarget("", spec.ClientProtocol, "")
+		return path, err
+	case channel.ProviderOpenRouter, channel.ProviderGroq, channel.ProviderXAI:
 		return spec.Path, nil
 	case channel.ProviderGemini:
 		path, ok := strings.CutPrefix(spec.Path, "/v1beta")

--- a/internal/execution/bifrost/executor_test.go
+++ b/internal/execution/bifrost/executor_test.go
@@ -1121,7 +1121,9 @@ func TestRuntimeMarksPromotedFirstChatStreamCapacityErrorReplaySafe(t *testing.T
 	defer server.Close()
 
 	runtime := newTestRuntime(t)
-	spec := compatibleSpec(server.URL)
+	// 非 /v1 原生地址现在也保真转发；此用例明确验证跨协议的 SDK 错误提升。
+	spec := convertedSpec(channel.OpenAICompatible, protocol.Anthropic, execution.OperationChatCompletion,
+		"/v1/messages", []byte(`{"model":"client-model","max_tokens":16,"messages":[{"role":"user","content":"hello"}]}`))
 	spec.TargetConfig = json.RawMessage(`{"base_url":"` + server.URL + `/tenant/openai"}`)
 	spec = freezeTestAttempt(spec)
 	var events []execution.StreamEvent
@@ -1172,7 +1174,8 @@ func TestRuntimeFirstByteAndStreamIdleTimeouts(t *testing.T) {
 		defer server.Close()
 
 		runtime := newTestRuntime(t)
-		spec := compatibleSpec(server.URL)
+		spec := convertedSpec(channel.OpenAICompatible, protocol.Anthropic, execution.OperationChatCompletion,
+			"/v1/messages", []byte(`{"model":"client-model","max_tokens":16,"messages":[{"role":"user","content":"hello"}]}`))
 		spec.TargetConfig = json.RawMessage(`{"base_url":"` + server.URL + `/tenant"}`)
 		spec.Timeouts.FirstByte = 20 * time.Millisecond
 		spec.Timeouts.Request = time.Second

--- a/internal/execution/bifrost/native_fidelity_test.go
+++ b/internal/execution/bifrost/native_fidelity_test.go
@@ -1,0 +1,155 @@
+package bifrost
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sync/atomic"
+	"testing"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+	"gpt-load/internal/usage"
+)
+
+func TestNativeMessagesPreserveConversationAndExtensions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		channel  channel.ID
+		protocol protocol.Protocol
+		prefix   string
+		path     string
+	}{
+		{channel.DeepSeek, protocol.Anthropic, "/tenant", "/anthropic/v1/messages"},
+		{channel.DeepSeek, protocol.OpenAICompletions, "/tenant", "/chat/completions"},
+		{channel.DeepSeek, protocol.OpenAIResponses, "/tenant", "/responses"},
+		{channel.OpenRouter, protocol.OpenAICompletions, "/api", "/v1/chat/completions"},
+		{channel.OpenRouter, protocol.OpenAIResponses, "/api", "/v1/responses"},
+		{channel.Groq, protocol.OpenAICompletions, "/openai", "/v1/chat/completions"},
+		{channel.XAI, protocol.OpenAICompletions, "", "/v1/chat/completions"},
+		{channel.XAI, protocol.OpenAIResponses, "", "/v1/responses"},
+		{channel.OpenAICompatible, protocol.OpenAICompletions, "/custom/api/v4", "/chat/completions"},
+		{channel.ZhipuAI, protocol.OpenAICompletions, "/api/paas/v4", "/chat/completions"},
+		{channel.Volcengine, protocol.OpenAICompletions, "/api/v3", "/chat/completions"},
+	}
+	for _, test := range tests {
+		for _, stream := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/%s/stream=%t", test.channel, test.protocol, stream), func(t *testing.T) {
+				body, responseBody, responseStream := nativeFidelityFixture(test.protocol)
+				var original map[string]json.RawMessage
+				if err := json.Unmarshal([]byte(body), &original); err != nil {
+					t.Fatal(err)
+				}
+				original["stream"] = json.RawMessage(fmt.Sprint(stream))
+				requestBody, err := json.Marshal(original)
+				if err != nil {
+					t.Fatal(err)
+				}
+				expected := nativeFidelityObject(t, requestBody)
+				expected["model"] = "upstream-model"
+				delete(expected, "provider")
+				expectedBody, err := json.Marshal(expected)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var calls atomic.Int64
+				server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+					calls.Add(1)
+					if request.Method != http.MethodPost || request.URL.Path != test.prefix+test.path {
+						t.Errorf("target = %s %s, want POST %s", request.Method, request.URL.Path, test.prefix+test.path)
+					}
+					if test.protocol == protocol.Anthropic {
+						if request.Header.Get("X-Api-Key") != "native-key" || request.Header.Get("Authorization") != "" {
+							t.Error("Anthropic credential was not selected correctly")
+						}
+					} else if request.Header.Get("Authorization") != "Bearer native-key" {
+						t.Error("OpenAI credential was not selected correctly")
+					}
+					actualBody, readErr := io.ReadAll(request.Body)
+					if readErr != nil {
+						t.Error(readErr)
+						return
+					}
+					if actual := nativeFidelityObject(t, actualBody); !reflect.DeepEqual(actual, expected) {
+						t.Errorf("native request changed conversation or extensions:\ngot  %s\nwant %s", actualBody, expectedBody)
+					}
+					if stream {
+						writer.Header().Set("Content-Type", "text/event-stream")
+						_, _ = io.WriteString(writer, responseStream)
+					} else {
+						writer.Header().Set("Content-Type", "application/json")
+						_, _ = io.WriteString(writer, responseBody)
+					}
+				}))
+				defer server.Close()
+				runtime := newRuntimeForTest(t, testRuntimeOptions{allowPrivateNetwork: true})
+				baseURL := server.URL + test.prefix
+				var spec execution.AttemptSpec
+				switch test.protocol {
+				case protocol.Anthropic:
+					spec = deepSeekAnthropicAttempt(t, baseURL)
+				case protocol.OpenAIResponses:
+					spec = openAIResponsesAttempt(t, test.channel, baseURL)
+				default:
+					spec = openAIChatAttempt(t, test.channel, baseURL, "native-key")
+				}
+				spec.ClientModel = spec.UpstreamModel
+				spec.Body = requestBody
+				if stream {
+					var events []execution.StreamEvent
+					result := runtime.ExecuteStream(t.Context(), spec, func(event execution.StreamEvent) error {
+						events = append(events, event.Clone())
+						return nil
+					})
+					assertRawStream(t, result, events, responseStream, usage.Tokens{UncachedInput: 100, CacheRead: 900, Output: 3})
+				} else {
+					result := runtime.Execute(t.Context(), spec)
+					if result.Error != nil || result.StatusCode != http.StatusOK || result.UpstreamProtocol != test.protocol {
+						t.Fatalf("native result = %+v", result)
+					}
+					if !bytes.Equal(result.Body, []byte(responseBody)) {
+						t.Errorf("native response changed: %s", result.Body)
+					}
+					assertUsage(t, result.Usage, usage.Tokens{UncachedInput: 100, CacheRead: 900, Output: 3})
+				}
+				if calls.Load() != 1 {
+					t.Errorf("upstream calls = %d, want 1", calls.Load())
+				}
+			})
+		}
+	}
+}
+
+func nativeFidelityObject(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	var result map[string]any
+	if err := decoder.Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func nativeFidelityFixture(clientProtocol protocol.Protocol) (string, string, string) {
+	switch clientProtocol {
+	case protocol.Anthropic:
+		return `{"model":"client-model","provider":"must-strip","max_tokens":8192,"system":[{"type":"text","text":"stable\ninstruction","cache_control":{"type":"ephemeral"}}],"thinking":{"type":"adaptive"},"output_config":{"effort":"high"},"tools":[{"name":"lookup","input_schema":{"type":"object","properties":{"q":{"type":"string"}}},"vendor_tool":{"precise":1.2300}}],"messages":[{"role":"user","content":"start"},{"role":"assistant","content":[{"type":"thinking","thinking":"reasoning history","signature":""},{"type":"tool_use","id":"call_1","name":"lookup","input":{"q":"one","n":9007199254740993}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_1","content":"result"}]},{"role":"system","content":[{"type":"text","text":"new instruction"}]},{"role":"assistant","content":[{"type":"text","text":"continued","vendor_block":true}]},{"role":"user","content":"next"}],"vendor_extension":{"precise":1.2300}}`,
+			`{"id":"msg_native","type":"message","role":"assistant","model":"upstream-model","content":[{"type":"text","text":"ok","vendor":true}],"stop_reason":"end_turn","usage":{"input_tokens":100,"cache_read_input_tokens":900,"output_tokens":3},"vendor_response":true}`,
+			"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_native\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"upstream-model\",\"content\":[],\"usage\":{\"input_tokens\":100,\"cache_read_input_tokens\":900,\"output_tokens\":0}}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"ok\"},\"vendor\":true}\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":3}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+	case protocol.OpenAIResponses:
+		return `{"model":"client-model","provider":"must-strip","instructions":"stable\ninstruction","input":[{"role":"user","content":[{"type":"input_text","text":"start","vendor_block":true}]},{"type":"function_call","id":"fc_1","call_id":"call_1","name":"lookup","arguments":"{\"n\":9007199254740993}"},{"type":"function_call_output","call_id":"call_1","output":"result"},{"role":"system","content":"new instruction"},{"role":"user","content":"next"}],"reasoning":{"effort":"high"},"vendor_extension":{"precise":1.2300}}`,
+			`{"id":"resp_native","object":"response","status":"completed","model":"upstream-model","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":1000,"input_tokens_details":{"cached_tokens":900},"output_tokens":3,"total_tokens":1003},"vendor_response":true}`,
+			"event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\",\"vendor\":true}\n\nevent: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_native\",\"object\":\"response\",\"status\":\"completed\",\"model\":\"upstream-model\",\"output\":[],\"usage\":{\"input_tokens\":1000,\"input_tokens_details\":{\"cached_tokens\":900},\"output_tokens\":3,\"total_tokens\":1003}}}\n\n"
+	default:
+		return `{"model":"client-model","provider":"must-strip","messages":[{"role":"system","content":"stable\ninstruction"},{"role":"user","content":"start"},{"role":"assistant","content":null,"reasoning_content":"reasoning history","tool_calls":[{"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{\"n\":9007199254740993}"}}],"vendor_message":true},{"role":"tool","tool_call_id":"call_1","content":"result"},{"role":"system","content":"new instruction"},{"role":"user","content":"next"}],"tools":[{"type":"function","function":{"name":"lookup","parameters":{"type":"object"}},"vendor_tool":true}],"tool_choice":"required","thinking":{"type":"enabled"},"reasoning_effort":"high","vendor_extension":{"precise":1.2300}}`,
+			`{"id":"chat_native","object":"chat.completion","model":"upstream-model","choices":[{"index":0,"message":{"role":"assistant","content":"ok","vendor":true},"finish_reason":"stop"}],"usage":{"prompt_tokens":1000,"prompt_tokens_details":{"cached_tokens":900},"completion_tokens":3,"total_tokens":1003},"vendor_response":true}`,
+			"data: {\"id\":\"chat_native\",\"object\":\"chat.completion.chunk\",\"model\":\"upstream-model\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"ok\",\"vendor\":true},\"finish_reason\":null}]}\n\ndata: {\"id\":\"chat_native\",\"object\":\"chat.completion.chunk\",\"model\":\"upstream-model\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1000,\"prompt_tokens_details\":{\"cached_tokens\":900},\"completion_tokens\":3,\"total_tokens\":1003}}\n\ndata: [DONE]\n\n"
+	}
+}

--- a/internal/execution/bifrost/native_fidelity_test.go
+++ b/internal/execution/bifrost/native_fidelity_test.go
@@ -137,6 +137,64 @@ func nativeFidelityObject(t *testing.T, body []byte) map[string]any {
 	return result
 }
 
+func TestNativeDeepSeekAnthropicReplayKeepsExistingPrefix(t *testing.T) {
+	t.Parallel()
+	wireBodies := make(chan []byte, 2)
+	const response = `{"id":"msg_replay","type":"message","role":"assistant","model":"upstream-model","content":[{"type":"thinking","thinking":"replay reasoning","signature":"synthetic-native-signature"},{"type":"tool_use","id":"call_replay","name":"lookup","input":{"n":9007199254740993}}],"stop_reason":"tool_use","usage":{"input_tokens":4,"output_tokens":2}}`
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		body, _ := io.ReadAll(request.Body)
+		wireBodies <- body
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(writer, response)
+	}))
+	defer server.Close()
+	runtime := newRuntimeForTest(t, testRuntimeOptions{allowPrivateNetwork: true})
+	spec := deepSeekAnthropicAttempt(t, server.URL)
+	initial, _, _ := nativeFidelityFixture(protocol.Anthropic)
+	spec.Body = []byte(initial)
+	first := runtime.Execute(t.Context(), spec)
+	if first.Error != nil {
+		t.Fatalf("first request: %+v", first.Error)
+	}
+	var returned struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(first.Body, &returned); err != nil {
+		t.Fatal(err)
+	}
+	root := nativeFidelityObject(t, spec.Body)
+	history := root["messages"].([]any)
+	assistant := map[string]any{"role": returned.Role, "content": returned.Content}
+	root["messages"] = append(history, assistant,
+		map[string]any{"role": "user", "content": json.RawMessage(`[{"type":"tool_result","tool_use_id":"call_replay","content":"result"},{"type":"image","source":{"type":"base64","media_type":"image/png","data":"aW1hZ2U="}}]`)},
+		map[string]any{"role": "system", "content": "new round instruction"},
+		map[string]any{"role": "user", "content": "continue"})
+	var err error
+	spec.Body, err = json.Marshal(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second := runtime.Execute(t.Context(), spec)
+	if second.Error != nil {
+		t.Fatalf("replayed request: %+v", second.Error)
+	}
+	before, after := nativeFidelityObject(t, <-wireBodies), nativeFidelityObject(t, <-wireBodies)
+	oldMessages, newMessages := before["messages"].([]any), after["messages"].([]any)
+	if !reflect.DeepEqual(oldMessages, newMessages[:len(oldMessages)]) {
+		t.Fatal("appending tool results and system instructions changed the existing message prefix")
+	}
+	expected := nativeFidelityObject(t, spec.Body)
+	if !reflect.DeepEqual(after["messages"], expected["messages"]) {
+		t.Fatal("response replay changed thinking, signature, tool arguments, media or associations")
+	}
+	for _, field := range []string{"system", "tools", "thinking", "output_config"} {
+		if !reflect.DeepEqual(before[field], after[field]) {
+			t.Errorf("appending a round changed %s", field)
+		}
+	}
+}
+
 func nativeFidelityFixture(clientProtocol protocol.Protocol) (string, string, string) {
 	switch clientProtocol {
 	case protocol.Anthropic:

--- a/internal/execution/bifrost/passthrough.go
+++ b/internal/execution/bifrost/passthrough.go
@@ -27,6 +27,24 @@ type passthroughStreamSDKResult struct {
 	err    *schemas.BifrostError
 }
 
+// nativeMessageProvider 为缺少透传接口的渠道复用相同 wire 协议，保留原有渠道身份。
+func nativeMessageProvider(providerKind channel.ProviderKind, spec execution.AttemptSpec) (schemas.ModelProvider, bool) {
+	if spec.RouteMode != execution.RouteNative ||
+		(spec.Operation != execution.OperationChatCompletion && spec.Operation != execution.OperationResponsesCreate) {
+		return "", false
+	}
+	switch providerKind {
+	case channel.ProviderDeepSeek, channel.ProviderOpenRouter, channel.ProviderGroq, channel.ProviderXAI:
+		if spec.ClientProtocol == protocol.OpenAICompletions || spec.ClientProtocol == protocol.OpenAIResponses {
+			return schemas.OpenAI, true
+		}
+		if providerKind == channel.ProviderDeepSeek && spec.ClientProtocol == protocol.Anthropic {
+			return schemas.Anthropic, true
+		}
+	}
+	return "", false
+}
+
 func sanitizeNativeChatBody(body []byte, upstreamModel string, stream ...bool) ([]byte, error) {
 	object, err := decodeNativeJSONObject(body)
 	if err != nil {

--- a/internal/execution/bifrost/runtime_manager.go
+++ b/internal/execution/bifrost/runtime_manager.go
@@ -112,12 +112,21 @@ func buildEffectiveProviderConfigForAttempt(
 	if err != nil {
 		return base, err
 	}
+	if nativeProvider, ok := nativeMessageProvider(resolved.ProviderKind, spec); ok {
+		provider := customProviderKey(nativeProvider, base.targetBaseURL)
+		config := buildProviderConfig(provider, base.targetBaseURL, true, nativeProvider, allowPrivateNetwork)
+		base, err = newEffectiveProviderConfig(provider, base.targetBaseURL, true, config)
+		if err != nil {
+			return effectiveProviderConfig{}, err
+		}
+		return applyAttemptProxy(base, spec.Proxy)
+	}
 	if !resolved.ProviderKind.SupportsOutboundProxy() {
 		return base, nil
 	}
 	if resolved.ProviderKind != channel.ProviderDeepSeek ||
 		spec.ClientProtocol != protocol.OpenAIResponses ||
-		(spec.Operation != execution.OperationResponsesCreate && spec.Operation != execution.OperationProbe) ||
+		spec.Operation != execution.OperationProbe ||
 		channel.RouteMode(spec.RouteMode) != channel.RouteNative {
 		return applyAttemptProxy(base, spec.Proxy)
 	}
@@ -223,7 +232,7 @@ func applyAttemptProxy(
 	return partitioned, nil
 }
 
-func buildDeepSeekResponsesConfig(
+func buildDeepSeekResponsesProbeConfig(
 	resolved channel.ResolvedTarget,
 	allowPrivateNetwork bool,
 ) (effectiveProviderConfig, error) {
@@ -231,7 +240,7 @@ func buildDeepSeekResponsesConfig(
 		resolved,
 		execution.AttemptSpec{
 			ClientProtocol: protocol.OpenAIResponses,
-			Operation:      execution.OperationResponsesCreate,
+			Operation:      execution.OperationProbe,
 			RouteMode:      execution.RouteNative,
 		},
 		allowPrivateNetwork,
@@ -774,10 +783,34 @@ func (manager *RuntimeManager) Reconcile(targets []provideradapter.RuntimeTarget
 			return fmt.Errorf("reconcile provider runtime %q proxy: %w", target.ChannelID, effectiveErr)
 		}
 		configs = append(configs, effectiveConfig)
+		for _, route := range []struct {
+			protocol  protocol.Protocol
+			operation execution.Operation
+		}{
+			{protocol.OpenAICompletions, execution.OperationChatCompletion},
+			{protocol.OpenAIResponses, execution.OperationResponsesCreate},
+			{protocol.Anthropic, execution.OperationChatCompletion},
+		} {
+			spec := execution.AttemptSpec{ClientProtocol: route.protocol, Operation: route.operation, RouteMode: execution.RouteNative}
+			if _, ok := nativeMessageProvider(target.ProviderKind, spec); !ok {
+				continue
+			}
+			if mode, ok := target.Mode(route.protocol, route.operation); !ok || mode != channel.RouteNative {
+				continue
+			}
+			for _, proxy := range []outboundproxy.Effective{{}, runtimeTarget.Proxy} {
+				spec.Proxy = proxy
+				nativeConfig, err := buildEffectiveProviderConfigForAttempt(target, spec, manager.options.allowPrivateNetwork)
+				if err != nil {
+					return fmt.Errorf("reconcile provider runtime %q native %q: %w", target.ChannelID, route.protocol, err)
+				}
+				configs = append(configs, nativeConfig)
+			}
+		}
 		if target.ProviderKind == channel.ProviderDeepSeek {
 			responsesMode, ok := target.Mode(protocol.OpenAIResponses, execution.OperationResponsesCreate)
 			if ok && responsesMode == channel.RouteNative {
-				responsesConfig, responsesErr := buildDeepSeekResponsesConfig(target, manager.options.allowPrivateNetwork)
+				responsesConfig, responsesErr := buildDeepSeekResponsesProbeConfig(target, manager.options.allowPrivateNetwork)
 				if responsesErr != nil {
 					return fmt.Errorf("reconcile provider runtime %q Responses: %w", target.ChannelID, responsesErr)
 				}
@@ -786,7 +819,7 @@ func (manager *RuntimeManager) Reconcile(targets []provideradapter.RuntimeTarget
 					target,
 					execution.AttemptSpec{
 						ClientProtocol: protocol.OpenAIResponses,
-						Operation:      execution.OperationResponsesCreate,
+						Operation:      execution.OperationProbe,
 						RouteMode:      execution.RouteNative,
 						Proxy:          runtimeTarget.Proxy,
 					},

--- a/internal/execution/bifrost/runtime_manager_test.go
+++ b/internal/execution/bifrost/runtime_manager_test.go
@@ -198,7 +198,7 @@ func TestEffectiveProviderConfigUsesSDKProviderAndCanonicalDefaultBaseURL(t *tes
 	}
 }
 
-func TestDeepSeekResponsesUsesDedicatedOpenAIRuntimeConfig(t *testing.T) {
+func TestDeepSeekResponsesProbeUsesDedicatedOpenAIRuntimeConfig(t *testing.T) {
 	registry := channel.NewRegistry()
 	resolved, err := registry.Resolve(channel.DeepSeek, json.RawMessage(`{"base_url":"https://deepseek.example/api"}`))
 	if err != nil {
@@ -208,7 +208,7 @@ func TestDeepSeekResponsesUsesDedicatedOpenAIRuntimeConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	responses, err := buildDeepSeekResponsesConfig(resolved, true)
+	responses, err := buildDeepSeekResponsesProbeConfig(resolved, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -550,6 +550,62 @@ func TestRuntimeManagerReconcilesGroupEffectiveProxy(t *testing.T) {
 		t.Fatalf("effective proxy runtime is not active: found=%t", exists)
 	}
 	<-manager.BeginShutdown()
+}
+
+func TestNativeMessageRuntimesStayReusableAfterReconcile(t *testing.T) {
+	t.Parallel()
+	registry := channel.NewRegistry()
+	for _, channelID := range []channel.ID{channel.DeepSeek, channel.OpenRouter, channel.Groq, channel.XAI} {
+		t.Run(string(channelID), func(t *testing.T) {
+			resolved, err := registry.Resolve(channelID, json.RawMessage(`{"base_url":"https://upstream.example/tenant"}`))
+			if err != nil {
+				t.Fatal(err)
+			}
+			manager, err := newRuntimeManager(runtimeOptions{}, registry)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(manager.Shutdown)
+			manager.pool = newRuntimeManagerPool(func(context.Context, effectiveProviderConfig) (managedProviderRuntime, error) {
+				return newFakeManagedRuntime(), nil
+			})
+			proxy := outboundproxy.Effective{
+				Config: outboundproxy.Config{Mode: outboundproxy.ModeCustom, URL: "http://proxy.example:8080"},
+				Source: outboundproxy.SourceGroup,
+			}
+			for _, clientProtocol := range []protocol.Protocol{protocol.OpenAICompletions, protocol.OpenAIResponses, protocol.Anthropic} {
+				operation := execution.OperationChatCompletion
+				if clientProtocol == protocol.OpenAIResponses {
+					operation = execution.OperationResponsesCreate
+				}
+				if mode, exists := resolved.Mode(clientProtocol, operation); !exists || mode != channel.RouteNative {
+					continue
+				}
+				spec := execution.AttemptSpec{ClientProtocol: clientProtocol, Operation: operation, RouteMode: execution.RouteNative, Proxy: proxy}
+				config, err := buildEffectiveProviderConfigForAttempt(resolved, spec, false)
+				if err != nil {
+					t.Fatal(err)
+				}
+				lease, err := manager.pool.acquire(t.Context(), config)
+				if err != nil {
+					t.Fatal(err)
+				}
+				original := lease.runtime.(*fakeManagedRuntime)
+				lease.Release()
+				if err := manager.Reconcile([]provideradapter.RuntimeTarget{{Target: resolved, Proxy: proxy}}); err != nil {
+					t.Fatal(err)
+				}
+				next, err := manager.pool.acquire(t.Context(), config)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if next.runtime != original || original.shutdowns.Load() != 0 {
+					t.Errorf("active %s runtime was retired by snapshot reconciliation", clientProtocol)
+				}
+				next.Release()
+			}
+		})
+	}
 }
 
 func TestRuntimeManagerPartitionsCredentialProxyByCredential(t *testing.T) {

--- a/internal/execution/bifrost/zero_output_test.go
+++ b/internal/execution/bifrost/zero_output_test.go
@@ -17,7 +17,7 @@ import (
 func TestRuntimeRejectsAnthropicZeroOutputBeforeTypedConversion(t *testing.T) {
 	t.Parallel()
 
-	for _, channelID := range []channel.ID{channel.Gemini, channel.OpenAI, channel.OpenAICompatible, channel.DeepSeek} {
+	for _, channelID := range []channel.ID{channel.Gemini, channel.OpenAI, channel.OpenAICompatible} {
 		for _, stream := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s/stream=%t", channelID, stream), func(t *testing.T) {
 				var calls atomic.Int64
@@ -70,7 +70,7 @@ func TestNativeAnthropicZeroOutputPreservesLimitAndResponse(t *testing.T) {
 	t.Parallel()
 
 	const responseBody = `{"id":"msg_1","type":"message","role":"assistant","model":"upstream-model","content":[],"stop_reason":"max_tokens","stop_sequence":null,"usage":{"input_tokens":4,"output_tokens":0}}`
-	for _, channelID := range []channel.ID{channel.Anthropic, channel.NewAPI} {
+	for _, channelID := range []channel.ID{channel.Anthropic, channel.NewAPI, channel.DeepSeek} {
 		t.Run(string(channelID), func(t *testing.T) {
 			var calls atomic.Int64
 			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -79,7 +79,11 @@ func TestNativeAnthropicZeroOutputPreservesLimitAndResponse(t *testing.T) {
 				if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
 					t.Error(err)
 				}
-				if string(body["max_tokens"]) != "0" || request.URL.Path != "/v1/messages" {
+				wantPath := "/v1/messages"
+				if channelID == channel.DeepSeek {
+					wantPath = "/anthropic/v1/messages"
+				}
+				if string(body["max_tokens"]) != "0" || request.URL.Path != wantPath {
 					t.Errorf("native path/limit = %s/%s", request.URL.Path, body["max_tokens"])
 				}
 				writer.Header().Set("Content-Type", "application/json")
@@ -88,6 +92,7 @@ func TestNativeAnthropicZeroOutputPreservesLimitAndResponse(t *testing.T) {
 			defer server.Close()
 			runtime := newProtocolTestRuntime(t, testRuntimeOptions{allowPrivateNetwork: true, anthropicBaseURL: server.URL})
 			runtime.baseURLs[channel.NewAPI] = server.URL
+			runtime.baseURLs[channel.DeepSeek] = server.URL
 			spec := convertedSpec(channelID, protocol.Anthropic, execution.OperationChatCompletion,
 				"/v1/messages", []byte(`{"model":"client-model","max_tokens":0,"messages":[{"role":"user","content":"hello"}]}`))
 			spec.ClientModel = spec.UpstreamModel

--- a/internal/execution/cpa/adapter.go
+++ b/internal/execution/cpa/adapter.go
@@ -111,6 +111,9 @@ func (a *Adapter) Execute(ctx context.Context, spec execution.AttemptSpec) (resu
 	if err != nil {
 		return unaryNotSent(execution.ErrorKindInvalidRequest, "unsupported subscription request", "", err)
 	}
+	if evidence := convertedInstructionFailure(spec, provider.ProviderKind()); evidence != nil {
+		return execution.AttemptResult{DispatchState: execution.DispatchNotSent, Error: evidence}
+	}
 	proxySettings, err := proxySettingsForAttempt(spec.Proxy)
 	if err != nil {
 		return unaryNotSent(
@@ -279,6 +282,9 @@ func (a *Adapter) ExecuteStream(
 	}
 	if countTokensOperation(spec.Operation) {
 		return streamNotSent(execution.ErrorKindInvalidRequest, "count tokens does not support streaming", "")
+	}
+	if evidence := convertedInstructionFailure(spec, provider.ProviderKind()); evidence != nil {
+		return execution.StreamResult{DispatchState: execution.DispatchNotSent, Error: evidence}
 	}
 	proxySettings, err := proxySettingsForAttempt(spec.Proxy)
 	if err != nil {

--- a/internal/execution/cpa/conversion_fidelity.go
+++ b/internal/execution/cpa/conversion_fidelity.go
@@ -1,0 +1,29 @@
+package cpa
+
+import (
+	"gpt-load/internal/channel"
+	"gpt-load/internal/dialect"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+)
+
+func convertedInstructionFailure(spec execution.AttemptSpec, providerKind channel.ProviderKind) *execution.ErrorEvidence {
+	if spec.RouteMode != execution.RouteConverted ||
+		(spec.Operation != execution.OperationChatCompletion && spec.Operation != execution.OperationResponsesCreate) ||
+		dialect.CountMidConversationSystemMessages(spec.ClientProtocol, spec.Body) == 0 {
+		return nil
+	}
+	lossy := false
+	switch providerKind {
+	case channel.ProviderClaude, channel.ProviderAntigravity:
+		lossy = true
+	case channel.ProviderCodex, channel.ProviderGrok:
+		// CPA 的 Claude 转换器把中途 system 包成 user；OpenAI 输入能原位映射为 developer。
+		lossy = spec.ClientProtocol == protocol.Anthropic
+	}
+	if !lossy {
+		return nil
+	}
+	return notSentEvidence(execution.ErrorKindConversionUnsupported,
+		"conversion cannot preserve mid-conversation system instructions", execution.ErrorCodeCriticalSemanticLoss)
+}

--- a/internal/execution/cpa/conversion_fidelity_test.go
+++ b/internal/execution/cpa/conversion_fidelity_test.go
@@ -1,0 +1,78 @@
+package cpa
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/execution"
+	"gpt-load/internal/protocol"
+)
+
+func TestAdapterRejectsOnlyLossyMidConversationInstructions(t *testing.T) {
+	t.Parallel()
+	for _, channelID := range []channel.ID{channel.Codex, channel.Grok, channel.Claude, channel.Antigravity} {
+		for _, clientProtocol := range []protocol.Protocol{protocol.OpenAICompletions, protocol.OpenAIResponses, protocol.Anthropic} {
+			for _, role := range []string{"system", "user"} {
+				for _, stream := range []bool{false, true} {
+					t.Run(fmt.Sprintf("%s/%s/%s/stream=%t", channelID, clientProtocol, role, stream), func(t *testing.T) {
+						registry := channel.NewRegistry()
+						target, err := registry.Resolve(channelID, nil)
+						if err != nil {
+							t.Fatal(err)
+						}
+						operation, path, field := execution.OperationChatCompletion, "/v1/chat/completions", "messages"
+						if clientProtocol == protocol.OpenAIResponses {
+							operation, path, field = execution.OperationResponsesCreate, "/v1/responses", "input"
+						} else if clientProtocol == protocol.Anthropic {
+							path = "/v1/messages"
+						}
+						mode, exists := target.Mode(clientProtocol, operation)
+						if !exists {
+							t.Fatal("expected subscription route is missing")
+						}
+						body, err := json.Marshal(map[string]any{"model": "client-model", "max_tokens": 32, field: []map[string]any{
+							{"role": "user", "content": "start"},
+							{"role": "assistant", "content": "reply"},
+							{"role": role, "content": "<system-reminder>new instruction</system-reminder>"},
+							{"role": "user", "content": "next"},
+						}})
+						if err != nil {
+							t.Fatal(err)
+						}
+						preparer := &fakeCredentialPreparer{evidence: &execution.ErrorEvidence{
+							Kind: execution.ErrorKindInternal, Code: "after_request_validation", Summary: "test boundary reached",
+						}}
+						adapter := NewAdapter(nil, registry)
+						adapter.credentials = preparer
+						spec := execution.NewAttemptSpec(execution.AttemptSpec{
+							RequestID: "fidelity-request", AttemptID: "fidelity-attempt", Sequence: 1,
+							ChannelID: string(channelID), TargetConfig: target.TargetConfig, RouteMode: mode,
+							ClientProtocol: clientProtocol, Operation: operation, Method: http.MethodPost, Path: path,
+							ClientModel: "client-model", UpstreamModel: "upstream-model", Body: body,
+							Credential: execution.NewCredentialSnapshot(1, 1, 1, []byte(`{}`)),
+						})
+						var evidence *execution.ErrorEvidence
+						if stream {
+							evidence = adapter.ExecuteStream(t.Context(), spec, func(execution.StreamEvent) error { return nil }).Error
+						} else {
+							evidence = adapter.Execute(t.Context(), spec).Error
+						}
+						wantRejected := role == "system" && mode == execution.RouteConverted &&
+							(channelID == channel.Claude || channelID == channel.Antigravity || clientProtocol == protocol.Anthropic)
+						if wantRejected {
+							if preparer.calls != 0 || evidence == nil || evidence.Kind != execution.ErrorKindConversionUnsupported ||
+								evidence.Code != execution.ErrorCodeCriticalSemanticLoss {
+								t.Fatalf("lossy conversion reached credentials: calls=%d error=%+v", preparer.calls, evidence)
+							}
+						} else if preparer.calls != 1 || evidence == nil || evidence.Code != "after_request_validation" {
+							t.Fatalf("preservable input was rejected: calls=%d error=%+v", preparer.calls, evidence)
+						}
+					})
+				}
+			}
+		}
+	}
+}

--- a/internal/execution/cpa/conversion_fidelity_test.go
+++ b/internal/execution/cpa/conversion_fidelity_test.go
@@ -15,7 +15,10 @@ func TestAdapterRejectsOnlyLossyMidConversationInstructions(t *testing.T) {
 	t.Parallel()
 	for _, channelID := range []channel.ID{channel.Codex, channel.Grok, channel.Claude, channel.Antigravity} {
 		for _, clientProtocol := range []protocol.Protocol{protocol.OpenAICompletions, protocol.OpenAIResponses, protocol.Anthropic} {
-			for _, role := range []string{"system", "user"} {
+			for _, role := range []string{"system", "developer", "user"} {
+				if role == "developer" && clientProtocol == protocol.Anthropic {
+					continue
+				}
 				for _, stream := range []bool{false, true} {
 					t.Run(fmt.Sprintf("%s/%s/%s/stream=%t", channelID, clientProtocol, role, stream), func(t *testing.T) {
 						registry := channel.NewRegistry()
@@ -33,12 +36,19 @@ func TestAdapterRejectsOnlyLossyMidConversationInstructions(t *testing.T) {
 						if !exists {
 							t.Fatal("expected subscription route is missing")
 						}
-						body, err := json.Marshal(map[string]any{"model": "client-model", "max_tokens": 32, field: []map[string]any{
+						messages := []map[string]any{
 							{"role": "user", "content": "start"},
 							{"role": "assistant", "content": "reply"},
 							{"role": role, "content": "<system-reminder>new instruction</system-reminder>"},
 							{"role": "user", "content": "next"},
-						}})
+						}
+						if clientProtocol == protocol.OpenAIResponses {
+							messages = append([]map[string]any{{
+								"type": "web_search_call", "id": "ws_history", "status": "completed",
+								"action": map[string]any{"type": "search", "query": "synthetic"},
+							}}, messages[2:]...)
+						}
+						body, err := json.Marshal(map[string]any{"model": "client-model", "max_tokens": 32, field: messages})
 						if err != nil {
 							t.Fatal(err)
 						}
@@ -60,7 +70,7 @@ func TestAdapterRejectsOnlyLossyMidConversationInstructions(t *testing.T) {
 						} else {
 							evidence = adapter.Execute(t.Context(), spec).Error
 						}
-						wantRejected := role == "system" && mode == execution.RouteConverted &&
+						wantRejected := role != "user" && mode == execution.RouteConverted &&
 							(channelID == channel.Claude || channelID == channel.Antigravity || clientProtocol == protocol.Anthropic)
 						if wantRejected {
 							if preparer.calls != 0 || evidence == nil || evidence.Kind != execution.ErrorKindConversionUnsupported ||


### PR DESCRIPTION
### 关联 Issue / Related Issue
暂无关联 Issue。

### 变更内容 / Change Content
- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

部分同协议消息请求仍经过 SDK 结构化重建，导致 DeepSeek 等路径的历史消息、思考或扩展字段被改写，破坏可复用前缀。本次补齐原生转发，并保护必要转换中的关键语义。

- DeepSeek、OpenRouter、Groq、xAI 的既有 native 消息及非 `/v1` 兼容前缀复用现有透传链路，保留真实地址、鉴权、代理、模型映射和 Runtime 复用。
- 转换时保留并存的全局 `instructions` / `system` 和工具 `auto` 的含义；按 Responses 输入项的顺序识别无角色历史，保护其后的 system/developer；对中途系统指令降级、工具约束丢失及显式思考被关闭等已确认有损输入，在发送前拒绝当前目标。普通 user 文本中的 `<system-reminder>` 保持放行。
- 增加实际出站内容、流式/非流式、多轮工具与思考回放、云平台分支和发送前拒绝的回归测试；补充无角色历史后的 system/developer 及普通 user、开头全局指令的正反用例。
- 非 `/v1` 兼容地址的上游模型发现使用原生响应；管理面继续解析、规范化模型 ID，公开 `/v1/models` 仍由网关依据可见模型生成。

兼容性：有损转换按现有机制跳过 Group，不改变凭据健康；候选均无法转换时返回现有 422 `protocol_conversion_unsupported`。不新增配置或数据库迁移，不升级 SDK。Anthropic 流式 usage 修复已在 #630 独立合并，当前分支已同步。

验证：
- `make check`（含 `go test -count=1 . ./internal/...`）。
- CPA embedded：在 `third_party/cpaembedded` 执行 `go test -count=1 ./embedded`，已通过。
- 维护者本地实测：DeepSeek 的 Anthropic Messages、OpenAI Chat、OpenAI Responses 三种协议缓存率均在 90% 以上；其他真实上游未逐一联调。

设计和核查记录按本次约定仅保存在本地 `docs/`，未提交公开文档或发布说明。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [ ] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.
