### PR TITLE
fix(codex): 补齐 WebSocket 额度观测并约束来源匹配

### DIFF
--- a/internal/execution/cpa/adapter.go
+++ b/internal/execution/cpa/adapter.go
@@ -49,6 +49,7 @@ type Adapter struct {
 type credentialPreparer interface {
 	Prepare(context.Context, channel.ID, execution.CredentialSnapshot, bool) (subscriptionruntime.Credential, *execution.ErrorEvidence)
 	RecordPassiveQuotaObservation(credentialID uint, identityGeneration uint64, observedAtMS int64, windows []providerobservation.QuotaWindow)
+	RecordPassiveQuotaPair(credentialID uint, identityGeneration uint64, preceding, latest subscription.PassiveQuotaSample)
 }
 
 // recordPassiveQuotaObservation forwards one execution's passive quota

--- a/internal/execution/cpa/adapter_test.go
+++ b/internal/execution/cpa/adapter_test.go
@@ -87,6 +87,12 @@ func (f *fakeCredentialPreparer) RecordPassiveQuotaObservation(
 	}
 }
 
+func (f *fakeCredentialPreparer) RecordPassiveQuotaPair(credentialID uint, identityGeneration uint64, preceding, latest subscription.PassiveQuotaSample) {
+	if f.delegate != nil {
+		f.delegate.RecordPassiveQuotaPair(credentialID, identityGeneration, preceding, latest)
+	}
+}
+
 type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (fn roundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) {

--- a/internal/execution/cpa/websocket.go
+++ b/internal/execution/cpa/websocket.go
@@ -13,12 +13,13 @@ import (
 	"gpt-load/internal/execution"
 	"gpt-load/internal/execution/wsnative"
 	"gpt-load/internal/protocol"
+	"gpt-load/internal/subscription"
 	"gpt-load/internal/subscription/providers/codex"
 	subscriptionruntime "gpt-load/internal/subscription/runtime"
 )
 
 type websocketProvider interface {
-	openWebsocket(execution.AttemptSpec, providerCredential, string, string) (execution.WebsocketSession, error)
+	openWebsocket(execution.AttemptSpec, providerCredential, string, string, func(http.Header, time.Time)) (execution.WebsocketSession, error)
 }
 
 // OpenWebsocket 使用既有凭据刷新和网络准备，Session 仍由单个下游连接拥有。
@@ -74,42 +75,54 @@ func (a *Adapter) OpenWebsocket(ctx context.Context, spec execution.AttemptSpec)
 	if err != nil {
 		return reject()
 	}
-	s, err := opener.openWebsocket(spec, credential, baseURL, settings.URL)
+	observationSpec := execution.AttemptSpec{Credential: execution.NewCredentialSnapshot(spec.Credential.ID, spec.Credential.Version, spec.Credential.IdentityGeneration, nil)}
+	observed := &observedWebsocketSession{adapter: a, spec: observationSpec}
+	s, err := opener.openWebsocket(spec, credential, baseURL, settings.URL, observed.observeHeaders)
 	if err != nil {
 		result.Error = codexWebsocketEvidence(ctx, err)
 		return nil, result
 	}
-	observationSpec := execution.AttemptSpec{Credential: execution.NewCredentialSnapshot(spec.Credential.ID, spec.Credential.Version, spec.Credential.IdentityGeneration, nil)}
-	return &observedWebsocketSession{WebsocketSession: s, adapter: a, spec: observationSpec}, result
+	observed.WebsocketSession = s
+	return observed, result
 }
 
 type observedWebsocketSession struct {
 	execution.WebsocketSession
-	adapter *Adapter
-	spec    execution.AttemptSpec
+	adapter   *Adapter
+	spec      execution.AttemptSpec
+	handshake subscription.PassiveQuotaSample
 }
 
 func (s *observedWebsocketSession) ExecuteTurn(ctx context.Context, payload []byte, emit func(context.Context, []byte) error) execution.WebsocketResult {
-	result := s.WebsocketSession.ExecuteTurn(ctx, payload, func(ctx context.Context, event []byte) error {
+	return s.WebsocketSession.ExecuteTurn(ctx, payload, func(ctx context.Context, event []byte) error {
 		observedAt := time.Now()
-		s.adapter.recordPassiveQuotaObservation(s.spec, observedAt, codex.NormalizeWebsocketQuotaWindows(event, observedAt))
+		windows := codex.NormalizeWebsocketQuotaWindows(event, observedAt)
+		if len(windows) > 0 {
+			s.adapter.credentials.RecordPassiveQuotaPair(s.spec.Credential.ID, s.spec.Credential.IdentityGeneration,
+				s.handshake, subscription.PassiveQuotaSample{ObservedAtMS: observedAt.UnixMilli(), Windows: windows})
+		}
 		if emit != nil {
 			return emit(ctx, event)
 		}
 		return nil
 	})
-	if len(result.Header) > 0 && !result.HeaderObservedAt.IsZero() {
-		signals := make(map[string]string)
-		for name, values := range result.Header {
-			signals[name] = strings.Join(values, ",")
-		}
-		now := result.HeaderObservedAt
-		s.adapter.recordPassiveQuotaObservation(s.spec, now, codex.NormalizePassiveQuotaWindows(signals, now))
-	}
-	return result
 }
 
-func (*codexProviderBridge) openWebsocket(spec execution.AttemptSpec, credential providerCredential, baseURL, proxyURL string) (execution.WebsocketSession, error) {
+// observeHeaders 保留响应头的原始额度样本；握手在交付本连接的事件之前记录。
+func (s *observedWebsocketSession) observeHeaders(headers http.Header, observedAt time.Time) {
+	if len(headers) == 0 || observedAt.IsZero() {
+		return
+	}
+	signals := make(map[string]string, len(headers))
+	for name, values := range headers {
+		signals[name] = strings.Join(values, ",")
+	}
+	windows := codex.NormalizePassiveQuotaWindows(signals, observedAt)
+	s.handshake = subscription.PassiveQuotaSample{ObservedAtMS: observedAt.UnixMilli(), Windows: windows}
+	s.adapter.recordPassiveQuotaObservation(s.spec, observedAt, windows)
+}
+
+func (*codexProviderBridge) openWebsocket(spec execution.AttemptSpec, credential providerCredential, baseURL, proxyURL string, observeHeaders func(http.Header, time.Time)) (execution.WebsocketSession, error) {
 	value, ok := credential.(codexProviderCredential)
 	if !ok {
 		return nil, errors.New("invalid websocket credential")
@@ -118,6 +131,7 @@ func (*codexProviderBridge) openWebsocket(spec execution.AttemptSpec, credential
 		CredentialID: strconv.FormatUint(uint64(spec.Credential.ID), 10), Credential: value.value,
 		BaseURL: baseURL, ProxyURL: proxyURL, TurnTimeout: spec.Timeouts.Request,
 		Headers:         spec.Header.Clone(),
+		ObserveHeaders:  observeHeaders,
 		MaxRequestBytes: wsnative.MaxMessageBytes, MaxEventBytes: wsnative.MaxMessageBytes,
 	})
 	if err != nil {

--- a/internal/execution/cpa/websocket.go
+++ b/internal/execution/cpa/websocket.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"gpt-load/internal/channel"
 	"gpt-load/internal/execution"
@@ -89,7 +90,14 @@ type observedWebsocketSession struct {
 }
 
 func (s *observedWebsocketSession) ExecuteTurn(ctx context.Context, payload []byte, emit func(context.Context, []byte) error) execution.WebsocketResult {
-	result := s.WebsocketSession.ExecuteTurn(ctx, payload, emit)
+	result := s.WebsocketSession.ExecuteTurn(ctx, payload, func(ctx context.Context, event []byte) error {
+		observedAt := time.Now()
+		s.adapter.recordPassiveQuotaObservation(s.spec, observedAt, codex.NormalizeWebsocketQuotaWindows(event, observedAt))
+		if emit != nil {
+			return emit(ctx, event)
+		}
+		return nil
+	})
 	if len(result.Header) > 0 && !result.HeaderObservedAt.IsZero() {
 		signals := make(map[string]string)
 		for name, values := range result.Header {

--- a/internal/execution/cpa/websocket_quota_test.go
+++ b/internal/execution/cpa/websocket_quota_test.go
@@ -3,24 +3,48 @@ package cpa
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
 	"os"
 	"testing"
 	"time"
 
+	"gpt-load/internal/channel"
 	"gpt-load/internal/execution"
+	"gpt-load/internal/storage/models"
 	"gpt-load/internal/subscription"
+	"gpt-load/internal/subscription/providers/codex"
+	providerobservation "gpt-load/internal/subscription/providers/observation"
 )
 
 type quotaEventSession struct {
 	execution.WebsocketSession
-	event []byte
+	event      []byte
+	result     execution.WebsocketResult
+	beforeEmit func()
+}
+
+type quotaTestWebsocketProvider struct {
+	*codexProviderBridge
+	event    []byte
+	header   http.Header
+	headerAt time.Time
+}
+
+func (p *quotaTestWebsocketProvider) openWebsocket(_ execution.AttemptSpec, _ providerCredential, _, _ string, observeHeaders func(http.Header, time.Time)) (execution.WebsocketSession, error) {
+	return &quotaEventSession{event: p.event, result: execution.WebsocketResult{DispatchState: execution.DispatchMaybeSent, Header: p.header, HeaderObservedAt: p.headerAt},
+		beforeEmit: func() { observeHeaders(p.header, p.headerAt) }}, nil
 }
 
 func (s *quotaEventSession) ExecuteTurn(ctx context.Context, _ []byte, emit func(context.Context, []byte) error) execution.WebsocketResult {
+	if s.beforeEmit != nil {
+		s.beforeEmit()
+	}
 	if err := emit(ctx, s.event); err != nil {
 		return execution.WebsocketResult{Error: &execution.ErrorEvidence{Code: "consumer_failed"}}
 	}
-	return execution.WebsocketResult{DispatchState: execution.DispatchMaybeSent}
+	return s.result
 }
 
 func TestWebsocketQuotaEventsRefreshBeforeTurnCompletesWithoutHeaders(t *testing.T) {
@@ -53,5 +77,87 @@ func TestWebsocketQuotaEventsRefreshBeforeTurnCompletesWithoutHeaders(t *testing
 		if result.Error != nil || len(result.Header) != 0 {
 			t.Fatalf("unexpected WS result: %+v", result)
 		}
+	}
+}
+
+func TestWebsocketQuotaKeepsHandshakeWhenEventOnlyUpdatesSpark(t *testing.T) {
+	for _, flushDuringTurn := range []bool{false, true} {
+		t.Run(fmt.Sprintf("flush_during_turn=%t", flushDuringTurn), func(t *testing.T) {
+			adapter, db, _, crypt, credential := newAdapterFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
+			manager := adapter.credentials.(*subscription.CredentialManager)
+			active, err := os.ReadFile("../../subscription/providers/codex/testdata/quota-active.json")
+			if err != nil {
+				t.Fatal(err)
+			}
+			snapshot, err := codex.NormalizeQuota(active, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := db.AutoMigrate(&models.CredentialObservation{}); err != nil {
+				t.Fatal(err)
+			}
+			storedAt := int64(1000)
+			row := models.CredentialObservation{CredentialID: credential.ID, State: models.CredentialObservationFresh,
+				SnapshotJSON: snapshot, ObservedAtMS: &storedAt, ObservationVersion: 1, UpdatedAtMS: storedAt}
+			if err := db.Create(&row).Error; err != nil {
+				t.Fatal(err)
+			}
+			event, err := os.ReadFile("../../subscription/providers/codex/testdata/quota-ws-account.json")
+			if err != nil {
+				t.Fatal(err)
+			}
+			// 条件复现：实测握手未带额度，此处显式提供受支持的 HTTP 额度字段。
+			provider := &quotaTestWebsocketProvider{
+				codexProviderBridge: adapter.providers[channel.ProviderCodex].(*codexProviderBridge), event: event,
+				headerAt: time.Now().Add(-time.Second),
+				header: http.Header{
+					"X-Codex-Active-Limit": {"premium"}, "X-Codex-Primary-Used-Percent": {"12"},
+					"X-Codex-Primary-Window-Minutes": {"10080"}, "X-Codex-Primary-Reset-At": {"1800000000"},
+				},
+			}
+			adapter.providers[channel.ProviderCodex] = provider
+			spec := validSpec(t, credential, crypt)
+			session, opened := adapter.OpenWebsocket(t.Context(), spec)
+			if opened.Error != nil {
+				t.Fatalf("open: %+v", opened.Error)
+			}
+			checkQuota := func() error {
+				if remaining, err := manager.FlushPassiveQuotaObservations(t.Context()); err != nil || remaining {
+					return fmt.Errorf("flush: remaining=%t error=%v", remaining, err)
+				}
+				if err := db.Take(&row, "credential_id = ?", credential.ID).Error; err != nil {
+					return err
+				}
+				var snapshot providerobservation.Snapshot
+				if err := json.Unmarshal(row.SnapshotJSON, &snapshot); err != nil {
+					return err
+				}
+				if len(snapshot.QuotaWindows) != 3 {
+					return fmt.Errorf("unexpected quota windows: %s", row.SnapshotJSON)
+				}
+				for _, window := range snapshot.QuotaWindows {
+					if window.SourceID == "codex" && (window.Used == nil || *window.Used != 12) {
+						return fmt.Errorf("handshake account quota lost: %s", row.SnapshotJSON)
+					}
+					if window.SourceID == "codex_bengalfox" && (window.Used == nil || *window.Used != 0) {
+						return fmt.Errorf("event did not retain Spark quota: %s", row.SnapshotJSON)
+					}
+				}
+				return nil
+			}
+			var quotaErr error
+			result := session.ExecuteTurn(t.Context(), spec.Body, func(_ context.Context, forwarded []byte) error {
+				if bytes.Equal(forwarded, event) && flushDuringTurn {
+					quotaErr = checkQuota()
+				}
+				return nil
+			})
+			if result.Error != nil || quotaErr != nil {
+				t.Fatalf("turn: result=%+v quota_error=%v", result, quotaErr)
+			}
+			if err := checkQuota(); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }

--- a/internal/execution/cpa/websocket_quota_test.go
+++ b/internal/execution/cpa/websocket_quota_test.go
@@ -1,0 +1,57 @@
+package cpa
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"gpt-load/internal/execution"
+	"gpt-load/internal/subscription"
+)
+
+type quotaEventSession struct {
+	execution.WebsocketSession
+	event []byte
+}
+
+func (s *quotaEventSession) ExecuteTurn(ctx context.Context, _ []byte, emit func(context.Context, []byte) error) execution.WebsocketResult {
+	if err := emit(ctx, s.event); err != nil {
+		return execution.WebsocketResult{Error: &execution.ErrorEvidence{Code: "consumer_failed"}}
+	}
+	return execution.WebsocketResult{DispatchState: execution.DispatchMaybeSent}
+}
+
+func TestWebsocketQuotaEventsRefreshBeforeTurnCompletesWithoutHeaders(t *testing.T) {
+	adapter, _, _, crypt, row := newAdapterFixture(t, credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
+	manager := adapter.credentials.(*subscription.CredentialManager)
+	event, err := os.ReadFile("../../subscription/providers/codex/testdata/quota-ws-account.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	session := &observedWebsocketSession{
+		WebsocketSession: &quotaEventSession{event: event}, adapter: adapter, spec: validSpec(t, row, crypt),
+	}
+	var lastVersion uint64
+	for turn := 0; turn < 2; turn++ {
+		startedAt := time.Now().UnixMilli()
+		result := session.ExecuteTurn(t.Context(), nil, func(_ context.Context, forwarded []byte) error {
+			if !bytes.Equal(forwarded, event) {
+				t.Fatal("quota observation changed the forwarded event")
+			}
+			dirty := manager.DirtyPassiveQuotaObservations(1)
+			if len(dirty) != 1 || len(dirty[0].Windows) != 3 {
+				t.Fatalf("quota event was not recorded before downstream delivery: %#v", dirty)
+			}
+			if dirty[0].ObservedAtMS < startedAt || dirty[0].Version <= lastVersion {
+				t.Fatalf("reused WS session did not refresh quota evidence: %#v", dirty[0])
+			}
+			lastVersion = dirty[0].Version
+			return nil
+		})
+		if result.Error != nil || len(result.Header) != 0 {
+			t.Fatalf("unexpected WS result: %+v", result)
+		}
+	}
+}

--- a/internal/subscription/passive_quota.go
+++ b/internal/subscription/passive_quota.go
@@ -7,13 +7,20 @@ import (
 	providerobservation "gpt-load/internal/subscription/providers/observation"
 )
 
-// PassiveQuotaObservation is one credential's not-yet-persisted passive quota
-// snapshot, captured from a single upstream response's headers.
+// PassiveQuotaSample 保留一份额度信号及其原始观测时间。
+type PassiveQuotaSample struct {
+	ObservedAtMS int64
+	Windows      []providerobservation.QuotaWindow
+}
+
+// PassiveQuotaObservation 保存一个凭据的最新待写样本。
+// WS 可附带同一连接的握手样本，时间独立保留，不累积事件历史。
 type PassiveQuotaObservation struct {
 	CredentialID       uint
 	IdentityGeneration uint64
 	ObservedAtMS       int64
 	Windows            []providerobservation.QuotaWindow
+	Preceding          *PassiveQuotaSample
 	Version            uint64
 }
 
@@ -21,6 +28,7 @@ type passiveQuotaEntry struct {
 	identityGeneration uint64
 	observedAtMS       int64
 	windows            []providerobservation.QuotaWindow
+	preceding          *PassiveQuotaSample
 	version            uint64
 	dirty              bool
 }
@@ -60,6 +68,30 @@ func (manager *CredentialManager) RecordPassiveQuotaObservation(
 	observedAtMS int64,
 	windows []providerobservation.QuotaWindow,
 ) {
+	manager.recordPassiveQuotaObservation(credentialID, identityGeneration, observedAtMS, windows, nil)
+}
+
+// RecordPassiveQuotaPair 让 WS 的最新事件携带同一连接的握手证据。
+// 两份样本分别校验时间；每个凭据仍仅保留一组，不合并其他请求或事件。
+func (manager *CredentialManager) RecordPassiveQuotaPair(
+	credentialID uint,
+	identityGeneration uint64,
+	preceding, latest PassiveQuotaSample,
+) {
+	var earlier *PassiveQuotaSample
+	if len(preceding.Windows) > 0 && preceding.ObservedAtMS <= latest.ObservedAtMS {
+		earlier = &preceding
+	}
+	manager.recordPassiveQuotaObservation(credentialID, identityGeneration, latest.ObservedAtMS, latest.Windows, earlier)
+}
+
+func (manager *CredentialManager) recordPassiveQuotaObservation(
+	credentialID uint,
+	identityGeneration uint64,
+	observedAtMS int64,
+	windows []providerobservation.QuotaWindow,
+	preceding *PassiveQuotaSample,
+) {
 	if manager == nil || manager.passiveQuota == nil || manager.registry == nil || credentialID == 0 || len(windows) == 0 {
 		return
 	}
@@ -69,7 +101,7 @@ func (manager *CredentialManager) RecordPassiveQuotaObservation(
 		if !ok || ref.IdentityGeneration != identityGeneration {
 			return
 		}
-		manager.passiveQuota.record(credentialID, identityGeneration, observedAtMS, windows)
+		manager.passiveQuota.record(credentialID, identityGeneration, observedAtMS, windows, preceding)
 	})
 }
 
@@ -98,6 +130,7 @@ func (pending *passiveQuotaPending) record(
 	identityGeneration uint64,
 	observedAtMS int64,
 	windows []providerobservation.QuotaWindow,
+	preceding *PassiveQuotaSample,
 ) {
 	pending.mu.Lock()
 	entry, exists := pending.entries[credentialID]
@@ -109,6 +142,7 @@ func (pending *passiveQuotaPending) record(
 		return
 	}
 	entry.windows = cloneQuotaWindows(windows)
+	entry.preceding = clonePassiveQuotaSample(preceding)
 	entry.observedAtMS = observedAtMS
 	pending.nextVersion++
 	entry.version = pending.nextVersion
@@ -142,6 +176,7 @@ func (pending *passiveQuotaPending) dirtyObservations(limit int) []PassiveQuotaO
 			IdentityGeneration: entry.identityGeneration,
 			ObservedAtMS:       entry.observedAtMS,
 			Windows:            cloneQuotaWindows(entry.windows),
+			Preceding:          clonePassiveQuotaSample(entry.preceding),
 			Version:            entry.version,
 		})
 		if len(result) >= limit {
@@ -149,6 +184,13 @@ func (pending *passiveQuotaPending) dirtyObservations(limit int) []PassiveQuotaO
 		}
 	}
 	return result
+}
+
+func clonePassiveQuotaSample(sample *PassiveQuotaSample) *PassiveQuotaSample {
+	if sample == nil {
+		return nil
+	}
+	return &PassiveQuotaSample{ObservedAtMS: sample.ObservedAtMS, Windows: cloneQuotaWindows(sample.Windows)}
 }
 
 // cloneQuotaWindows detaches a window slice from its caller, including the

--- a/internal/subscription/passive_quota_flush.go
+++ b/internal/subscription/passive_quota_flush.go
@@ -220,6 +220,12 @@ func mergePassiveQuotaSnapshot(
 // matchPassiveQuotaWindow 按来源和实际周期对齐主动/被动数据；槽位不参与推断。
 // 其他未提供 SourceID 的渠道保留 ID 匹配，但不能覆盖带来源标识的窗口。
 func matchPassiveQuotaWindow(windows []providerobservation.QuotaWindow, patch providerobservation.QuotaWindow) int {
+	if patch.SourceID == "" && patch.SourceName != "" {
+		patch.SourceID = passiveQuotaSourceByName(windows, patch)
+		if patch.SourceID == "" {
+			return -1
+		}
+	}
 	matched := -1
 	for index, window := range windows {
 		if patch.SourceID != "" {
@@ -237,4 +243,24 @@ func matchPassiveQuotaWindow(windows []providerobservation.QuotaWindow, patch pr
 		matched = index
 	}
 	return matched
+}
+
+// Codex WS 的附加额度只报告原始 limit_name。利用主动观测已保存的名称和周期
+// 解析来源，再走既有 SourceID 匹配；不使用格式化后的 Label，也不推测名称别名。
+func passiveQuotaSourceByName(windows []providerobservation.QuotaWindow, patch providerobservation.QuotaWindow) string {
+	if patch.WindowSeconds == nil || *patch.WindowSeconds <= 0 {
+		return ""
+	}
+	sourceID := ""
+	for _, window := range windows {
+		if window.Scope == "account" || window.Scope != patch.SourceName || window.SourceID == "" ||
+			window.WindowSeconds == nil || *window.WindowSeconds != *patch.WindowSeconds {
+			continue
+		}
+		if sourceID != "" {
+			return ""
+		}
+		sourceID = window.SourceID
+	}
+	return sourceID
 }

--- a/internal/subscription/passive_quota_flush.go
+++ b/internal/subscription/passive_quota_flush.go
@@ -88,7 +88,7 @@ func (manager *CredentialManager) flushOnePassiveQuotaObservationLocked(
 			manager.passiveQuota.ack(observation.CredentialID, observation.Version)
 			return nil
 		}
-		merge, mergeErr := mergePassiveQuotaSnapshot(row.SnapshotJSON, observation.Windows)
+		merge, observedAtMS, mergeErr := mergePassiveQuotaSamples(row.SnapshotJSON, row.ObservedAtMS, observation)
 		if mergeErr != nil {
 			// A snapshot this malformed cannot be repaired by retrying the
 			// same merge; drop the observation instead of retrying forever.
@@ -105,7 +105,7 @@ func (manager *CredentialManager) flushOnePassiveQuotaObservationLocked(
 		// credential was observed just now, so the sync time advances even
 		// when the snapshot itself stays byte-identical.
 		updates := map[string]any{
-			"observed_at_ms": observation.ObservedAtMS,
+			"observed_at_ms": observedAtMS,
 			"updated_at_ms":  manager.now().UnixMilli(),
 		}
 		if merge.Changed {
@@ -137,6 +137,33 @@ func (manager *CredentialManager) flushOnePassiveQuotaObservationLocked(
 		// write. Retry once against the row it left behind.
 	}
 	return fmt.Errorf("passive quota observation for credential %d conflicted with a concurrent write", observation.CredentialID)
+}
+
+// mergePassiveQuotaSamples 按原始时间处理握手和事件，再通过同一次 CAS 写入。
+// 每份样本都与数据库中的时间比较，避免把旧握手改记为事件时间、覆盖期间的主动刷新。
+func mergePassiveQuotaSamples(raw []byte, storedAtMS *int64, observation PassiveQuotaObservation) (passiveQuotaMerge, int64, error) {
+	result := passiveQuotaMerge{Encoded: raw}
+	var observedAtMS int64
+	samples := [2]*PassiveQuotaSample{
+		observation.Preceding,
+		{ObservedAtMS: observation.ObservedAtMS, Windows: observation.Windows},
+	}
+	for _, sample := range samples {
+		if sample == nil || (storedAtMS != nil && sample.ObservedAtMS <= *storedAtMS) {
+			continue
+		}
+		merged, err := mergePassiveQuotaSnapshot(result.Encoded, sample.Windows)
+		if err != nil {
+			return passiveQuotaMerge{}, 0, err
+		}
+		if merged.Matched {
+			observedAtMS = sample.ObservedAtMS
+		}
+		merged.Matched = merged.Matched || result.Matched
+		merged.Changed = merged.Changed || result.Changed
+		result = merged
+	}
+	return result, observedAtMS, nil
 }
 
 // passiveQuotaMerge is the outcome of overlaying one response's windows onto

--- a/internal/subscription/passive_quota_websocket_test.go
+++ b/internal/subscription/passive_quota_websocket_test.go
@@ -201,3 +201,80 @@ func TestMergeWebsocketQuotaPrefersNamedCopyForTheSameSourceAndPeriod(t *testing
 		}
 	}
 }
+
+func TestFlushWebsocketQuotaPairPreservesEachSampleTime(t *testing.T) {
+	tests := []struct {
+		name                        string
+		storedAt, headerAt, eventAt int64
+		eventSource                 string
+		wantAccount, wantSpark      float64
+		wantObservedAt              int64
+	}{
+		{"complementary windows", 1000, 2000, 3000, "codex_bengalfox", 12, 20, 3000},
+		{"active refresh between samples", 2500, 2000, 3000, "codex_bengalfox", 90, 20, 3000},
+		{"active refresh ties handshake", 2000, 2000, 3000, "codex_bengalfox", 90, 20, 3000},
+		{"active refresh ties event", 3000, 2000, 3000, "codex_bengalfox", 90, 5, 3000},
+		{"samples in same millisecond", 1000, 2000, 2000, "codex_bengalfox", 12, 20, 2000},
+		{"event supersedes same window", 1000, 2000, 3000, "codex", 20, 5, 3000},
+		{"unmatched event keeps handshake time", 1000, 2000, 3000, "unknown", 12, 5, 2000},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			manager, db, registry, _, credential := newCredentialManagerFixture(t,
+				credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
+			newFlushableCredentialObservation(t, manager, credential.ID, models.CredentialObservationFresh,
+				`{"plan_summary":{},"quota_windows":[{"source_id":"codex","id":"account","scope":"account","window_seconds":604800,"used":90},{"source_id":"codex_bengalfox","id":"spark","scope":"GPT-5.3-Codex-Spark","window_seconds":604800,"used":5}]}`)
+			if err := db.Model(&models.CredentialObservation{}).Where("credential_id = ?", credential.ID).
+				Update("observed_at_ms", test.storedAt).Error; err != nil {
+				t.Fatal(err)
+			}
+			period := int64(604800)
+			header := PassiveQuotaSample{ObservedAtMS: test.headerAt, Windows: []providerobservation.QuotaWindow{
+				{SourceID: "codex", WindowSeconds: &period, Used: floatPointer(12), Limit: floatPointer(100), Remaining: floatPointer(88), Utilization: floatPointer(.12)},
+			}}
+			event := PassiveQuotaSample{ObservedAtMS: test.eventAt, Windows: []providerobservation.QuotaWindow{
+				{SourceID: test.eventSource, WindowSeconds: &period, Used: floatPointer(20), Limit: floatPointer(100), Remaining: floatPointer(80), Utilization: floatPointer(.20)},
+			}}
+			ref, _ := registry.CredentialRef(credential.ID)
+			manager.RecordPassiveQuotaPair(credential.ID, ref.IdentityGeneration, header, event)
+			if remaining, err := manager.FlushPassiveQuotaObservations(t.Context()); err != nil || remaining {
+				t.Fatalf("flush: remaining=%t error=%v", remaining, err)
+			}
+			var stored models.CredentialObservation
+			if err := db.Take(&stored, "credential_id = ?", credential.ID).Error; err != nil {
+				t.Fatal(err)
+			}
+			var snapshot providerobservation.Snapshot
+			if err := json.Unmarshal(stored.SnapshotJSON, &snapshot); err != nil {
+				t.Fatal(err)
+			}
+			if stored.ObservedAtMS == nil || *stored.ObservedAtMS != test.wantObservedAt || len(snapshot.QuotaWindows) != 2 ||
+				*snapshot.QuotaWindows[0].Used != test.wantAccount || *snapshot.QuotaWindows[1].Used != test.wantSpark {
+				t.Fatalf("unexpected timestamp or quota values: time=%v snapshot=%s", stored.ObservedAtMS, stored.SnapshotJSON)
+			}
+		})
+	}
+}
+
+func TestWebsocketQuotaPairCoalescesWithoutRedatingHandshake(t *testing.T) {
+	manager := testCredentialManagerForPassiveQuota(t)
+	header := PassiveQuotaSample{ObservedAtMS: 1000, Windows: []providerobservation.QuotaWindow{{ID: "account", Used: floatPointer(12)}}}
+	event := PassiveQuotaSample{ObservedAtMS: 2000, Windows: []providerobservation.QuotaWindow{{ID: "spark", Used: floatPointer(20)}}}
+	manager.RecordPassiveQuotaPair(7, 100, header, event)
+	event.ObservedAtMS = 3000
+	*event.Windows[0].Used = 30
+	manager.RecordPassiveQuotaPair(7, 100, header, event)
+	*header.Windows[0].Used = 99
+	*event.Windows[0].Used = 99
+	dirty := manager.DirtyPassiveQuotaObservations(1)
+	if len(dirty) != 1 || dirty[0].Preceding == nil || dirty[0].Preceding.ObservedAtMS != 1000 ||
+		*dirty[0].Preceding.Windows[0].Used != 12 || dirty[0].ObservedAtMS != 3000 || *dirty[0].Windows[0].Used != 30 {
+		t.Fatalf("coalescing lost the handshake time or retained caller pointers: %#v", dirty)
+	}
+	// HTTP 继续整份替换，不继承另一请求留下的握手样本。
+	manager.RecordPassiveQuotaObservation(7, 100, 4000, []providerobservation.QuotaWindow{{ID: "http"}})
+	dirty = manager.DirtyPassiveQuotaObservations(1)
+	if len(dirty) != 1 || dirty[0].Preceding != nil || len(dirty[0].Windows) != 1 || dirty[0].Windows[0].ID != "http" {
+		t.Fatalf("HTTP inherited a WS sample: %#v", dirty)
+	}
+}

--- a/internal/subscription/passive_quota_websocket_test.go
+++ b/internal/subscription/passive_quota_websocket_test.go
@@ -1,0 +1,146 @@
+package subscription
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"gpt-load/internal/storage/models"
+	"gpt-load/internal/subscription/providers/codex"
+	providerobservation "gpt-load/internal/subscription/providers/observation"
+)
+
+func TestFlushWebsocketQuotaCapturedEventsKeepAccountAndSparkSeparate(t *testing.T) {
+	for _, sample := range []string{"quota-ws-account.json", "quota-ws-spark.json"} {
+		t.Run(sample, func(t *testing.T) {
+			manager, db, registry, _, credential := newCredentialManagerFixture(t,
+				credentialJSON("access", "refresh", time.Now().Add(time.Hour)))
+			active, err := os.ReadFile("providers/codex/testdata/quota-active.json")
+			if err != nil {
+				t.Fatal(err)
+			}
+			raw, err := codex.NormalizeQuota(active, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			newFlushableCredentialObservation(t, manager, credential.ID, models.CredentialObservationFresh, string(raw))
+			payload, err := os.ReadFile("providers/codex/testdata/" + sample)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ref, _ := registry.CredentialRef(credential.ID)
+			for _, observedAtMS := range []int64{2000, 3000} {
+				windows := codex.NormalizeWebsocketQuotaWindows(payload, time.UnixMilli(observedAtMS))
+				manager.RecordPassiveQuotaObservation(credential.ID, ref.IdentityGeneration, observedAtMS, windows)
+				if pending, err := manager.FlushPassiveQuotaObservations(t.Context()); err != nil || pending {
+					t.Fatalf("flush: pending=%v error=%v", pending, err)
+				}
+				var stored models.CredentialObservation
+				if err := db.Take(&stored, "credential_id = ?", credential.ID).Error; err != nil {
+					t.Fatal(err)
+				}
+				var snapshot providerobservation.Snapshot
+				if err := json.Unmarshal(stored.SnapshotJSON, &snapshot); err != nil {
+					t.Fatal(err)
+				}
+				if stored.ObservedAtMS == nil || *stored.ObservedAtMS != observedAtMS || len(snapshot.QuotaWindows) != 3 {
+					t.Fatalf("quota event did not refresh the existing windows: %s", stored.SnapshotJSON)
+				}
+				if bytes.Contains(stored.SnapshotJSON, []byte("SourceName")) || bytes.Contains(stored.SnapshotJSON, []byte("source_name")) {
+					t.Fatal("transient source hint was persisted")
+				}
+				for _, window := range snapshot.QuotaWindows {
+					if window.SourceID == "codex" && (*window.Used != 6 || *window.Remaining != 94) {
+						t.Fatalf("Spark overwrote account quota: %#v", window)
+					}
+					if window.SourceID == "codex_bengalfox" && (*window.Used != 0 || *window.Remaining != 100) {
+						t.Fatalf("Spark quota was not retained: %#v", window)
+					}
+					for _, patch := range windows {
+						if patch.WindowSeconds != nil && *patch.WindowSeconds == *window.WindowSeconds &&
+							(patch.SourceID == window.SourceID || patch.SourceName == window.Scope) {
+							if patch.ResetAtMS == nil || window.ResetAtMS == nil || *window.ResetAtMS != *patch.ResetAtMS {
+								t.Fatalf("quota reset was not refreshed: source=%s period=%d", window.SourceID, *window.WindowSeconds)
+							}
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestCapturedHTTPAndWebsocketQuotaAgreeAfterMatching(t *testing.T) {
+	active, err := os.ReadFile("providers/codex/testdata/quota-active.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := codex.NormalizeQuota(active, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"account", "spark"} {
+		t.Run(name, func(t *testing.T) {
+			headerJSON, err := os.ReadFile("providers/codex/testdata/quota-http-" + name + ".json")
+			if err != nil {
+				t.Fatal(err)
+			}
+			var headers http.Header
+			if err := json.Unmarshal(headerJSON, &headers); err != nil {
+				t.Fatal(err)
+			}
+			signals := make(map[string]string)
+			for key := range headers {
+				signals[key] = headers.Get(key)
+			}
+			payload, err := os.ReadFile("providers/codex/testdata/quota-ws-" + name + ".json")
+			if err != nil {
+				t.Fatal(err)
+			}
+			observedAt := time.Unix(1789204875, 0)
+			httpMerged, err := mergePassiveQuotaSnapshot(raw, codex.NormalizePassiveQuotaWindows(signals, observedAt))
+			if err != nil {
+				t.Fatal(err)
+			}
+			wsMerged, err := mergePassiveQuotaSnapshot(raw, codex.NormalizeWebsocketQuotaWindows(payload, observedAt))
+			if err != nil {
+				t.Fatal(err)
+			}
+			for index, httpWindow := range httpMerged.Windows {
+				wsWindow := wsMerged.Windows[index]
+				if httpWindow.SourceID != wsWindow.SourceID || *httpWindow.WindowSeconds != *wsWindow.WindowSeconds ||
+					*httpWindow.Used != *wsWindow.Used || *httpWindow.Remaining != *wsWindow.Remaining || httpWindow.State != wsWindow.State {
+					t.Fatalf("HTTP and WS disagree for source=%s period=%d", httpWindow.SourceID, *httpWindow.WindowSeconds)
+				}
+			}
+		})
+	}
+}
+
+func TestPassiveQuotaSourceNameRequiresUniqueOriginalNameAndPeriod(t *testing.T) {
+	period := int64(18000)
+	window := providerobservation.QuotaWindow{SourceID: "codex_bengalfox", ID: "spark-primary", Scope: "GPT-5.3-Codex-Spark", WindowSeconds: &period}
+	patch := providerobservation.QuotaWindow{SourceName: window.Scope, WindowSeconds: &period}
+	if got := matchPassiveQuotaWindow([]providerobservation.QuotaWindow{window}, patch); got != 0 {
+		t.Fatalf("original source name did not resolve: %d", got)
+	}
+	for _, name := range []string{"GPT 5.3 Codex Spark", "Unknown", "account"} {
+		patch.SourceName = name
+		if got := matchPassiveQuotaWindow([]providerobservation.QuotaWindow{window}, patch); got != -1 {
+			t.Fatalf("unconfirmed alias %q matched", name)
+		}
+	}
+	patch.SourceName = window.Scope
+	other := window
+	other.SourceID = "codex_other"
+	if got := matchPassiveQuotaWindow([]providerobservation.QuotaWindow{window, other}, patch); got != -1 {
+		t.Fatal("ambiguous source name matched")
+	}
+	patch.WindowSeconds = nil
+	if got := matchPassiveQuotaWindow([]providerobservation.QuotaWindow{window}, patch); got != -1 {
+		t.Fatal("source name without period matched")
+	}
+}

--- a/internal/subscription/providers/codex/testdata/quota-active.json
+++ b/internal/subscription/providers/codex/testdata/quota-active.json
@@ -1,0 +1,36 @@
+{
+  "additional_rate_limits": [
+    {
+      "limit_name": "GPT-5.3-Codex-Spark",
+      "metered_feature": "codex_bengalfox",
+      "rate_limit": {
+        "allowed": true,
+        "limit_reached": false,
+        "primary_window": {
+          "used_percent": 0,
+          "limit_window_seconds": 18000,
+          "reset_after_seconds": 17892,
+          "reset_at": 1789222880
+        },
+        "secondary_window": {
+          "used_percent": 0,
+          "limit_window_seconds": 604800,
+          "reset_after_seconds": 604692,
+          "reset_at": 1789809680
+        }
+      },
+      "normal_model_slug": null
+    }
+  ],
+  "rate_limit": {
+    "allowed": true,
+    "limit_reached": false,
+    "primary_window": {
+      "used_percent": 6,
+      "limit_window_seconds": 604800,
+      "reset_after_seconds": 600494,
+      "reset_at": 1789805482
+    },
+    "secondary_window": null
+  }
+}

--- a/internal/subscription/providers/codex/testdata/quota-http-account.json
+++ b/internal/subscription/providers/codex/testdata/quota-http-account.json
@@ -1,0 +1,59 @@
+{
+  "X-Codex-Active-Limit": [
+    "premium"
+  ],
+  "X-Codex-Bengalfox-Limit-Name": [
+    "GPT-5.3-Codex-Spark"
+  ],
+  "X-Codex-Bengalfox-Primary-Over-Secondary-Limit-Percent": [
+    "0"
+  ],
+  "X-Codex-Bengalfox-Primary-Reset-After-Seconds": [
+    "18000"
+  ],
+  "X-Codex-Bengalfox-Primary-Reset-At": [
+    "1789222873"
+  ],
+  "X-Codex-Bengalfox-Primary-Used-Percent": [
+    "0"
+  ],
+  "X-Codex-Bengalfox-Primary-Window-Minutes": [
+    "300"
+  ],
+  "X-Codex-Bengalfox-Secondary-Reset-After-Seconds": [
+    "604800"
+  ],
+  "X-Codex-Bengalfox-Secondary-Reset-At": [
+    "1789809673"
+  ],
+  "X-Codex-Bengalfox-Secondary-Used-Percent": [
+    "0"
+  ],
+  "X-Codex-Bengalfox-Secondary-Window-Minutes": [
+    "10080"
+  ],
+  "X-Codex-Primary-Over-Secondary-Limit-Percent": [
+    "0"
+  ],
+  "X-Codex-Primary-Reset-After-Seconds": [
+    "600609"
+  ],
+  "X-Codex-Primary-Reset-At": [
+    "1789805481"
+  ],
+  "X-Codex-Primary-Used-Percent": [
+    "6"
+  ],
+  "X-Codex-Primary-Window-Minutes": [
+    "10080"
+  ],
+  "X-Codex-Secondary-Reset-After-Seconds": [
+    "0"
+  ],
+  "X-Codex-Secondary-Used-Percent": [
+    "0"
+  ],
+  "X-Codex-Secondary-Window-Minutes": [
+    "0"
+  ]
+}

--- a/internal/subscription/providers/codex/testdata/quota-http-spark.json
+++ b/internal/subscription/providers/codex/testdata/quota-http-spark.json
@@ -1,0 +1,62 @@
+{
+  "X-Codex-Active-Limit": [
+    "codex_bengalfox"
+  ],
+  "X-Codex-Bengalfox-Limit-Name": [
+    "GPT-5.3-Codex-Spark"
+  ],
+  "X-Codex-Bengalfox-Primary-Over-Secondary-Limit-Percent": [
+    "0"
+  ],
+  "X-Codex-Bengalfox-Primary-Reset-After-Seconds": [
+    "18000"
+  ],
+  "X-Codex-Bengalfox-Primary-Reset-At": [
+    "1789222878"
+  ],
+  "X-Codex-Bengalfox-Primary-Used-Percent": [
+    "0"
+  ],
+  "X-Codex-Bengalfox-Primary-Window-Minutes": [
+    "300"
+  ],
+  "X-Codex-Bengalfox-Secondary-Reset-After-Seconds": [
+    "604800"
+  ],
+  "X-Codex-Bengalfox-Secondary-Reset-At": [
+    "1789809678"
+  ],
+  "X-Codex-Bengalfox-Secondary-Used-Percent": [
+    "0"
+  ],
+  "X-Codex-Bengalfox-Secondary-Window-Minutes": [
+    "10080"
+  ],
+  "X-Codex-Primary-Over-Secondary-Limit-Percent": [
+    "0"
+  ],
+  "X-Codex-Primary-Reset-After-Seconds": [
+    "18000"
+  ],
+  "X-Codex-Primary-Reset-At": [
+    "1789222878"
+  ],
+  "X-Codex-Primary-Used-Percent": [
+    "0"
+  ],
+  "X-Codex-Primary-Window-Minutes": [
+    "300"
+  ],
+  "X-Codex-Secondary-Reset-After-Seconds": [
+    "604800"
+  ],
+  "X-Codex-Secondary-Reset-At": [
+    "1789809678"
+  ],
+  "X-Codex-Secondary-Used-Percent": [
+    "0"
+  ],
+  "X-Codex-Secondary-Window-Minutes": [
+    "10080"
+  ]
+}

--- a/internal/subscription/providers/codex/testdata/quota-ws-account.json
+++ b/internal/subscription/providers/codex/testdata/quota-ws-account.json
@@ -1,0 +1,33 @@
+{
+  "additional_rate_limits": {
+    "GPT-5.3-Codex-Spark": {
+      "allowed": true,
+      "limit_reached": false,
+      "primary": {
+        "used_percent": 0,
+        "window_minutes": 300,
+        "reset_after_seconds": 18000,
+        "reset_at": 1789222875
+      },
+      "secondary": {
+        "used_percent": 0,
+        "window_minutes": 10080,
+        "reset_after_seconds": 604800,
+        "reset_at": 1789809675
+      }
+    }
+  },
+  "code_review_rate_limits": null,
+  "rate_limits": {
+    "allowed": true,
+    "limit_reached": false,
+    "primary": {
+      "used_percent": 6,
+      "window_minutes": 10080,
+      "reset_after_seconds": 600607,
+      "reset_at": 1789805481
+    },
+    "secondary": null
+  },
+  "type": "codex.rate_limits"
+}

--- a/internal/subscription/providers/codex/testdata/quota-ws-spark.json
+++ b/internal/subscription/providers/codex/testdata/quota-ws-spark.json
@@ -1,0 +1,38 @@
+{
+  "additional_rate_limits": {
+    "GPT-5.3-Codex-Spark": {
+      "allowed": true,
+      "limit_reached": false,
+      "primary": {
+        "used_percent": 0,
+        "window_minutes": 300,
+        "reset_after_seconds": 17891,
+        "reset_at": 1789222880
+      },
+      "secondary": {
+        "used_percent": 0,
+        "window_minutes": 10080,
+        "reset_after_seconds": 604691,
+        "reset_at": 1789809680
+      }
+    }
+  },
+  "code_review_rate_limits": null,
+  "rate_limits": {
+    "allowed": true,
+    "limit_reached": false,
+    "primary": {
+      "used_percent": 0,
+      "window_minutes": 300,
+      "reset_after_seconds": 17891,
+      "reset_at": 1789222880
+    },
+    "secondary": {
+      "used_percent": 0,
+      "window_minutes": 10080,
+      "reset_after_seconds": 604691,
+      "reset_at": 1789809680
+    }
+  },
+  "type": "codex.rate_limits"
+}

--- a/internal/subscription/providers/codex/websocket.go
+++ b/internal/subscription/providers/codex/websocket.go
@@ -26,6 +26,7 @@ type WSSessionOptions struct {
 	MaxRequestBytes int
 	MaxEventBytes   int
 	Headers         http.Header
+	ObserveHeaders  func(http.Header, time.Time)
 }
 
 // WSTurnResult 的 Usage 保留上游 JSON，缺失时为 nil，不伪造零用量。
@@ -58,8 +59,9 @@ func NewWSSession(options WSSessionOptions) (*WSSession, error) {
 	bridge, err := cpaembedded.NewCodexWSSession(cpaembedded.CodexWSSessionOptions{
 		CredentialID: options.CredentialID, Credential: credentialToBridge(options.Credential),
 		BaseURL: options.BaseURL, ProxyURL: options.ProxyURL,
-		Headers:     options.Headers.Clone(),
-		TurnTimeout: options.TurnTimeout, MaxRequestBytes: options.MaxRequestBytes, MaxEventBytes: options.MaxEventBytes,
+		Headers:        options.Headers.Clone(),
+		ObserveHeaders: options.ObserveHeaders,
+		TurnTimeout:    options.TurnTimeout, MaxRequestBytes: options.MaxRequestBytes, MaxEventBytes: options.MaxEventBytes,
 	})
 	if err != nil {
 		return nil, wsErrorFromBridge(err)

--- a/internal/subscription/providers/codex/websocket_quota.go
+++ b/internal/subscription/providers/codex/websocket_quota.go
@@ -1,0 +1,144 @@
+package codex
+
+import (
+	"encoding/json"
+	"math"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/buger/jsonparser"
+)
+
+type websocketQuotaWindow struct {
+	UsedPercent       *float64 `json:"used_percent"`
+	WindowMinutes     *int64   `json:"window_minutes"`
+	ResetAt           *int64   `json:"reset_at"`
+	ResetAfterSeconds *int64   `json:"reset_after_seconds"`
+}
+
+type websocketQuotaRate struct {
+	Allowed      *bool                 `json:"allowed"`
+	LimitReached *bool                 `json:"limit_reached"`
+	Primary      *websocketQuotaWindow `json:"primary"`
+	Secondary    *websocketQuotaWindow `json:"secondary"`
+}
+
+// NormalizeWebsocketQuotaWindows 读取 Codex 原生额度事件，不改动发给客户端的消息。
+// WS 的具名附加额度由已有快照解析来源，不能按 HTTP 响应头命名空间推导 SourceID。
+func NormalizeWebsocketQuotaWindows(payload []byte, observedAt time.Time) []quotaWindow {
+	kind, err := jsonparser.GetString(payload, "type")
+	if err != nil || kind != "codex.rate_limits" {
+		return nil
+	}
+	var event struct {
+		RateLimits           *websocketQuotaRate            `json:"rate_limits"`
+		MeteredLimitName     string                         `json:"metered_limit_name"`
+		LimitName            string                         `json:"limit_name"`
+		AdditionalRateLimits map[string]*websocketQuotaRate `json:"additional_rate_limits"`
+	}
+	if json.Unmarshal(payload, &event) != nil || len(event.AdditionalRateLimits) > 8 {
+		return nil
+	}
+	additional := make([]quotaWindow, 0, 2*len(event.AdditionalRateLimits))
+	names := make([]string, 0, len(event.AdditionalRateLimits))
+	for name := range event.AdditionalRateLimits {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	additionalComplete := true
+	for _, name := range names {
+		windows, complete := normalizeWebsocketQuotaRate(event.AdditionalRateLimits[name], observedAt)
+		name = strings.TrimSpace(name)
+		if !complete || len(windows) == 0 || name == "" {
+			additionalComplete = false
+		}
+		if name == "" {
+			continue
+		}
+		for _, window := range windows {
+			window.SourceName = name
+			additional = append(additional, window)
+		}
+	}
+	sourceID := normalizeQuotaSourceID(event.MeteredLimitName)
+	if sourceID == "" {
+		sourceID = normalizeQuotaSourceID(event.LimitName)
+	}
+	if sourceID == "" && !additionalComplete {
+		// 缺少来源且附加数据不完整，无法排除顶层是附加额度的副本。
+		return additional
+	}
+	if sourceID == "" || sourceID == codexAccountActiveLimit {
+		sourceID = codexAccountQuotaSourceID
+	}
+	primary, _ := normalizeWebsocketQuotaRate(event.RateLimits, observedAt)
+	result := make([]quotaWindow, 0, len(primary)+len(additional))
+	for _, window := range primary {
+		duplicate := false
+		for _, other := range additional {
+			// 实测 Spark 的顶层与附加窗口重复，但没有 metered_limit_name。
+			// 保留具名窗口，避免把这个副本当成普通账号额度写回。
+			candidate := window
+			other.SourceName = ""
+			candidate.ID, other.ID = "", ""
+			if reflect.DeepEqual(candidate, other) {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			window.SourceID = sourceID
+			result = append(result, window)
+		}
+	}
+	return append(result, additional...)
+}
+
+func normalizeWebsocketQuotaRate(rate *websocketQuotaRate, observedAt time.Time) ([]quotaWindow, bool) {
+	if rate == nil {
+		return nil, false
+	}
+	fields := map[string]any{}
+	if rate.Allowed != nil {
+		fields["allowed"] = *rate.Allowed
+	}
+	if rate.LimitReached != nil {
+		fields["limit_reached"] = *rate.LimitReached
+	}
+	complete := true
+	for _, slot := range []struct {
+		name   string
+		window *websocketQuotaWindow
+	}{{"primary", rate.Primary}, {"secondary", rate.Secondary}} {
+		window := slot.window
+		if window == nil {
+			continue
+		}
+		if window.UsedPercent == nil || math.IsNaN(*window.UsedPercent) || math.IsInf(*window.UsedPercent, 0) ||
+			*window.UsedPercent < 0 || *window.UsedPercent > 100 || window.WindowMinutes == nil ||
+			*window.WindowMinutes <= 0 || *window.WindowMinutes > passiveQuotaMaxResetAtSeconds/60 {
+			complete = false
+			continue
+		}
+		values := map[string]string{
+			"used-percent":   strconv.FormatFloat(*window.UsedPercent, 'f', -1, 64),
+			"window-minutes": strconv.FormatInt(*window.WindowMinutes, 10),
+		}
+		if window.ResetAt != nil {
+			values["reset-at"] = strconv.FormatInt(*window.ResetAt, 10)
+		}
+		if window.ResetAfterSeconds != nil {
+			values["reset-after-seconds"] = strconv.FormatInt(*window.ResetAfterSeconds, 10)
+		}
+		fields[slot.name+"_window"] = passiveQuotaWindowFields(values, observedAt)
+	}
+	windows := normalizeRateWindows(fields, "", "", "")
+	for index := range windows {
+		windows[index].Label, windows[index].LabelKey = "", ""
+		windows[index].Scope, windows[index].Unit = "", ""
+	}
+	return windows, complete
+}

--- a/internal/subscription/providers/codex/websocket_quota_test.go
+++ b/internal/subscription/providers/codex/websocket_quota_test.go
@@ -24,9 +24,12 @@ func TestWebsocketQuotaDoesNotGuessAccountSourceWhenMeteredValuesDiffer(t *testi
 		t.Fatal(err)
 	}
 	windows := NormalizeWebsocketQuotaWindows(payload, time.Unix(1000, 0))
+	if len(windows) != 2 {
+		t.Fatalf("windows = %#v, want both Spark windows", windows)
+	}
 	for _, window := range windows {
-		if window.SourceID != "" {
-			t.Fatalf("unidentified event invented source %q", window.SourceID)
+		if window.SourceID != "" || window.SourceName != "GPT-5.3-Codex-Spark" {
+			t.Fatalf("unexpected Spark source: id=%q name=%q", window.SourceID, window.SourceName)
 		}
 	}
 }

--- a/internal/subscription/providers/codex/websocket_quota_test.go
+++ b/internal/subscription/providers/codex/websocket_quota_test.go
@@ -1,0 +1,90 @@
+package codex
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// testdata 为 2026-09-12 对同一账号实测得到的额度字段，不包含身份和凭据。
+func TestWebsocketQuotaCapturedAccountAndSparkEvents(t *testing.T) {
+	for _, test := range []struct {
+		file         string
+		accountCount int
+	}{
+		{"quota-ws-account.json", 1},
+		{"quota-ws-spark.json", 0},
+	} {
+		t.Run(test.file, func(t *testing.T) {
+			payload, err := os.ReadFile("testdata/" + test.file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			windows := NormalizeWebsocketQuotaWindows(payload, time.Unix(1789204875, 0))
+			if len(windows) != test.accountCount+2 {
+				t.Fatalf("windows=%#v", windows)
+			}
+			account, spark := 0, 0
+			for _, window := range windows {
+				if window.SourceID == "codex" {
+					account++
+					if *window.Used != 6 || *window.Remaining != 94 || *window.WindowSeconds != 604800 {
+						t.Fatalf("account quota=%#v", window)
+					}
+				} else if window.SourceName == "GPT-5.3-Codex-Spark" && window.SourceID == "" {
+					spark++
+					if *window.Used != 0 || *window.Remaining != 100 || *window.ResetAtMS <= 0 {
+						t.Fatalf("Spark quota=%#v", window)
+					}
+				}
+				if window.Label != "" || window.Scope != "" || window.Unit != "" {
+					t.Fatalf("passive event rewrites presentation: %#v", window)
+				}
+			}
+			if account != test.accountCount || spark != 2 {
+				t.Fatalf("account=%d spark=%d", account, spark)
+			}
+		})
+	}
+}
+
+func TestWebsocketQuotaKeepsExplicitSourceAndExistingConversions(t *testing.T) {
+	observedAt := time.Unix(1000, 0)
+	windows := NormalizeWebsocketQuotaWindows([]byte(`{
+		"type":"codex.rate_limits","metered_limit_name":"CODEX-BENGALFOX",
+		"rate_limits":{"allowed":false,"secondary":{"used_percent":1,"window_minutes":10080,
+			"reset_at":-1,"reset_after_seconds":60}}
+	}`), observedAt)
+	if len(windows) != 1 || windows[0].SourceID != "codex_bengalfox" ||
+		*windows[0].Used != 1 || *windows[0].Remaining != 99 || *windows[0].Utilization != .01 ||
+		*windows[0].WindowSeconds != 604800 || *windows[0].ResetAtMS != 1060000 || windows[0].State != "exhausted" {
+		t.Fatalf("windows=%#v", windows)
+	}
+}
+
+func TestWebsocketQuotaRejectsUnusableOrAmbiguousSignals(t *testing.T) {
+	for _, payload := range []string{
+		`{"type":"response.completed","response":{"usage":{"input_tokens":5}}}`,
+		`{"type":"codex.rate_limits"}`,
+		`{"type":"codex.rate_limits","rate_limits":{"primary":{"used_percent":101,"window_minutes":300}}}`,
+		`{"type":"codex.rate_limits","rate_limits":{"primary":{"used_percent":1,"window_minutes":0}}}`,
+		`{"type":"codex.rate_limits","rate_limits":{"primary":{"used_percent":1}}}`,
+		`{"type":"codex.rate_limits","rate_limits":{"primary":{"used_percent":1,"window_minutes":300}},"additional_rate_limits":{"Unknown":null}}`,
+		`{"type":"codex.rate_limits","rate_limits":{"primary":{"used_percent":1,"window_minutes":300}}} {}`,
+	} {
+		if got := NormalizeWebsocketQuotaWindows([]byte(payload), time.Unix(1000, 0)); len(got) != 0 {
+			t.Fatalf("invalid event produced quota: %s => %#v", payload, got)
+		}
+	}
+}
+
+func TestWebsocketQuotaDropsMeteredCopyEvenWhenSlotsDiffer(t *testing.T) {
+	windows := NormalizeWebsocketQuotaWindows([]byte(`{
+		"type":"codex.rate_limits",
+		"rate_limits":{"primary":{"used_percent":5,"window_minutes":10080,"reset_at":1800000000}},
+		"additional_rate_limits":{"Spark":{"secondary":{"used_percent":5,"window_minutes":10080,"reset_at":1800000000}}}
+	}`), time.Unix(1000, 0))
+	if len(windows) != 1 || windows[0].SourceID != "" || windows[0].SourceName != "Spark" {
+		t.Fatalf("metered copy reached the account pool: %#v", windows)
+	}
+}

--- a/internal/subscription/providers/observation/snapshot.go
+++ b/internal/subscription/providers/observation/snapshot.go
@@ -42,7 +42,9 @@ type AccountSummary struct {
 
 type QuotaWindow struct {
 	// SourceID 是提供方的额度来源标识，不是展示名称或请求模型。
-	SourceID      string   `json:"source_id,omitempty"`
+	SourceID string `json:"source_id,omitempty"`
+	// SourceName 仅用于 Codex WS 观测中尚未解析的上游额度名称，不持久化或对外返回。
+	SourceName    string   `json:"-"`
 	ID            string   `json:"id"`
 	Label         string   `json:"label"`
 	LabelKey      string   `json:"label_key,omitempty"`

--- a/third_party/cpaembedded/embedded/codex_websocket.go
+++ b/third_party/cpaembedded/embedded/codex_websocket.go
@@ -38,6 +38,9 @@ type CodexWSSessionOptions struct {
 	MaxRequestBytes int
 	MaxEventBytes   int
 	Headers         http.Header
+	// ObserveHeaders 在事件之前交付握手头，在结束前交付失败响应头。
+	// 回调须及时返回，不等待本轮结束。
+	ObserveHeaders func(http.Header, time.Time)
 }
 
 // CodexWSTurnResult 只描述本轮执行，不执行健康、额度或日志记账。
@@ -122,7 +125,8 @@ func NewCodexWSSession(options CodexWSSessionOptions) (*CodexWSSession, error) {
 	session := &CodexWSSession{
 		auth: auth, id: codexWSSessionIDPrefix + uuid.NewString(), options: options, closeDone: make(chan struct{}),
 		inner: internalexecutor.NewCodexWebsocketsExecutor(&internalconfig.Config{
-			Codex: internalconfig.CodexConfig{ModelLevelCooling: true},
+			// 不启用 SDK 的启动缓冲，确保 ExecuteStream 先返回握手，再交付原生事件。
+			Codex: internalconfig.CodexConfig{ModelLevelCooling: true, StreamBootstrapBuffering: false},
 		}),
 	}
 	session.resource = &codexWSResource{session: session}
@@ -202,18 +206,30 @@ func (s *CodexWSSession) ExecuteTurn(ctx context.Context, payload json.RawMessag
 		result: &result, maxBytes: s.options.MaxEventBytes, emit: emit, cancel: cancel,
 		failSession: func() { s.invalidate(false) },
 	}
+	headersReady := make(chan struct{})
 	stream, executionErr := s.inner.ExecuteStream(turnCtx, s.auth, cliproxyexecutor.Request{
 		Model: model, Payload: append([]byte(nil), payload...), Format: sdktranslator.FormatOpenAIResponse,
 	}, cliproxyexecutor.Options{
 		Stream: true, Headers: normalizedCodexHeaders(s.options.Headers), SourceFormat: sdktranslator.FormatOpenAIResponse, ResponseFormat: sdktranslator.FormatOpenAIResponse,
 		Metadata:           map[string]any{cliproxyexecutor.ExecutionSessionMetadataKey: s.id},
-		ExecutionLifecycle: s.resource, WebSocketResponseObserver: observation.observe,
+		ExecutionLifecycle: s.resource,
+		WebSocketResponseObserver: func(ctx context.Context, event cliproxyexecutor.WebSocketResponseEvent) {
+			// SDK 的读取协程可先于 ExecuteStream 返回运行；握手交接完成前不交付事件。
+			<-headersReady
+			observation.observe(ctx, event)
+		},
 	})
 	if stream != nil {
 		result.Headers = stream.Headers.Clone()
 		if len(result.Headers) > 0 {
 			result.HeaderObservedAt = time.Now()
+			if s.options.ObserveHeaders != nil {
+				s.options.ObserveHeaders(result.Headers.Clone(), result.HeaderObservedAt)
+			}
 		}
+	}
+	close(headersReady)
+	if stream != nil {
 		// 原生 JSON 由 observer 交付。排空 SDK 的转换输出，确保单轮收尾完成。
 		for chunk := range stream.Chunks {
 			if chunk.Err != nil && executionErr == nil {
@@ -254,6 +270,9 @@ func (s *CodexWSSession) ExecuteTurn(ctx context.Context, payload json.RawMessag
 			result.Headers = headers.Headers().Clone()
 			if len(result.Headers) > 0 {
 				result.HeaderObservedAt = time.Now()
+				if s.options.ObserveHeaders != nil {
+					s.options.ObserveHeaders(result.Headers.Clone(), result.HeaderObservedAt)
+				}
 			}
 		}
 		// SDK 请求预处理失败且未接触上游时，不破坏已有连接。

--- a/third_party/cpaembedded/embedded/codex_websocket_test.go
+++ b/third_party/cpaembedded/embedded/codex_websocket_test.go
@@ -213,7 +213,20 @@ func TestCodexWSSessionContinuationAndIsolation(t *testing.T) {
 	defer server.Close()
 	session := wsTestSession(t, server.URL)
 	events := 0
+	headerCalls := 0
+	var headerAt time.Time
+	session.options.ObserveHeaders = func(headers http.Header, observedAt time.Time) {
+		if events != 0 || observedAt.IsZero() || headers.Get("X-Codex-Test") != "handshake" {
+			t.Error("handshake was not delivered before events with its original time")
+		}
+		headerCalls++
+		headerAt = observedAt
+		headers.Set("X-Codex-Test", "caller mutation")
+	}
 	consume := func(ctx context.Context, event json.RawMessage) error {
+		if headerCalls != 1 {
+			t.Error("event overtook handshake delivery")
+		}
 		if !json.Valid(event) {
 			t.Error("event is not native JSON")
 		}
@@ -237,7 +250,8 @@ func TestCodexWSSessionContinuationAndIsolation(t *testing.T) {
 	if second.ResponseID == first.ResponseID || events != 2 || connections.Load() != 1 {
 		t.Fatal("turns did not reuse one connection")
 	}
-	if first.Headers.Get("X-Codex-Test") == "" || second.Headers.Get("X-Codex-Test") != "" {
+	if first.Headers.Get("X-Codex-Test") != "handshake" || !first.HeaderObservedAt.Equal(headerAt) ||
+		len(second.Headers) != 0 || !second.HeaderObservedAt.IsZero() || headerCalls != 1 {
 		t.Fatal("handshake headers were lost or reused as fresh observation")
 	}
 	other := wsTestSession(t, server.URL)


### PR DESCRIPTION
### 关联 Issue / Related Issue
<!-- 请填写此 PR 关联的 issue 编号，例如：Closes #123 / Please link the issue number, e.g., Closes #123 -->
无关联 Issue。

### 变更内容 / Change Content
<!-- 请简要描述本次变更的核心内容 / Please briefly describe the core changes of this PR -->
- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

<!-- 请在下方详细描述你的变更 / Please describe your changes in detail below -->
Codex 复用 WebSocket 连接时，后续轮次没有新的握手响应头，额度卡片因此可能长期停留在旧值。本 PR 在 `codex.rate_limits` 事件到达时记录可确认来源的额度，复用现有异步保存与运行时投影。

- 范围仅限 Codex WS 被动额度采集，保留现有 HTTP 额度解析、来源识别与去重规则。
- WS 握手响应头先于原生事件交付；待写数据保留同一连接的握手和最新事件各自的观测时间，分别核对新旧后再条件写入，避免部分事件挤掉握手额度或旧握手覆盖主动刷新。
- WS 附加额度使用上游原始名称，在同一凭据的已有快照中按名称和实际周期唯一解析 `SourceID`。同名候选缺少来源标识时也按歧义处理。
- 来源解析完成后，按实际目标窗口去重。同来源、同周期的顶层副本让位于具名额度；数值差异不影响优先级，不同来源即使数值相同也各自保留。
- 有附加额度却缺少来源标识的顶层数据会被跳过，不再根据百分比或重置时间猜测归属，避免 Spark 覆盖普通账号额度。
- 保留旧观测不能覆盖新观测、目标身份校验、未知窗口不创建、有效重复观测推进同步时间等既有行为。

**行为边界：** 实测部分普通 WS 事件也没有顶层来源标识。这类报文中的具名附加额度仍可更新，但无来源的普通窗口保留上次数据，需要手动同步或后续收到可确认来源的数据；本 PR 未增加主动查询兜底。

**验证：** `make check`、嵌入式 CPA 模块的测试、`go vet` 与依赖一致性检查均通过。回归覆盖脱敏 HTTP/WS 实测样本、连续 WS 轮次、来源缺失且重置时间不同、不同来源数值相同、同来源副本数值不同、名称候选缺少来源标识，以及额度与重置时间的保存。另覆盖握手与事件在轮内或轮后写入、主动刷新介于两份样本之间、毫秒时间相同、同窗口被新事件更新、未知事件不推进同步时间及 HTTP 保持整份替换。带额度握手采用构造样本验证，既有实测握手未携带额度字段。实测样本仅包含额度字段，不含账号身份或凭据。

**兼容性：** 无数据库迁移、无管理 API 字段变化、无新增依赖。`SourceName` 为仅用于 WS 匹配的内存字段，不持久化或对外返回。无需变更公开配置文档，本次未修改公开文档。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [ ] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.
