### PR TITLE
fix(cpa): 保留 Codex 和 Grok 的中途系统指令

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/nicksnyder/go-i18n/v2 v2.6.1
 	github.com/router-for-me/CLIProxyAPI/v7/gptload-embedded v0.0.0
 	github.com/sirupsen/logrus v1.10.2
+	github.com/tidwall/gjson v1.19.0
+	github.com/tidwall/sjson v1.2.5
 	go.uber.org/dig v1.19.0
 	golang.org/x/crypto v0.56.0
 	golang.org/x/net v0.58.0
@@ -103,10 +105,8 @@ require (
 	github.com/savsgio/gotils v0.0.0-20250408102913-196191ec6287 // indirect
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
-	github.com/tidwall/gjson v1.19.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
-	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/tiktoken-go/tokenizer v0.8.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect

--- a/internal/execution/cpa/adapter.go
+++ b/internal/execution/cpa/adapter.go
@@ -112,8 +112,9 @@ func (a *Adapter) Execute(ctx context.Context, spec execution.AttemptSpec) (resu
 	if err != nil {
 		return unaryNotSent(execution.ErrorKindInvalidRequest, "unsupported subscription request", "", err)
 	}
-	if evidence := convertedInstructionFailure(spec, provider.ProviderKind()); evidence != nil {
-		return execution.AttemptResult{DispatchState: execution.DispatchNotSent, Error: evidence}
+	spec, instructionFailure := prepareConvertedInstructions(spec, provider.ProviderKind())
+	if instructionFailure != nil {
+		return execution.AttemptResult{DispatchState: execution.DispatchNotSent, Error: instructionFailure}
 	}
 	proxySettings, err := proxySettingsForAttempt(spec.Proxy)
 	if err != nil {
@@ -284,8 +285,9 @@ func (a *Adapter) ExecuteStream(
 	if countTokensOperation(spec.Operation) {
 		return streamNotSent(execution.ErrorKindInvalidRequest, "count tokens does not support streaming", "")
 	}
-	if evidence := convertedInstructionFailure(spec, provider.ProviderKind()); evidence != nil {
-		return execution.StreamResult{DispatchState: execution.DispatchNotSent, Error: evidence}
+	spec, instructionFailure := prepareConvertedInstructions(spec, provider.ProviderKind())
+	if instructionFailure != nil {
+		return execution.StreamResult{DispatchState: execution.DispatchNotSent, Error: instructionFailure}
 	}
 	proxySettings, err := proxySettingsForAttempt(spec.Proxy)
 	if err != nil {

--- a/internal/execution/cpa/conversion_fidelity.go
+++ b/internal/execution/cpa/conversion_fidelity.go
@@ -1,29 +1,48 @@
 package cpa
 
 import (
+	"strconv"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
 	"gpt-load/internal/channel"
 	"gpt-load/internal/dialect"
 	"gpt-load/internal/execution"
 	"gpt-load/internal/protocol"
 )
 
-func convertedInstructionFailure(spec execution.AttemptSpec, providerKind channel.ProviderKind) *execution.ErrorEvidence {
+func prepareConvertedInstructions(spec execution.AttemptSpec, providerKind channel.ProviderKind) (execution.AttemptSpec, *execution.ErrorEvidence) {
 	if spec.RouteMode != execution.RouteConverted ||
-		(spec.Operation != execution.OperationChatCompletion && spec.Operation != execution.OperationResponsesCreate) ||
-		dialect.CountMidConversationSystemMessages(spec.ClientProtocol, spec.Body) == 0 {
-		return nil
+		(spec.Operation != execution.OperationChatCompletion && spec.Operation != execution.OperationResponsesCreate) {
+		return spec, nil
+	}
+	if (providerKind == channel.ProviderCodex || providerKind == channel.ProviderGrok) && spec.ClientProtocol == protocol.Anthropic {
+		// 两个渠道共用 Codex 转换器；先映射角色，避免 CPA 将 system 降为 user 提醒并移动位置。
+		for index, message := range gjson.GetBytes(spec.Body, "messages").Array() {
+			if message.Get("role").String() != "system" {
+				continue
+			}
+			body, err := sjson.SetBytes(spec.Body, "messages."+strconv.Itoa(index)+".role", "developer")
+			if err != nil {
+				return spec, notSentEvidence(execution.ErrorKindInvalidRequest,
+					"cannot preserve subscription system instructions", "invalid_subscription_instructions")
+			}
+			spec.Body = body
+		}
+		return spec, nil
+	}
+	if dialect.CountMidConversationSystemMessages(spec.ClientProtocol, spec.Body) == 0 {
+		return spec, nil
 	}
 	lossy := false
 	switch providerKind {
 	case channel.ProviderClaude, channel.ProviderAntigravity:
 		lossy = true
-	case channel.ProviderCodex, channel.ProviderGrok:
-		// CPA 的 Claude 转换器把中途 system 包成 user；OpenAI 输入能原位映射为 developer。
-		lossy = spec.ClientProtocol == protocol.Anthropic
 	}
 	if !lossy {
-		return nil
+		return spec, nil
 	}
-	return notSentEvidence(execution.ErrorKindConversionUnsupported,
+	return spec, notSentEvidence(execution.ErrorKindConversionUnsupported,
 		"conversion cannot preserve mid-conversation system instructions", execution.ErrorCodeCriticalSemanticLoss)
 }

--- a/internal/execution/cpa/conversion_fidelity.go
+++ b/internal/execution/cpa/conversion_fidelity.go
@@ -14,7 +14,8 @@ import (
 
 func prepareConvertedInstructions(spec execution.AttemptSpec, providerKind channel.ProviderKind) (execution.AttemptSpec, *execution.ErrorEvidence) {
 	if spec.RouteMode != execution.RouteConverted ||
-		(spec.Operation != execution.OperationChatCompletion && spec.Operation != execution.OperationResponsesCreate) {
+		(spec.Operation != execution.OperationChatCompletion && spec.Operation != execution.OperationResponsesCreate &&
+			spec.Operation != execution.OperationCountTokens) {
 		return spec, nil
 	}
 	if (providerKind == channel.ProviderCodex || providerKind == channel.ProviderGrok) && spec.ClientProtocol == protocol.Anthropic {
@@ -32,7 +33,8 @@ func prepareConvertedInstructions(spec execution.AttemptSpec, providerKind chann
 		}
 		return spec, nil
 	}
-	if dialect.CountMidConversationSystemMessages(spec.ClientProtocol, spec.Body) == 0 {
+	if spec.Operation == execution.OperationCountTokens ||
+		dialect.CountMidConversationSystemMessages(spec.ClientProtocol, spec.Body) == 0 {
 		return spec, nil
 	}
 	lossy := false

--- a/internal/execution/cpa/conversion_fidelity_test.go
+++ b/internal/execution/cpa/conversion_fidelity_test.go
@@ -195,11 +195,79 @@ func TestAdapterPreservesAnthropicInstructionsOnResponsesTargets(t *testing.T) {
 					"input.6.content.0.text": "<system-reminder>ordinary reminder</system-reminder>",
 					"input.7.call_id":        "call_lookup", "input.7.name": "lookup",
 					"input.8.content.0.text": "DURING_TOOL", "input.9.call_id": "call_lookup",
+					"input.9.output":          "tool result",
 					"input.10.content.0.text": "next", "reasoning.effort": "high",
 				} {
 					if got := gjson.GetBytes(wire, path).String(); got != want {
 						t.Errorf("upstream %s = %q, want %q", path, got, want)
 					}
+				}
+			})
+		}
+	}
+}
+
+func TestAdapterTokenCountPreservesAnthropicInstructions(t *testing.T) {
+	for _, target := range []struct {
+		channel channel.ID
+		model   string
+	}{
+		{channel.Codex, "gpt-5.6-luna"},
+		{channel.Grok, "grok-4.3"},
+	} {
+		for _, input := range []struct {
+			name    string
+			content string
+		}{
+			{"string", `"Always answer in Chinese"`},
+			{"blocks", `[{"type":"text","text":"Use Chinese"},{"type":"text","text":"Keep the answer concise"}]`},
+		} {
+			t.Run(fmt.Sprintf("%s/%s", target.channel, input.name), func(t *testing.T) {
+				adapter := NewAdapter(nil, channel.NewRegistry())
+				preparer := &fakeCredentialPreparer{evidence: &execution.ErrorEvidence{
+					Kind: execution.ErrorKindInternal, Summary: "local token count must not prepare credentials",
+				}}
+				adapter.credentials = preparer
+				count := func(role string) int64 {
+					t.Helper()
+					body := []byte(fmt.Sprintf(`{
+						"model":%q,"system":"GLOBAL",
+						"messages":[
+							{"role":%q,"content":"PREFIX"},
+							{"role":"user","content":"hello"},
+							{"role":"assistant","content":"ok"},
+							{"role":%q,"content":%s},
+							{"role":"user","content":"<system-reminder>ordinary reminder</system-reminder>"}
+						]
+					}`, target.model, role, role, input.content))
+					spec := execution.NewAttemptSpec(execution.AttemptSpec{
+						RequestID: "count-instructions", AttemptID: "count-instructions-1", Sequence: 1,
+						ChannelID: string(target.channel), RouteMode: execution.RouteConverted,
+						ClientProtocol: protocol.Anthropic, Operation: execution.OperationCountTokens,
+						ClientModel: target.model, UpstreamModel: target.model,
+						Method: http.MethodPost, Path: "/v1/messages/count_tokens", Body: body,
+						Credential: execution.NewCredentialSnapshot(1, 1, 1, []byte(`{}`)),
+					})
+					result := adapter.Execute(t.Context(), spec)
+					if result.Error != nil {
+						t.Fatalf("count instructions: %+v", result.Error)
+					}
+					if preparer.calls != 0 || result.Header.Get(localTokenCountHeader) != "local-estimate" {
+						t.Fatal("token count did not use the local estimator")
+					}
+					if !bytes.Equal(spec.Body, body) {
+						t.Fatal("token count changed the original request")
+					}
+					tokens := gjson.GetBytes(result.Body, "input_tokens").Int()
+					if tokens <= 0 {
+						t.Fatalf("invalid token count: %s", result.Body)
+					}
+					return tokens
+				}
+				// 执行请求以 developer 原位发送指令，计数必须采用同一个提示。
+				want := count("developer")
+				if got := count("system"); got != want {
+					t.Fatalf("system token count = %d, executed developer prompt count = %d", got, want)
 				}
 			})
 		}

--- a/internal/execution/cpa/conversion_fidelity_test.go
+++ b/internal/execution/cpa/conversion_fidelity_test.go
@@ -1,14 +1,24 @@
 package cpa
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"reflect"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/tidwall/gjson"
 
 	"gpt-load/internal/channel"
 	"gpt-load/internal/execution"
 	"gpt-load/internal/protocol"
+	"gpt-load/internal/subscription/providers/grok"
+	subscriptionruntime "gpt-load/internal/subscription/runtime"
 )
 
 func TestAdapterRejectsOnlyLossyMidConversationInstructions(t *testing.T) {
@@ -16,9 +26,6 @@ func TestAdapterRejectsOnlyLossyMidConversationInstructions(t *testing.T) {
 	for _, channelID := range []channel.ID{channel.Codex, channel.Grok, channel.Claude, channel.Antigravity} {
 		for _, clientProtocol := range []protocol.Protocol{protocol.OpenAICompletions, protocol.OpenAIResponses, protocol.Anthropic} {
 			for _, role := range []string{"system", "developer", "user"} {
-				if role == "developer" && clientProtocol == protocol.Anthropic {
-					continue
-				}
 				for _, stream := range []bool{false, true} {
 					t.Run(fmt.Sprintf("%s/%s/%s/stream=%t", channelID, clientProtocol, role, stream), func(t *testing.T) {
 						registry := channel.NewRegistry()
@@ -71,7 +78,7 @@ func TestAdapterRejectsOnlyLossyMidConversationInstructions(t *testing.T) {
 							evidence = adapter.Execute(t.Context(), spec).Error
 						}
 						wantRejected := role != "user" && mode == execution.RouteConverted &&
-							(channelID == channel.Claude || channelID == channel.Antigravity || clientProtocol == protocol.Anthropic)
+							(channelID == channel.Claude || channelID == channel.Antigravity)
 						if wantRejected {
 							if preparer.calls != 0 || evidence == nil || evidence.Kind != execution.ErrorKindConversionUnsupported ||
 								evidence.Code != execution.ErrorCodeCriticalSemanticLoss {
@@ -83,6 +90,118 @@ func TestAdapterRejectsOnlyLossyMidConversationInstructions(t *testing.T) {
 					})
 				}
 			}
+		}
+	}
+}
+
+func TestAdapterPreservesAnthropicInstructionsOnResponsesTargets(t *testing.T) {
+	for _, channelID := range []channel.ID{channel.Codex, channel.Grok} {
+		for _, stream := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/stream=%t", channelID, stream), func(t *testing.T) {
+				model := "gpt-5.6-luna"
+				canonical := credentialJSON("access", "refresh", time.Now().Add(time.Hour))
+				if channelID == channel.Grok {
+					model = "grok-4.3"
+					var err error
+					canonical, err = grok.MarshalCredential(grok.Credential{
+						Type: grok.Provider, AccessToken: "access", RefreshToken: "refresh", AccountID: "xai-account",
+						Email: "grok@example.com", Expire: "2030-01-01T00:00:00Z", TokenEndpoint: "https://auth.x.ai/oauth/token",
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+				adapter := NewAdapter(nil, channel.NewRegistry())
+				adapter.credentials = &fakeCredentialPreparer{credential: subscriptionruntime.NewCredential(
+					canonical, "instruction-account", subscriptionruntime.Account{}, time.Time{}, false, nil,
+				)}
+				body := []byte(fmt.Sprintf(`{
+					"model":%q,"max_tokens":64,"stream":%t,
+					"system":[{"type":"text","text":"GLOBAL"}],
+					"thinking":{"type":"adaptive"},"output_config":{"effort":"high"},
+					"messages":[
+						{"role":"system","content":"PREFIX"},
+						{"role":"user","content":"start"},
+						{"role":"assistant","content":"first"},
+						{"role":"system","content":[{"type":"text","text":"MID_ONE"},{"type":"text","text":"MID_TWO"}]},
+						{"role":"developer","content":"EXISTING_DEVELOPER"},
+						{"role":"user","content":"<system-reminder>ordinary reminder</system-reminder>"},
+						{"role":"assistant","content":[{"type":"tool_use","id":"call_lookup","name":"lookup","input":{"query":"hello"}}]},
+						{"role":"system","content":"DURING_TOOL"},
+						{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_lookup","content":"tool result"}]},
+						{"role":"user","content":"next"}
+					],
+					"tools":[{"name":"lookup","input_schema":{"type":"object","properties":{"query":{"type":"string"}}}}]
+				}`, model, stream))
+				spec := execution.NewAttemptSpec(execution.AttemptSpec{
+					RequestID: "instruction-request", AttemptID: "instruction-attempt", Sequence: 1,
+					ChannelID: string(channelID), RouteMode: execution.RouteConverted,
+					ClientProtocol: protocol.Anthropic, Operation: execution.OperationChatCompletion,
+					ClientModel: model, UpstreamModel: model, Method: http.MethodPost, Path: "/v1/messages",
+					Body: body, Credential: execution.NewCredentialSnapshot(1, 1, 1, canonical),
+				})
+				wireBodies := make(chan []byte, 1)
+				transport := roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+					wire, err := io.ReadAll(request.Body)
+					if err != nil {
+						return nil, err
+					}
+					select {
+					case wireBodies <- wire:
+					default:
+						return nil, fmt.Errorf("unexpected repeated upstream request")
+					}
+					return &http.Response{
+						StatusCode: http.StatusOK, Header: http.Header{"Content-Type": {"text/event-stream"}},
+						Body:    io.NopCloser(strings.NewReader(`data: {"type":"response.completed","response":{"id":"resp_instructions","object":"response","status":"completed","model":"` + model + `","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}` + "\n\n")),
+						Request: request,
+					}, nil
+				})
+				ctx := context.WithValue(t.Context(), "cliproxy.roundtripper", http.RoundTripper(transport))
+				var evidence *execution.ErrorEvidence
+				if stream {
+					evidence = adapter.ExecuteStream(ctx, spec, func(execution.StreamEvent) error { return nil }).Error
+				} else {
+					evidence = adapter.Execute(ctx, spec).Error
+				}
+				if evidence != nil {
+					t.Fatalf("instruction conversion failed: %+v", evidence)
+				}
+				if !bytes.Equal(spec.Body, body) {
+					t.Fatal("conversion changed the original request used by other attempts")
+				}
+				var wire []byte
+				select {
+				case wire = <-wireBodies:
+				default:
+					t.Fatal("request did not reach the upstream transport")
+				}
+				var order []string
+				for _, item := range gjson.GetBytes(wire, "input").Array() {
+					role := item.Get("role").String()
+					if role == "" {
+						role = item.Get("type").String()
+					}
+					order = append(order, role)
+				}
+				wantOrder := []string{"developer", "developer", "user", "assistant", "developer", "developer", "user", "function_call", "developer", "function_call_output", "user"}
+				if !reflect.DeepEqual(order, wantOrder) {
+					t.Fatalf("upstream message order = %v, want %v", order, wantOrder)
+				}
+				for path, want := range map[string]string{
+					"input.0.content.0.text": "GLOBAL", "input.1.content.0.text": "PREFIX",
+					"input.4.content.0.text": "MID_ONE", "input.4.content.1.text": "MID_TWO",
+					"input.5.content.0.text": "EXISTING_DEVELOPER",
+					"input.6.content.0.text": "<system-reminder>ordinary reminder</system-reminder>",
+					"input.7.call_id":        "call_lookup", "input.7.name": "lookup",
+					"input.8.content.0.text": "DURING_TOOL", "input.9.call_id": "call_lookup",
+					"input.10.content.0.text": "next", "reasoning.effort": "high",
+				} {
+					if got := gjson.GetBytes(wire, path).String(); got != want {
+						t.Errorf("upstream %s = %q, want %q", path, got, want)
+					}
+				}
+			})
 		}
 	}
 }


### PR DESCRIPTION
### 关联 Issue / Related Issue
暂无关联 Issue；修复 #631 引入的 Anthropic → Codex/Grok 兼容性回归。

### 变更内容 / Change Content
- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

Claude Code 的 Anthropic 请求包含中途 system 消息时，Codex/Grok 路径会在发送前返回 422。现在在调用 CPA 前将消息中的 system 映射为 developer，保留指令内容和会话位置，允许这类请求正常转换。

- 统一聊天与本地 token 计数的指令映射，覆盖流式和非流式请求；已有 developer、顶层 system、普通 user 提醒及原始请求不被改写。
- 保留其他渠道的有损转换拒绝规则，以及工具约束和 DeepSeek 思考检查。
- 补充实际出站内容的回归测试，验证多段指令、工具调用与结果的顺序及内容、思考配置、请求隔离，以及本地计数与执行提示的一致性。已有 gjson/sjson 依赖调整为直接依赖，版本不变。

验证：
- `make check` 通过。
- `third_party/cpaembedded` 中 `go test -count=1 ./...` 通过。
- 新增回归用例在修复前复现同一拒绝错误，修复后通过。
- 用户实测确认：Claude Code 使用 Anthropic 协议请求 Codex 账号的 GPT 模型正常。Grok 已通过自动化出站验证，未做真实账号联调。

兼容性：不新增配置或数据库迁移。本次未更新公开文档或发布说明。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [ ] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.
