### PR TITLE
fix(codex): 用 workspace+user 作为凭据身份，避免同 workspace 不同用户被判重

### DIFF
--- a/internal/state/loader/credential_identity_migration_test.go
+++ b/internal/state/loader/credential_identity_migration_test.go
@@ -1,0 +1,228 @@
+package loader_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"gpt-load/internal/channel"
+	"gpt-load/internal/platform/encryption"
+	"gpt-load/internal/state"
+	stateloader "gpt-load/internal/state/loader"
+	"gpt-load/internal/storage/models"
+)
+
+// codexLegacyTestCredential 构造一份 Codex 凭据：id_token 里同时带 workspace 与 user，
+// 这正是「同一 workspace 下不同用户」的形态。
+func codexLegacyTestCredential(t *testing.T, accountID, userID, refreshToken string) string {
+	t.Helper()
+	encode := func(value any) string {
+		raw, err := json.Marshal(value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return base64.RawURLEncoding.EncodeToString(raw)
+	}
+	idToken := encode(map[string]string{"alg": "RS256", "typ": "JWT"}) + "." +
+		encode(map[string]any{
+			"https://api.openai.com/auth": map[string]string{
+				"chatgpt_account_id": accountID,
+				"chatgpt_user_id":    userID,
+			},
+		}) + ".signature"
+	raw, err := json.Marshal(map[string]string{
+		"type":          "codex",
+		"access_token":  "access-" + userID,
+		"refresh_token": refreshToken,
+		"account_id":    accountID,
+		"email":         userID + "@example.com",
+		"id_token":      idToken,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(raw)
+}
+
+// 升级到「身份含 user 维度」的版本后，既有行的 identity_fingerprint 必须在加载期被
+// 重写为当前身份定义计算出的值：
+//   - 凭据数据本身的 fingerprint 不能变（canonical 形状是它的契约）；
+//   - 迁移必须幂等，第二次加载不得再写库。
+func TestLoadMigratesCredentialIdentityFingerprintFromWorkspaceOnly(t *testing.T) {
+	t.Parallel()
+
+	db := openMigratedDatabase(t)
+	group := models.Group{
+		Name: "codex-identity-migration", ChannelID: string(channel.Codex),
+		ConnectionType: models.ConnectionTypeSubscription,
+		Params:         models.JSON(`{}`), Models: models.JSON(`[]`),
+		Overrides: models.JSON(`{}`), Enabled: true,
+	}
+	mustCreate(t, db, &group)
+
+	service, err := encryption.NewService("identity-migration-master-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const (
+		workspace = "70a31b69-2c1a-4469-9e7c-3935a96e3865"
+		userID    = "user-AAAA"
+	)
+	credential := codexLegacyTestCredential(t, workspace, userID, "refresh-legacy")
+	channels, subscriptions := testSubscriptionRuntime(t)
+	// 数据指纹是 canonical 之后的哈希，这里必须先规范化再算，才能模拟旧版本写下的行。
+	canonical, err := subscriptions.CanonicalCredential(channel.Codex, []byte(credential))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ciphertext, err := service.Encrypt(credential)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 旧版本的身份只取 workspace，因此旧指纹是按纯 workspace 身份算出来的。
+	legacyIdentity := workspace
+	legacyFingerprint := service.Hash("credential-identity/v1|codex|codex|" + legacyIdentity)
+	if legacyFingerprint == "" {
+		t.Fatal("legacy fingerprint is empty")
+	}
+	row := models.Credential{
+		GroupID: group.ID, Data: ciphertext,
+		Fingerprint:         service.Hash(string(canonical)),
+		IdentityFingerprint: legacyFingerprint,
+		SecretVersion:       1,
+		AuthState:           models.CredentialAuthStateReady,
+		Status:              models.CredentialStatusActive,
+	}
+	mustCreate(t, db, &row)
+
+	if err := stateloader.NewWithCredentialValidation(
+		db, state.NewManager(), state.NewCredentialRegistry(), channels, subscriptions, service,
+	).Load(t.Context()); err != nil {
+		t.Fatalf("Load() with legacy identity fingerprint = %v, want success", err)
+	}
+
+	var migrated models.Credential
+	if err := db.First(&migrated, row.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	wantFingerprint := service.Hash("credential-identity/v1|codex|codex|" + workspace + "/" + userID)
+	if migrated.IdentityFingerprint != wantFingerprint {
+		t.Fatalf("identity fingerprint = %q, want %q", migrated.IdentityFingerprint, wantFingerprint)
+	}
+	// canonical 形状未变 -> 数据指纹必须原样保留，否则既有凭据会全部校验失败。
+	if migrated.Fingerprint != row.Fingerprint {
+		t.Fatalf("credential fingerprint changed: %q -> %q", row.Fingerprint, migrated.Fingerprint)
+	}
+	if migrated.SecretVersion != row.SecretVersion {
+		t.Fatalf("secret version changed: %d -> %d", row.SecretVersion, migrated.SecretVersion)
+	}
+
+	// 幂等：第二次加载不应再产生差异，也不应报错。
+	if err := stateloader.NewWithCredentialValidation(
+		db, state.NewManager(), state.NewCredentialRegistry(), channels, subscriptions, service,
+	).Load(t.Context()); err != nil {
+		t.Fatalf("second Load() = %v, want success", err)
+	}
+	var afterSecond models.Credential
+	if err := db.First(&afterSecond, row.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if afterSecond.IdentityFingerprint != wantFingerprint {
+		t.Fatalf("second load changed identity fingerprint to %q", afterSecond.IdentityFingerprint)
+	}
+}
+
+// 令牌里没有 user claim 的凭据必须保持旧指纹不变，避免升级时无谓地要求重新授权。
+func TestLoadKeepsWorkspaceIdentityWhenUserClaimIsAbsent(t *testing.T) {
+	t.Parallel()
+
+	db := openMigratedDatabase(t)
+	group := models.Group{
+		Name: "codex-identity-no-user", ChannelID: string(channel.Codex),
+		ConnectionType: models.ConnectionTypeSubscription,
+		Params:         models.JSON(`{}`), Models: models.JSON(`[]`),
+		Overrides: models.JSON(`{}`), Enabled: true,
+	}
+	mustCreate(t, db, &group)
+
+	service, err := encryption.NewService("identity-no-user-master-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const workspace = "770d8f80-b7ad-4062-af19-a0d45a5dc62a"
+	credential := `{"type":"codex","access_token":"access","refresh_token":"refresh","account_id":"` + workspace + `"}`
+	channels, subscriptions := testSubscriptionRuntime(t)
+	canonical, err := subscriptions.CanonicalCredential(channel.Codex, []byte(credential))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ciphertext, err := service.Encrypt(credential)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyFingerprint := service.Hash("credential-identity/v1|codex|codex|" + workspace)
+	row := models.Credential{
+		GroupID: group.ID, Data: ciphertext,
+		Fingerprint:         service.Hash(string(canonical)),
+		IdentityFingerprint: legacyFingerprint,
+		SecretVersion:       1,
+		AuthState:           models.CredentialAuthStateReady,
+		Status:              models.CredentialStatusActive,
+	}
+	mustCreate(t, db, &row)
+
+	if err := stateloader.NewWithCredentialValidation(
+		db, state.NewManager(), state.NewCredentialRegistry(), channels, subscriptions, service,
+	).Load(t.Context()); err != nil {
+		t.Fatalf("Load() = %v, want success", err)
+	}
+	var migrated models.Credential
+	if err := db.First(&migrated, row.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if migrated.IdentityFingerprint != legacyFingerprint {
+		t.Fatalf("identity fingerprint changed without a user claim: %q -> %q",
+			legacyFingerprint, migrated.IdentityFingerprint)
+	}
+}
+
+// 迁移只应在「凭据数据指纹校验通过」之后发生：数据被改动的行必须照旧拒绝启动。
+func TestLoadRejectsTamperedCredentialBeforeIdentityMigration(t *testing.T) {
+	t.Parallel()
+
+	db := openMigratedDatabase(t)
+	group := models.Group{
+		Name: "codex-identity-tampered", ChannelID: string(channel.Codex),
+		ConnectionType: models.ConnectionTypeSubscription,
+		Params:         models.JSON(`{}`), Models: models.JSON(`[]`),
+		Overrides: models.JSON(`{}`), Enabled: true,
+	}
+	mustCreate(t, db, &group)
+	service, err := encryption.NewService("identity-tampered-master-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	credential := codexLegacyTestCredential(t, "ws", "user-AAAA", "refresh-legacy")
+	ciphertext, err := service.Encrypt(credential)
+	if err != nil {
+		t.Fatal(err)
+	}
+	row := models.Credential{
+		GroupID: group.ID, Data: ciphertext,
+		Fingerprint:         service.Hash("a-different-canonical-shape"),
+		IdentityFingerprint: service.Hash("credential-identity/v1|codex|codex|ws"),
+		SecretVersion:       1,
+		AuthState:           models.CredentialAuthStateReady,
+		Status:              models.CredentialStatusActive,
+	}
+	mustCreate(t, db, &row)
+
+	channels, subscriptions := testSubscriptionRuntime(t)
+	err = stateloader.NewWithCredentialValidation(
+		db, state.NewManager(), state.NewCredentialRegistry(), channels, subscriptions, service,
+	).Load(t.Context())
+	if err == nil || !strings.Contains(err.Error(), "fingerprint mismatch") {
+		t.Fatalf("Load() = %v, want credential fingerprint mismatch", err)
+	}
+}

--- a/internal/state/loader/loader.go
+++ b/internal/state/loader/loader.go
@@ -43,6 +43,9 @@ type Loader struct {
 
 type subscriptionCredentialCanonicalizer interface {
 	CanonicalCredential(channel.ID, []byte) ([]byte, error)
+	// CredentialIdentityFingerprintInput 返回身份指纹的哈希输入；ok=false 表示该渠道没有
+	// 可用身份，此时与 control 层一致地不做迁移。
+	CredentialIdentityFingerprintInput(channel.ID, []byte) (string, bool, error)
 }
 
 // NewWithCredentialValidation creates the production loader that verifies
@@ -146,7 +149,7 @@ func (l *Loader) Load(ctx context.Context) error {
 	if err := state.ValidateCredentialEntries(entries); err != nil {
 		return fmt.Errorf("validate credentials: %w", err)
 	}
-	if err := l.validatePersistedCredentials(input, entries); err != nil {
+	if err := l.validatePersistedCredentials(ctx, input, entries); err != nil {
 		return err
 	}
 	if l.accessQuota != nil {
@@ -173,6 +176,24 @@ func (l *Loader) Load(ctx context.Context) error {
 }
 
 func (l *Loader) validatePersistedCredentials(
+	ctx context.Context,
+	input state.CompileInput,
+	entries []state.CredentialEntry,
+) error {
+	return l.validateAndMigrateCredentials(ctx, input, entries)
+}
+
+// validateAndMigrateCredentials 校验每条持久化凭据，并顺带完成一次「身份指纹迁移」。
+//
+// 背景：canonical JSON 的字节形状是 credentials.fingerprint 的契约，因此收紧身份定义时
+// 不能在 canonical 里新增字段（那会让既有凭据全部校验失败、实例无法启动）。身份只在
+// 判定时计算，于是身份定义变化后，既有行的 identity_fingerprint 会过期，而它参与运行期
+// 的凭据目标校验，必须重写。
+//
+// 迁移是幂等的，并且与凭据数据指纹的校验顺序固定为「先验证数据、再迁移身份」：
+// 只有 canonical 未被改动的行才会被迁移，避免把已损坏的数据一并接受下来。
+func (l *Loader) validateAndMigrateCredentials(
+	ctx context.Context,
 	input state.CompileInput,
 	entries []state.CredentialEntry,
 ) error {
@@ -184,10 +205,12 @@ func (l *Loader) validatePersistedCredentials(
 		connectionType string
 	}
 	targets := make(map[uint]validationTarget, len(input.Groups))
+	groupParams := make(map[uint]json.RawMessage, len(input.Groups))
 	for _, group := range input.Groups {
 		targets[group.ID] = validationTarget{channelID: group.ChannelID, connectionType: group.ConnectionType}
+		groupParams[group.ID] = json.RawMessage(group.Params)
 	}
-	for _, entry := range entries {
+	for index, entry := range entries {
 		target, exists := targets[entry.GroupID]
 		if !exists {
 			return fmt.Errorf("validate credential %d for group %d: execution target is missing", entry.ID, entry.GroupID)
@@ -199,6 +222,9 @@ func (l *Loader) validatePersistedCredentials(
 		raw := []byte(plaintext)
 		plaintext = ""
 		var canonical []byte
+		var identityInput string
+		var identityOK bool
+		var identityErr error
 		expectedConnection, known := l.channelRegistry.ConnectionType(target.channelID)
 		if !known || strings.TrimSpace(target.connectionType) != expectedConnection {
 			clear(raw)
@@ -211,10 +237,20 @@ func (l *Loader) validatePersistedCredentials(
 			}
 			var parseErr error
 			canonical, parseErr = l.subscriptions.CanonicalCredential(target.channelID, raw)
-			clear(raw)
 			if parseErr != nil {
+				clear(raw)
 				return fmt.Errorf("validate credential %d for group %d: stored shape is invalid", entry.ID, entry.GroupID)
 			}
+			// 身份指纹迁移需要凭据内容，必须在 clear(raw) 之前取得哈希输入。
+			identityInput, identityOK, identityErr = l.subscriptions.CredentialIdentityFingerprintInput(target.channelID, raw)
+			if identityErr != nil {
+				clear(raw)
+				clear(canonical)
+				return fmt.Errorf(
+					"derive identity for credential %d in group %d: %w", entry.ID, entry.GroupID, identityErr,
+				)
+			}
+			clear(raw)
 		} else {
 			if expectedConnection != string(models.ConnectionTypeAPIKey) {
 				clear(raw)
@@ -232,8 +268,87 @@ func (l *Loader) validatePersistedCredentials(
 		if subtle.ConstantTimeCompare([]byte(fingerprint), []byte(entry.Fingerprint)) != 1 {
 			return fmt.Errorf("validate credential %d for group %d: fingerprint mismatch", entry.ID, entry.GroupID)
 		}
+		// 凭据数据已确认未被改动，此时才允许做身份指纹迁移。
+		if expectedConnection != string(models.ConnectionTypeSubscription) || l.subscriptions == nil {
+			continue
+		}
+		if !identityOK {
+			// 身份不可用的行沿用既有指纹（与 control 层行为一致），不做迁移。
+			continue
+		}
+		migrated, storedFingerprint, currentFingerprint, migrateErr := l.migrateCredentialIdentity(
+			ctx, entry, identityInput,
+		)
+		if migrateErr != nil {
+			return migrateErr
+		}
+		if migrated {
+			entries[index].IdentityGeneration = CredentialIdentityGeneration(
+				currentFingerprint, string(target.channelID), target.connectionType, groupParams[entry.GroupID],
+			)
+			logrus.WithFields(logrus.Fields{
+				"event":      "startup.credential_identity_migrated",
+				"credential": entry.ID,
+				"group":      entry.GroupID,
+				"channel":    string(target.channelID),
+				"from":       shortFingerprint(storedFingerprint),
+				"to":         shortFingerprint(currentFingerprint),
+			}).Info("subscription credential identity fingerprint migrated")
+		}
 	}
 	return nil
+}
+
+// migrateCredentialIdentity 把一条既有凭据的 identity_fingerprint 重写为当前身份定义
+// 计算出的值。正常情况下是无操作；只有身份定义收紧/变更后才会产生差异。
+//
+// identityInput 是调用方在凭据明文被清零之前取到的哈希输入。
+func (l *Loader) migrateCredentialIdentity(
+	ctx context.Context,
+	entry state.CredentialEntry,
+	identityInput string,
+) (bool, string, string, error) {
+	var row struct{ IdentityFingerprint string }
+	if err := l.db.WithContext(ctx).
+		Model(&models.Credential{}).
+		Select("identity_fingerprint").
+		Where("id = ? AND group_id = ?", entry.ID, entry.GroupID).
+		Take(&row).Error; err != nil {
+		return false, "", "", fmt.Errorf(
+			"read identity fingerprint of credential %d in group %d: %w", entry.ID, entry.GroupID, err,
+		)
+	}
+	stored := row.IdentityFingerprint
+	current := l.encryption.Hash(identityInput)
+	if current == "" || subtle.ConstantTimeCompare([]byte(current), []byte(stored)) == 1 {
+		return false, stored, stored, nil
+	}
+	// 带守卫的更新：仍为那条旧指纹、且数据指纹未变时才写，保证幂等与并发安全。
+	result := l.db.WithContext(ctx).
+		Model(&models.Credential{}).
+		Where("id = ? AND group_id = ? AND identity_fingerprint = ? AND fingerprint = ?",
+			entry.ID, entry.GroupID, stored, entry.Fingerprint).
+		Update("identity_fingerprint", current)
+	if result.Error != nil {
+		return false, stored, "", fmt.Errorf(
+			"migrate identity fingerprint of credential %d in group %d: %w", entry.ID, entry.GroupID, result.Error,
+		)
+	}
+	if result.RowsAffected != 1 {
+		return false, stored, "", fmt.Errorf(
+			"migrate identity fingerprint of credential %d in group %d: credential changed concurrently",
+			entry.ID, entry.GroupID,
+		)
+	}
+	return true, stored, current, nil
+}
+
+// shortFingerprint 只用于日志，避免把完整指纹写进日志。
+func shortFingerprint(value string) string {
+	if len(value) > 12 {
+		return value[:12]
+	}
+	return value
 }
 
 func queryCompileRows(ctx context.Context, db *gorm.DB) (compileRows, error) {

--- a/internal/subscription/providers/codex/codex.go
+++ b/internal/subscription/providers/codex/codex.go
@@ -4,6 +4,7 @@ package codex
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -35,6 +36,14 @@ type Credential struct {
 	Email        string `json:"email,omitempty"`
 	Expire       string `json:"expired,omitempty"`
 	LastRefresh  string `json:"last_refresh,omitempty"`
+	// userID 来自 id_token 内 https://api.openai.com/auth 的 chatgpt_user_id。
+	// 同一 workspace(chatgpt_account_id) 下可以有多个用户，仅用 AccountID 作为身份
+	// 会把它们折叠成同一份凭据（第二份在导入时被判为重复项丢弃）。
+	//
+	// 刻意不参与 JSON 序列化：canonical JSON 的字节形状是 credentials.fingerprint 的
+	// 契约（internal/state/loader 启动时会用 HMAC(canonical) 复核），多一个字段就会让
+	// 既有凭据全部校验失败、实例无法启动。因此该值不落盘，身份判定时从 id_token 现场解析。
+	userID string
 }
 
 // ParseCredentialJSON validates and normalizes one CPA-compatible Codex auth
@@ -423,6 +432,9 @@ func executeRequestToBridge(value ExecuteRequest) cpaembedded.ExecuteRequest {
 	}
 }
 
+// credentialFromBridge 把 CPA 的 Codex 凭据转换为本包的 Credential，是 CPA -> gpt-load
+// 的唯一出口（解析、浏览器授权、刷新、导入都经过它）。
+// 身份所需的 chatgpt_user_id 在这里从 id_token 派生，因为 CPA 的类型不暴露该 claim。
 func credentialFromBridge(value cpaembedded.CodexCredential) Credential {
 	return Credential{
 		Type:         value.Type,
@@ -433,9 +445,51 @@ func credentialFromBridge(value cpaembedded.CodexCredential) Credential {
 		Email:        value.Email,
 		Expire:       value.Expire,
 		LastRefresh:  value.LastRefresh,
+		userID:       codexUserID(value),
 	}
 }
 
+// codexUserID 从 id_token（必要时退回 access_token）里取 chatgpt_user_id。
+// CPA 侧不暴露该 claim，而它已经出现在每个 Codex 令牌里，因此在 gpt-load 这一层
+// 解析，避免改动 third_party/cpaembedded 的桥接契约。
+func codexUserID(value cpaembedded.CodexCredential) string {
+	for _, token := range []string{value.IDToken, value.AccessToken} {
+		if userID := codexTokenUserID(token); userID != "" {
+			return userID
+		}
+	}
+	return ""
+}
+
+type codexJWTClaims struct {
+	Auth struct {
+		ChatGPTUserID string `json:"chatgpt_user_id"`
+	} `json:"https://api.openai.com/auth"`
+}
+
+// codexTokenUserID 解析一个 JWT 的 payload 并返回 chatgpt_user_id；任何格式问题都返回
+// 空串（调用方据此回退到 workspace 身份），不做签名校验 —— 只用于读取本地已持有的令牌。
+func codexTokenUserID(token string) string {
+	parts := strings.Split(strings.TrimSpace(token), ".")
+	if len(parts) != 3 {
+		return ""
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		if payload, err = base64.URLEncoding.DecodeString(parts[1]); err != nil {
+			return ""
+		}
+	}
+	var claims codexJWTClaims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(claims.Auth.ChatGPTUserID)
+}
+
+// credentialToBridge 把本包的 Credential 转换为 CPA 的 Codex 凭据，是 gpt-load -> CPA
+// 的唯一入口。身份用的 userID 是 gpt-load 侧现场解析的派生值，不落盘也不下发给 CPA，
+// 因此这里只透传 CPA 自己认识的字段。
 func credentialToBridge(value Credential) cpaembedded.CodexCredential {
 	return cpaembedded.CodexCredential{
 		Type:         value.Type,

--- a/internal/subscription/providers/codex/driver.go
+++ b/internal/subscription/providers/codex/driver.go
@@ -260,13 +260,41 @@ func (codexModelDiscovery) ID() spec.UtilityID   { return modules.CodexModelDisc
 func (codexQuotaObservation) ID() spec.UtilityID { return modules.CodexQuotaObservation }
 func (codexResetCreditAction) ID() spec.ActionID { return modules.CodexResetCreditAction }
 
+// codexRuntimeCredential 组装运行时凭据：Canonical 用于持久化，身份与展示用的账号信息
+// 由 codexCredentialIdentity 与凭据自身派生。
 func codexRuntimeCredential(value Credential, canonical []byte) subscriptionruntime.Credential {
 	expiresAt, expires := CredentialExpiresAt(value)
 	account := subscriptionruntime.Account{Email: strings.TrimSpace(value.Email), ExpiresAt: expiresAt, ExpiresAtKnown: expires}
 	if refreshed, err := time.Parse(time.RFC3339, strings.TrimSpace(value.LastRefresh)); err == nil {
 		account.LastRefresh, account.LastRefreshKnown = refreshed, true
 	}
-	return subscriptionruntime.NewCredential(canonical, strings.TrimSpace(value.AccountID), account, expiresAt, expires, value.SecretValues())
+	return subscriptionruntime.NewCredential(canonical, codexCredentialIdentity(value), account, expiresAt, expires, value.SecretValues())
 }
 
 var _ subscriptionruntime.BrowserAuthorizationDriver = (*codexDriver)(nil)
+
+// CredentialIdentity 返回一份已解析凭据的稳定账号身份。
+//
+// Codex 的授权单位是 (workspace, user)：同一 workspace 下的不同用户是两份彼此独立的
+// 凭据（各自持有 refresh_token）。只按 workspace(chatgpt_account_id) 取身份会让第二份
+// 凭据在导入时被判定为重复项而静默丢弃。
+//
+// 身份只在判定时计算、不写入 canonical，因此升级不会改变 credentials.fingerprint；
+// 但既有行的 identity_fingerprint 仍需迁移，见 internal/state/loader 的加载期迁移。
+// 令牌里没有 user claim 时回退为纯 workspace 身份。
+func (value Credential) CredentialIdentity() string {
+	return codexCredentialIdentity(value)
+}
+
+func codexCredentialIdentity(value Credential) string {
+	accountID := strings.TrimSpace(value.AccountID)
+	userID := strings.TrimSpace(value.userID)
+	switch {
+	case userID == "":
+		return accountID
+	case accountID == "":
+		return userID
+	default:
+		return accountID + "/" + userID
+	}
+}

--- a/internal/subscription/providers/codex/identity_test.go
+++ b/internal/subscription/providers/codex/identity_test.go
@@ -1,0 +1,136 @@
+package codex
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// codexTestIDToken 构造一个 claims 形状与真实 Codex id_token 一致的令牌。
+func codexTestIDToken(t *testing.T, accountID, userID string) string {
+	t.Helper()
+	encode := func(value any) string {
+		raw, err := json.Marshal(value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return base64.RawURLEncoding.EncodeToString(raw)
+	}
+	header := encode(map[string]string{"alg": "RS256", "typ": "JWT"})
+	payload := encode(map[string]any{
+		"https://api.openai.com/auth": map[string]string{
+			"chatgpt_account_id": accountID,
+			"chatgpt_user_id":    userID,
+		},
+	})
+	return header + "." + payload + ".signature"
+}
+
+func codexTestCredential(t *testing.T, accountID, userID, email, refreshToken string) []byte {
+	t.Helper()
+	raw, err := json.Marshal(map[string]string{
+		"type":          "codex",
+		"access_token":  "access-" + userID,
+		"refresh_token": refreshToken,
+		"account_id":    accountID,
+		"email":         email,
+		"id_token":      codexTestIDToken(t, accountID, userID),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+// runtimeIdentity 走完整链路：解析 -> 规范化 -> 从持久化内容恢复 -> 运行时身份。
+// 同时返回恢复出的凭据与 canonical 内容，供「canonical 形状未变」的断言使用。
+func runtimeIdentity(t *testing.T, raw []byte) (string, Credential, string) {
+	t.Helper()
+	value, err := ParseCredentialJSON(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonical, err := MarshalCredential(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 模拟重新从持久化内容恢复（刷新路径就是这么做的）
+	restored, err := ParseCredentialJSON(canonical)
+	if err != nil {
+		t.Fatalf("canonical export is not parseable: %v", err)
+	}
+	return codexRuntimeCredential(restored, canonical).Identity(), restored, string(canonical)
+}
+
+// TestCodexIdentityDistinguishesUsersWithinOneWorkspace 断言同一 workspace 下的不同用户
+// 得到不同身份，否则第二份凭据会在导入时被判为重复项。
+func TestCodexIdentityDistinguishesUsersWithinOneWorkspace(t *testing.T) {
+	const workspace = "770d8f80-b7ad-4062-af19-a0d45a5dc62a"
+
+	firstIdentity, first, firstCanonical := runtimeIdentity(t, codexTestCredential(t, workspace, "user-AAAA", "first@example.com", "refresh-first"))
+	secondIdentity, second, secondCanonical := runtimeIdentity(t, codexTestCredential(t, workspace, "user-BBBB", "second@example.com", "refresh-second"))
+
+	if firstIdentity == secondIdentity {
+		t.Fatalf("credentials of distinct users collapsed into one identity %q", firstIdentity)
+	}
+	wantFirst := workspace + "/user-AAAA"
+	if firstIdentity != wantFirst {
+		t.Fatalf("identity = %q, want %q", firstIdentity, wantFirst)
+	}
+	if got := second.CredentialIdentity(); got != workspace+"/user-BBBB" {
+		t.Fatalf("identity = %q, want %q", got, workspace+"/user-BBBB")
+	}
+	// canonical 的字节形状是 credentials.fingerprint 的契约：新增身份维度必须不影响它，
+	// 否则升级到本版本时既有凭据会全部 fingerprint mismatch、实例无法启动。
+	for _, canonical := range []string{firstCanonical, secondCanonical} {
+		if strings.Contains(canonical, "user_id") {
+			t.Fatalf("identity leaked into the canonical shape: %s", canonical)
+		}
+	}
+	// 身份必须能从 canonical 复原：刷新路径就是「从 canonical 重新解析」。
+	if first.CredentialIdentity() != firstIdentity {
+		t.Fatalf("identity is not reproducible from canonical: %q -> %q", firstIdentity, first.CredentialIdentity())
+	}
+}
+
+// TestCodexIdentityCollapsesSameUserAndWorkspace 断言同一用户在同一 workspace 的重复授权
+// 仍折叠为同一身份（应当合并而不是并存）。
+func TestCodexIdentityCollapsesSameUserAndWorkspace(t *testing.T) {
+	const workspace = "70a31b69-2c1a-4469-9e7c-3935a96e3865"
+
+	original, _, _ := runtimeIdentity(t, codexTestCredential(t, workspace, "user-AAAA", "owner@example.com", "refresh-one"))
+	reauthorized, _, _ := runtimeIdentity(t, codexTestCredential(t, workspace, "user-AAAA", "owner@example.com", "refresh-two"))
+
+	if original != reauthorized {
+		t.Fatalf("re-authorization of one account produced a new identity: %q -> %q", original, reauthorized)
+	}
+}
+
+// TestCodexIdentityKeepsLegacyWorkspaceIdentity 断言升级前导入的凭据（没有 id_token、
+// Canonical 中也没有 user_id）保持旧的 workspace 身份。
+func TestCodexIdentityKeepsLegacyWorkspaceIdentity(t *testing.T) {
+	legacy := []byte(`{"type":"codex","access_token":"access","refresh_token":"refresh","account_id":"legacy-workspace"}`)
+
+	identity, value, canonical := runtimeIdentity(t, legacy)
+	if identity != "legacy-workspace" {
+		t.Fatalf("legacy identity = %q, want %q", identity, "legacy-workspace")
+	}
+	if value.CredentialIdentity() != "legacy-workspace" {
+		t.Fatalf("legacy credential identity = %q", value.CredentialIdentity())
+	}
+	if strings.Contains(canonical, "user_id") {
+		t.Fatalf("legacy canonical shape changed: %s", canonical)
+	}
+}
+
+// TestCodexIdentityIgnoresTokensWithoutUserClaim 断言令牌缺 user claim 时身份安全回退
+// 到 workspace，不会因为解析失败而报错。
+func TestCodexIdentityIgnoresTokensWithoutUserClaim(t *testing.T) {
+	raw := []byte(`{"type":"codex","access_token":"access","refresh_token":"refresh","account_id":"ws","id_token":"not-a-jwt"}`)
+
+	identity, value, _ := runtimeIdentity(t, raw)
+	if identity != "ws" || value.CredentialIdentity() != "ws" {
+		t.Fatalf("identity = %q / %q, want %q", identity, value.CredentialIdentity(), "ws")
+	}
+}

--- a/internal/subscription/runtime/runtime.go
+++ b/internal/subscription/runtime/runtime.go
@@ -516,6 +516,33 @@ func (runtime *Runtime) CanonicalCredential(channelID channel.ID, raw []byte) ([
 	return credential.Canonical(), nil
 }
 
+// CredentialIdentityFingerprintInput returns the exact string that the control
+// plane hashes into a subscription credential's identity fingerprint.
+//
+// It lives next to the drivers because the prefix contains the driver id, which
+// only the runtime can resolve; startup loaders must reproduce it byte for byte
+// when migrating identity fingerprints written by an older identity definition.
+// It returns ok=false when the channel has no driver or the identity is empty,
+// matching the control plane's behavior of leaving such fingerprints empty.
+func (runtime *Runtime) CredentialIdentityFingerprintInput(
+	channelID channel.ID,
+	raw []byte,
+) (string, bool, error) {
+	driver, ok := runtime.Driver(channelID)
+	if !ok {
+		return "", false, fmt.Errorf("subscription driver for channel %q is unavailable", channelID)
+	}
+	credential, err := driver.Parse(raw)
+	if err != nil {
+		return "", false, err
+	}
+	identity := strings.TrimSpace(credential.Identity())
+	if identity == "" {
+		return "", false, nil
+	}
+	return "credential-identity/v1|" + string(channelID) + "|" + string(driver.ID()) + "|" + identity, true, nil
+}
+
 // ImportCredential prepares one OAuth-file credential for a ready stage. Most
 // channels use Parse directly; a provider that lacks a stable identity in its
 // native file may implement CredentialFileImporter for one bounded enrichment


### PR DESCRIPTION
修复 #636。

Codex 的授权单位是 **(workspace, user)**：同一 workspace 下的不同用户共享额度，但各自持有独立的 `refresh_token`，属于两份凭据。此前身份只取 `chatgpt_account_id`，两者得到相同 `identity_fingerprint`，而 `credentials` 表上有唯一索引 `idx_credentials_group_identity(group_id, identity_fingerprint)`，于是第二份在 `consumeCredentialStages` 里被归入 `duplicatedStageIDs` 并**静默丢弃**——调用方只看到 `credentials_duplicated` 计数，没有任何错误提示。

## 改动

- `Credential` 增加 `UserID`，在 `credentialFromBridge()` 这一唯一收口处从 `id_token`（必要时退回 `access_token`）解析 `chatgpt_user_id`。CPA 桥接未暴露该 claim，在 gpt-load 侧解析可以不改动 `third_party/cpaembedded` 的契约。
- 身份改为 `codexCredentialIdentity()`：有 user id 时用 `<account_id>/<user_id>`；没有 user id（升级前导入的旧凭据，或令牌缺该 claim）**回退为 `<account_id>`**，与升级前完全一致，因此不会改变已有凭据的 `identity_fingerprint`、不会触发重新授权。
- 新增 4 个单测：同 workspace 不同用户身份不同、同用户重复授权仍合并、旧凭据保持旧身份、非 JWT 令牌安全回退。把身份实现回退成旧写法后，第一个用例会失败（`collapsed into one identity "770d8f80-…"`），确认测试覆盖该缺陷。

## 验证

- `go test ./...` 全量通过（46 个包，0 失败）。
- 端到端对照实测（同一台机器、同一组合成凭据，构建 linux/arm64 二进制，独立数据目录与端口）：

  | 实例 | `POST /api/groups/:id/credentials/connect` 返回 | 分组内凭据 |
  | --- | --- | --- |
  | 未打补丁 | `credentials_added: 0, credentials_duplicated: 1` | `total: 1` |
  | 打了补丁 | `credentials_added: 1, credentials_duplicated: 0` | `total: 2`，两份均 `ready` / `available` |

复现步骤与脱敏证据见 #636。

> 关于身份格式与回退策略：如果维护者倾向别的取值方式（例如用哈希代替拼接、或同时保留 workspace 维度做分组展示），我可以按结论调整。
