### PR TITLE
test(cpa): 修复替换连接测试的时序误报

### DIFF
--- a/third_party/cpaembedded/embedded/codex_websocket_test.go
+++ b/third_party/cpaembedded/embedded/codex_websocket_test.go
@@ -569,13 +569,27 @@ func TestCodexWSSessionGuardsSDKSendRetry(t *testing.T) {
 
 func TestCodexWSSessionRejectsSDKReplacementConnection(t *testing.T) {
 	var frames, handshakes atomic.Int32
+	var handlersMu sync.Mutex
+	var handlers []chan struct{}
+	recordAfterSend := make(chan struct{})
+	releaseStats := sync.OnceFunc(func() { close(recordAfterSend) })
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		done := make(chan struct{})
+		handlersMu.Lock()
+		replacement := len(handlers) > 0
+		handlers = append(handlers, done)
+		handlersMu.Unlock()
+		defer close(done)
 		conn, err := (&websocket.Upgrader{}).Upgrade(w, r, nil)
 		if err != nil {
 			t.Error(err)
 			return
 		}
 		defer conn.Close()
+		if replacement {
+			// 握手已响应，但延后服务端统计，固定客户端先返回的调度顺序。
+			<-recordAfterSend
+		}
 		handshakes.Add(1)
 		if _, _, err := conn.ReadMessage(); err != nil {
 			return
@@ -587,6 +601,7 @@ func TestCodexWSSessionRejectsSDKReplacementConnection(t *testing.T) {
 		_, _, _ = conn.ReadMessage()
 	}))
 	defer server.Close()
+	defer releaseStats()
 	session := wsTestSession(t, server.URL)
 	if _, err := session.ExecuteTurn(context.Background(), json.RawMessage(`{"model":"gpt-5","input":"hello"}`), nil); err != nil {
 		t.Fatal(err)
@@ -602,8 +617,30 @@ func TestCodexWSSessionRejectsSDKReplacementConnection(t *testing.T) {
 		Metadata:           map[string]any{cliproxyexecutor.ExecutionSessionMetadataKey: session.id},
 		ExecutionLifecycle: session.resource,
 	})
-	if err == nil || frames.Load() != 1 || handshakes.Load() != 2 {
-		t.Fatalf("replacement sent a request: frames=%d handshakes=%d error=%v", frames.Load(), handshakes.Load(), err)
+	cancel()
+	releaseStats()
+	// 请求上下文已结束，使用独立期限等待服务端完成统计和业务帧读取。
+	waitCtx, cancelWait := context.WithTimeout(context.Background(), time.Second)
+	defer cancelWait()
+	handlersMu.Lock()
+	pendingHandlers := append([]chan struct{}(nil), handlers...)
+	handlersMu.Unlock()
+	for _, done := range pendingHandlers {
+		select {
+		case <-done:
+		case <-waitCtx.Done():
+			t.Fatal("server handlers did not finish after SDK replacement rejection")
+		}
+	}
+	var wsErr *CodexWSError
+	if !errors.As(err, &wsErr) || wsErr.Code != "session_closed" {
+		t.Fatalf("replacement binding error=%v, want session_closed", err)
+	}
+	if got := handshakes.Load(); got != 2 {
+		t.Fatalf("unexpected handshake count: got=%d want=2", got)
+	}
+	if got := frames.Load(); got != 1 {
+		t.Fatalf("unexpected business frame count: got=%d want=1", got)
 	}
 }
 


### PR DESCRIPTION
### 关联 Issue / Related Issue
无。

### 变更内容 / Change Content
- [x] Bug 修复 / Bug fix
- [ ] 新功能 / New feature
- [ ] 其他改动 / Other changes

`race-cpa` 中的替换连接测试在客户端收到 `session_closed` 后立即检查服务端计数；服务端尚未更新第二次握手计数时，测试会偶发误报。

等待服务端处理结束后再断言，并分别检查拒绝错误、握手数和业务帧数。测试通过通道固定“客户端先返回、服务端后统计”的顺序，覆盖原失败条件。仅修改测试，不影响生产行为、兼容性或数据库，无需更新公开文档。

验证：
- 加入受控时序后，原断言按预期失败：`frames=1 handshakes=1 error=codex websocket: session_closed`。
- 在 `third_party/cpaembedded` 执行 `go test -count=500 -run '^TestCodexWSSessionRejectsSDKReplacementConnection$' -timeout=60s ./embedded`，通过。
- 在 `third_party/cpaembedded` 执行 `go test -count=1 -timeout=60s ./...`，通过。
- `make check` 通过；按仓库约定，本地未运行 `-race`，由远端 CI 验证。

### 自查清单 / Checklist
- [x] 我已运行 `make check`，或在说明中写明无法运行的原因和未验证范围。 / I ran `make check`, or documented why it could not run and what remains unverified.
- [x] 本 PR 范围聚焦，未包含无关改动。 / This PR is focused and contains no unrelated changes.
- [ ] 我已更新必要的公开文档或发布说明。 / I updated any required public documentation or release notes.
- [x] 我已确认提交、日志和测试数据不包含敏感信息。 / I confirmed that commits, logs, and fixtures contain no sensitive data.
- [x] 如适用，我已说明兼容性或数据迁移影响。 / Where applicable, I documented compatibility or data-migration impact.
